### PR TITLE
Fix crash when we close the window immediately after its start

### DIFF
--- a/skiko/src/jvmMain/cpp/linux/drawlayer.cc
+++ b/skiko/src/jvmMain/cpp/linux/drawlayer.cc
@@ -17,7 +17,7 @@ extern "C"
     {
     }
 
-    JNIEXPORT void JNICALL Java_org_jetbrains_skiko_HardwareLayer_dispose(JNIEnv *env, jobject canvas)
+    JNIEXPORT void JNICALL Java_org_jetbrains_skiko_HardwareLayer_nativeDispose(JNIEnv *env, jobject canvas)
     {
     }
 

--- a/skiko/src/jvmMain/cpp/windows/drawlayer.cc
+++ b/skiko/src/jvmMain/cpp/windows/drawlayer.cc
@@ -8,7 +8,7 @@ extern "C"
     {
     }
 
-    JNIEXPORT void JNICALL Java_org_jetbrains_skiko_HardwareLayer_dispose(JNIEnv *env, jobject canvas)
+    JNIEXPORT void JNICALL Java_org_jetbrains_skiko_HardwareLayer_nativeDispose(JNIEnv *env, jobject canvas)
     {
     }
 

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/HardwareLayer.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/HardwareLayer.kt
@@ -35,11 +35,21 @@ abstract class HardwareLayer : Canvas() {
 
     protected open fun init() {
         useDrawingSurfacePlatformInfo(::nativeInit)
+        onInit()
     }
 
-    protected open external fun nativeInit(platformInfo: Long)
+    fun dispose() {
+        if (isInit) {
+            onDispose()
+            nativeDispose()
+        }
+    }
 
-    open external fun dispose()
+    protected open fun onInit() = Unit
+    protected open fun onDispose() = Unit
+
+    private external fun nativeInit(platformInfo: Long)
+    private external fun nativeDispose()
 
     protected open fun contentScaleChanged() = Unit
 

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/SkiaLayer.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/SkiaLayer.kt
@@ -36,8 +36,8 @@ open class SkiaLayer(
     private val pictureRecorder = PictureRecorder()
     private val pictureLock = Any()
 
-    override fun init() {
-        super.init()
+    override fun onInit() {
+        super.onInit()
         val initialRenderApi = fallbackRenderApiQueue.removeAt(0)
         contextHandler = createContextHandler(this, initialRenderApi)
         redrawer = platformOperations.createRedrawer(this, initialRenderApi, properties)
@@ -45,15 +45,15 @@ open class SkiaLayer(
         redraw()
     }
 
-    override fun dispose() {
+    override fun onDispose() {
         check(!isDisposed)
         check(isEventDispatchThread())
+        redrawer?.dispose()  // we should dispose redrawer first (to cancel `draw` in rendering thread)
         contextHandler?.dispose()
-        redrawer?.dispose()
         picture?.instance?.close()
         pictureRecorder.close()
         isDisposed = true
-        super.dispose()
+        super.onDispose()
     }
 
     override fun setBounds(x: Int, y: Int, width: Int, height: Int) {

--- a/skiko/src/jvmMain/objectiveC/macos/drawlayer.m
+++ b/skiko/src/jvmMain/objectiveC/macos/drawlayer.m
@@ -112,7 +112,7 @@ JNIEXPORT void JNICALL Java_org_jetbrains_skiko_HardwareLayer_nativeInit(JNIEnv 
     [layerStorage addObject: layersSet];
 }
 
-JNIEXPORT void JNICALL Java_org_jetbrains_skiko_HardwareLayer_dispose(JNIEnv *env, jobject canvas)
+JNIEXPORT void JNICALL Java_org_jetbrains_skiko_HardwareLayer_nativeDispose(JNIEnv *env, jobject canvas)
 {
     LayerHandler *layer = findByObject(env, canvas);
     if (layer != NULL)


### PR DESCRIPTION
```
Thread 0 Crashed:: Java: AWT-AppKit  Dispatch queue: com.apple.main-thread
0   libsystem_kernel.dylib          0x00007fff203b2936 __pthread_kill + 10
1   libsystem_pthread.dylib         0x00007fff203e1615 pthread_kill + 263
2   libsystem_c.dylib               0x00007fff20336411 abort + 120
3   libjvm.dylib                    0x0000000108d899bc os::abort(bool, void*, void const*) + 22
4   libjvm.dylib                    0x0000000108ecf0cd VMError::report_and_die(int, char const*, char const*, __va_list_tag*, Thread*, unsigned char*, void*, void*, char const*, int, unsigned long) + 2953
5   libjvm.dylib                    0x0000000108ece51e VMError::report_and_die(Thread*, unsigned int, unsigned char*, void*, void*, char const*, ...) + 152
6   libjvm.dylib                    0x0000000108ecf169 VMError::report_and_die(Thread*, unsigned int, unsigned char*, void*, void*) + 33
7   libjvm.dylib                    0x0000000108d8d95d JVM_handle_bsd_signal + 774
8   libjvm.dylib                    0x0000000108d8b4b5 signalHandler(int, __siginfo*, void*) + 45
9   libsystem_platform.dylib        0x00007fff20426d7d _sigtramp + 29
10  ???                             0x0000000000000054 0 + 84
11  libskiko-macos-x64.dylib        0x000000011e5e0fe0 -[AWTGLLayer canDrawInCGLContext:pixelFormat:forLayerTime:displayTime:] + 208
12  com.apple.QuartzCore            0x00007fff26cd854f CAOpenGLLayerDraw(CAOpenGLLayer*, double, CVTimeStamp const*, unsigned int) + 691
13  com.apple.QuartzCore            0x00007fff26cd80be -[CAOpenGLLayer _display] + 582
14  com.apple.QuartzCore            0x00007fff26c3350f CA::Layer::display_if_needed(CA::Transaction*) + 863
15  com.apple.QuartzCore            0x00007fff26d7e622 CA::Context::commit_transaction(CA::Transaction*, double, double*) + 666
16  com.apple.QuartzCore            0x00007fff26c14a43 CA::Transaction::commit() + 713
17  com.apple.QuartzCore            0x00007fff26c4d4a2 CA::Transaction::observer_callback(__CFRunLoopObserver*, unsigned long, void*) + 110
18  com.apple.CoreFoundation        0x00007fff204d95f1 __CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__ + 23
19  com.apple.CoreFoundation        0x00007fff204d9485 __CFRunLoopDoObservers + 543
20  com.apple.CoreFoundation        0x00007fff204d7f74 CFRunLoopRunSpecific + 683
21  com.apple.HIToolbox             0x00007fff28789ad3 RunCurrentEventLoopInMode + 292
22  com.apple.HIToolbox             0x00007fff28789835 ReceiveNextEventCommon + 587
23  com.apple.HIToolbox             0x00007fff287895d3 _BlockUntilNextEventMatchingListInModeWithFilter + 70
24  com.apple.AppKit                0x00007fff22cc51da _DPSNextEvent + 864
25  com.apple.AppKit                0x00007fff22cc39ad -[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 1364
26  com.apple.AppKit                0x00007fff22cb5d15 -[NSApplication run] + 586
27  com.jetbrains.toolbox           0x0000000105405b7e runApp() + 30
28  com.jetbrains.toolbox           0x00000001053f8ad1 main_jvm_launcher(int, char**) + 1137
29  com.jetbrains.toolbox           0x00000001053f8d62 main + 34
30  libdyld.dylib                   0x00007fff203fcf3d start + 1
```