### PR TITLE
Fix window.layer.focusTraversalKeysEnabled = false

### DIFF
--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/SkiaLayer.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/SkiaLayer.kt
@@ -8,6 +8,7 @@ import org.jetbrains.skija.*
 import org.jetbrains.skiko.context.ContextHandler
 import org.jetbrains.skiko.context.createContextHandler
 import org.jetbrains.skiko.redrawer.Redrawer
+import java.awt.AWTKeyStroke
 import java.awt.Graphics
 import java.awt.event.*
 import java.awt.im.InputMethodRequests
@@ -242,6 +243,10 @@ open class SkiaLayer(
 
     override fun removeKeyListener(l: KeyListener) {
         backedLayer.removeKeyListener(l)
+    }
+
+    override fun setFocusTraversalKeysEnabled(focusTraversalKeysEnabled: Boolean) {
+        backedLayer.focusTraversalKeysEnabled = focusTraversalKeysEnabled
     }
 
     /**

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/SkiaLayer.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/SkiaLayer.kt
@@ -8,7 +8,6 @@ import org.jetbrains.skija.*
 import org.jetbrains.skiko.context.ContextHandler
 import org.jetbrains.skiko.context.createContextHandler
 import org.jetbrains.skiko.redrawer.Redrawer
-import java.awt.AWTKeyStroke
 import java.awt.Graphics
 import java.awt.event.*
 import java.awt.im.InputMethodRequests


### PR DESCRIPTION
Disabling focus keys didn't work

Test:
```
    window.layer.focusTraversalKeysEnabled = false
    window.layer.addKeyListener(object : KeyAdapter() {
        override fun keyPressed(event: KeyEvent) {
            println("keyPressed")
        }
    })
```

Press Tab or Shift-Tab. Before fix there was no output in console