### PR TITLE
Some fixes after metal

### DIFF
--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/SkiaLayer.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/SkiaLayer.kt
@@ -50,7 +50,6 @@ open class SkiaLayer(
         if (!isInited && isShowing) {
             backedLayer.defineContentScale()
             init()
-            isInited = true
         }
     }
 
@@ -86,19 +85,22 @@ open class SkiaLayer(
         contextHandler = createContextHandler(this, initialRenderApi)
         redrawer = platformOperations.createRedrawer(this, initialRenderApi, properties)
         redrawer?.syncSize()
+        isInited = true
+
         redraw()
     }
 
     open fun dispose() {
         check(!isDisposed)
         check(isEventDispatchThread())
-        redrawer?.dispose()  // we should dispose redrawer first (to cancel `draw` in rendering thread)
-        contextHandler?.dispose()
-        picture?.instance?.close()
-        pictureRecorder.close()
-        isDisposed = true
+
         if (isInited) {
+            redrawer?.dispose()  // we should dispose redrawer first (to cancel `draw` in rendering thread)
+            contextHandler?.dispose()
+            picture?.instance?.close()
+            pictureRecorder.close()
             backedLayer.dispose()
+            isDisposed = true
         }
     }
 

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/SkiaLayer.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/SkiaLayer.kt
@@ -84,10 +84,7 @@ open class SkiaLayer(
         val initialRenderApi = fallbackRenderApiQueue.removeAt(0)
         contextHandler = createContextHandler(this, initialRenderApi)
         redrawer = platformOperations.createRedrawer(this, initialRenderApi, properties)
-        redrawer?.syncSize()
         isInited = true
-
-        redraw()
     }
 
     open fun dispose() {
@@ -107,12 +104,6 @@ open class SkiaLayer(
     override fun setBounds(x: Int, y: Int, width: Int, height: Int) {
         super.setBounds(x, y, width, height)
         backedLayer.setSize(width, height)
-        if (backedLayer.checkContentScale()) {
-            contentScaleChanged()
-        }
-        redrawer?.syncSize()
-        redraw()
-        revalidate()
     }
 
     override fun paint(g: Graphics) {
@@ -145,21 +136,6 @@ open class SkiaLayer(
     }
 
     private var redrawScheduled = false
-
-    /**
-     * Redraw as soon as possible (but not right now)
-     */
-    fun redraw() {
-        if (!redrawScheduled) {
-            redrawScheduled = true
-            invokeLater {
-                redrawScheduled = false
-                if (!isDisposed) {
-                    redrawer?.redrawImmediately()
-                }
-            }
-        }
-    }
 
     /**
      * Redraw on the next animation Frame (on vsync signal if vsync is enabled).


### PR DESCRIPTION
- Remove manual revalidate/redraw

We don't need them anymore, because `paint` will be called every time we change size and init layer.

It is because we changed java.awt.Canvas to javax.swing.JPanel

- fix dipose