### PR TITLE
macOs, Windows. draw in a background thread

### DIFF
--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/SkiaLayer.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/SkiaLayer.kt
@@ -248,6 +248,6 @@ open class SkiaLayer(
         redrawer?.dispose()
         contextHandler = createContextHandler(this, renderApi)
         redrawer = platformOperations.createRedrawer(this, renderApi, properties)
-        repaint()
+        redrawer!!.redrawImmediately()
     }
 }

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/SkiaLayer.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/SkiaLayer.kt
@@ -174,7 +174,7 @@ open class SkiaLayer(
     @Suppress("LeakingThis")
     private val fpsCounter = defaultFPSCounter(this)
 
-    open fun update(nanoTime: Long) {
+    internal fun update(nanoTime: Long) {
         check(!isDisposed)
         check(isEventDispatchThread())
 
@@ -208,14 +208,21 @@ open class SkiaLayer(
         }
     }
 
-    open fun draw() {
+    internal fun prepareDrawContext(): Boolean {
         check(!isDisposed)
         contextHandler?.apply {
             if (!initContext()) {
                 fallbackToNextApi()
-                return
+                return false
             }
             initCanvas()
+        }
+        return true
+    }
+
+    internal fun draw() {
+        check(!isDisposed)
+        contextHandler?.apply {
             clearCanvas()
             synchronized(pictureLock) {
                 val picture = picture

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/SkikoProperties.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/SkikoProperties.kt
@@ -55,7 +55,7 @@ internal object SkikoProperties {
 
         when (hostOs) {
             OS.Linux -> renderApiList = mutableListOf(GraphicsApi.OPENGL, GraphicsApi.SOFTWARE)
-            OS.MacOS -> renderApiList = mutableListOf(GraphicsApi.METAL, GraphicsApi.OPENGL, GraphicsApi.SOFTWARE)
+            OS.MacOS -> renderApiList = mutableListOf(GraphicsApi.METAL, GraphicsApi.SOFTWARE)
             OS.Windows -> renderApiList = mutableListOf(GraphicsApi.DIRECT3D, GraphicsApi.OPENGL, GraphicsApi.SOFTWARE)
         }
         renderApiList.remove(head)

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/redrawer/LinuxOpenGLRedrawer.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/redrawer/LinuxOpenGLRedrawer.kt
@@ -49,7 +49,9 @@ internal class LinuxOpenGLRedrawer(
     }
 
     private fun draw() {
-        layer.draw()
+        if (layer.prepareDrawContext()) {
+            layer.draw()
+        }
     }
 
     companion object {

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/redrawer/MacOsOpenGLRedrawer.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/redrawer/MacOsOpenGLRedrawer.kt
@@ -1,7 +1,6 @@
 package org.jetbrains.skiko.redrawer
 
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.swing.Swing
 import org.jetbrains.skiko.FrameDispatcher
 import org.jetbrains.skiko.SkiaLayer
@@ -11,7 +10,6 @@ import org.jetbrains.skiko.Task
 import org.jetbrains.skiko.useDrawingSurfacePlatformInfo
 import javax.swing.SwingUtilities.convertPoint
 import javax.swing.SwingUtilities.getRootPane
-import kotlin.system.measureNanoTime
 
 // Current implementation is fragile (it works in all tested cases, but we can't test everything)
 //
@@ -31,7 +29,9 @@ internal class MacOsOpenGLRedrawer(
     private val drawLayer = object : AWTGLLayer(containerLayerPtr, setNeedsDisplayOnBoundsChange = true) {
         override fun draw() = synchronized(drawLock) {
             if (!isDisposed) {
-                layer.draw()
+                if (layer.prepareDrawContext()) {
+                    layer.draw()
+                }
             }
         }
 

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/redrawer/SoftwareRedrawer.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/redrawer/SoftwareRedrawer.kt
@@ -11,7 +11,9 @@ internal class SoftwareRedrawer(
 
     private val frameDispatcher = FrameDispatcher(Dispatchers.Swing) {
         layer.update(System.nanoTime())
-        layer.draw()
+        if (layer.prepareDrawContext()) {
+            layer.draw()
+        }
     }
 
     override fun dispose() {
@@ -24,6 +26,8 @@ internal class SoftwareRedrawer(
 
     override fun redrawImmediately() {
         layer.update(System.nanoTime())
-        layer.draw()
+        if (layer.prepareDrawContext()) {
+            layer.draw()
+        }
     }
 }

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/redrawer/WindowsOpenGLRedrawer.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/redrawer/WindowsOpenGLRedrawer.kt
@@ -53,7 +53,9 @@ internal class WindowsOpenGLRedrawer(
     }
 
     private fun draw() {
-        layer.draw()
+        if (layer.prepareDrawContext()) {
+            layer.draw()
+        }
     }
 
     private fun makeCurrent() = makeCurrent(device, context)


### PR DESCRIPTION
fixes 1) and 3) in #76

also fixes slow event dispathing in Compose (it is because vsync blocked AWT thread)