### PR TITLE
Fix skiko-jvm-runtime-macos_x64 is not found by gradle

### DIFF
--- a/samples/SkijaInjectSample/build.gradle
+++ b/samples/SkijaInjectSample/build.gradle
@@ -34,7 +34,7 @@ if (osArch == "x86_64") {
 } else {
     throw Error("Unsupported arch: $osArch")
 }
-def target = "${targetOs}_${targetArch}"
+def target = "${targetOs}-${targetArch}"
 
 def version = "0.1-SNAPSHOT"
 if (project.hasProperty('skiko.version')) {


### PR DESCRIPTION
After running `./gradlew publishToMavenLocal`, _skiko-jvm-runtime-macos-x64_ will be generated, but gradle is looking for _skiko-jvm-runtime-macos_x64_
So the target should be `"${targetOs}-${targetArch}"`

Fixed #22