### PR TITLE
Fix linux dpi

### DIFF
--- a/samples/SkijaInjectSample/build.gradle.kts
+++ b/samples/SkijaInjectSample/build.gradle.kts
@@ -52,6 +52,7 @@ val additionalArguments = mutableMapOf<String, String>()
 
 val casualRun = tasks.named<JavaExec>("run") {
     systemProperty("skiko.fps.enabled", "true")
+    systemProperty("skiko.linux.autodpi", "true")
     systemProperty("skiko.hardwareInfo.enabled", "true")
     jvmArgs?.add("-ea")
     // Use systemProperty("skiko.library.path", "/tmp") to test loader.

--- a/samples/SkijaInjectSample/src/main/kotlin/SkijaInjectSample/App.kt
+++ b/samples/SkijaInjectSample/src/main/kotlin/SkijaInjectSample/App.kt
@@ -19,6 +19,7 @@ import java.nio.file.Files
 import javax.imageio.ImageIO
 
 fun main(args: Array<String>) {
+    tryEnableUIScaling()
     val windows = 1
     repeat(windows) {
         createWindow("window $it", windows == 1)

--- a/samples/SkijaInjectSample/src/main/kotlin/SkijaInjectSample/App.kt
+++ b/samples/SkijaInjectSample/src/main/kotlin/SkijaInjectSample/App.kt
@@ -19,7 +19,6 @@ import java.nio.file.Files
 import javax.imageio.ImageIO
 
 fun main(args: Array<String>) {
-    tryEnableUIScaling()
     val windows = 1
     repeat(windows) {
         createWindow("window $it", windows == 1)

--- a/skiko/src/jvmMain/cpp/linux/drawlayer.cc
+++ b/skiko/src/jvmMain/cpp/linux/drawlayer.cc
@@ -55,16 +55,33 @@ extern "C"
         return 1;
     }
 
+    double getDpiScale() {
+        Display *display = XOpenDisplay(nullptr);
+        if (display != nullptr) {
+            double result = getDpiScaleByDisplay(display);
+            XCloseDisplay(display);
+            return result;
+        } else {
+            return 1;
+        }
+    }
+
     JNIEXPORT jfloat JNICALL Java_org_jetbrains_skiko_PlatformOperationsKt_linuxGetDpiScaleNative(JNIEnv *env, jobject properties, jlong platformInfoPtr)
     {
         JAWT_X11DrawingSurfaceInfo *dsi_x11 = fromJavaPointer<JAWT_X11DrawingSurfaceInfo *>(platformInfoPtr);
         return (float) getDpiScaleByDisplay(dsi_x11->display);
     }
 
-     JNIEXPORT jint JNICALL Java_org_jetbrains_skiko_SystemThemeKt_getCurrentSystemTheme(JNIEnv *env, jobject topLevel)
-     {
-        // Unknown.
-        return 2;
-     }
+    JNIEXPORT jint JNICALL Java_org_jetbrains_skiko_SystemThemeKt_getCurrentSystemTheme(JNIEnv *env, jobject topLevel)
+    {
+       // Unknown.
+       return 2;
+    }
+
+
+    JNIEXPORT jfloat JNICALL Java_org_jetbrains_skiko_SetupKt_linuxGetSystemDpiScale(JNIEnv *env, jobject layer)
+    {
+        return (float) getDpiScale();
+    }
 
 } // extern "C"

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/Library.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/Library.kt
@@ -79,11 +79,7 @@ object Library {
         }
 
         // TODO move properties to SkikoProperties
-        Setup.init(
-            System.getProperty("skiko.rendering.noerasebackground") != "false",
-            System.getProperty("skiko.rendering.laf.global") == "true",
-            System.getProperty("skiko.rendering.useScreenMenuBar") != "false"
-        )
+        Setup.init()
 
         try {
             // Init code executed after library was loaded.

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/PlatformOperations.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/PlatformOperations.kt
@@ -99,18 +99,6 @@ internal val platformOperations: PlatformOperations by lazy {
 
                 override fun getDpiScale(component: Component): Float {
                     return component.graphicsConfiguration.defaultTransform.scaleX.toFloat()
-                    // TODO doesn't work well because java doesn't scale windows (content has offset with 200% scale)
-                    //
-                    // Two solutions:
-                    // 1. dynamically change sun.java2d.uiScale (it is global property,
-                    // so we have to be careful) and update all windows
-                    //
-                    // 2. apply contentScale manually to all windows
-                    // (it is not good, because on different platform windows will have different size.
-                    // Maybe we will apply contentScale manually on all platforms?)
-
-                    // see also comment for HardwareLayer.checkContentScale
-                    // return (component as HardwareLayer).useDrawingSurfacePlatformInfo(::linuxGetDpiScaleNative)
                 }
 
                 override fun createRedrawer(

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/PlatformOperations.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/PlatformOperations.kt
@@ -98,7 +98,7 @@ internal val platformOperations: PlatformOperations by lazy {
                 }
 
                 override fun getDpiScale(component: Component): Float {
-                    // return component.graphicsConfiguration.defaultTransform.scaleX.toFloat()
+                    return component.graphicsConfiguration.defaultTransform.scaleX.toFloat()
                     // TODO doesn't work well because java doesn't scale windows (content has offset with 200% scale)
                     //
                     // Two solutions:
@@ -110,7 +110,7 @@ internal val platformOperations: PlatformOperations by lazy {
                     // Maybe we will apply contentScale manually on all platforms?)
 
                     // see also comment for HardwareLayer.checkContentScale
-                    return (component as HardwareLayer).useDrawingSurfacePlatformInfo(::linuxGetDpiScaleNative)
+                    // return (component as HardwareLayer).useDrawingSurfacePlatformInfo(::linuxGetDpiScaleNative)
                 }
 
                 override fun createRedrawer(

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/PlatformOperations.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/PlatformOperations.kt
@@ -98,7 +98,7 @@ internal val platformOperations: PlatformOperations by lazy {
                 }
 
                 override fun getDpiScale(component: Component): Float {
-                    return component.graphicsConfiguration.defaultTransform.scaleX.toFloat()
+                    // return component.graphicsConfiguration.defaultTransform.scaleX.toFloat()
                     // TODO doesn't work well because java doesn't scale windows (content has offset with 200% scale)
                     //
                     // Two solutions:
@@ -110,7 +110,7 @@ internal val platformOperations: PlatformOperations by lazy {
                     // Maybe we will apply contentScale manually on all platforms?)
 
                     // see also comment for HardwareLayer.checkContentScale
-                    // return component.useDrawingSurfacePlatformInfo(::linuxGetDpiScaleNative)
+                    return (component as HardwareLayer).useDrawingSurfacePlatformInfo(::linuxGetDpiScaleNative)
                 }
 
                 override fun createRedrawer(

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/Setup.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/Setup.kt
@@ -8,11 +8,6 @@ object Setup {
         globalLAF: Boolean = false,
         useScreenMenuBar: Boolean = true
     ) {
-        if (hostOs == OS.Linux) {
-            val scale = linuxGetSystemDpiScale()
-            System.setProperty("sun.java2d.uiScale.enabled", "true")
-            System.setProperty("sun.java2d.uiScale", "$scale")
-        }
         if (noEraseBackground) {
             // we have to set this property to avoid render flickering.
             System.setProperty("sun.awt.noerasebackground", "true")
@@ -31,4 +26,12 @@ object Setup {
     }
 }
 
-external fun linuxGetSystemDpiScale(): Float
+fun tryEnableUIScaling() {
+    if (hostOs == OS.Linux) {
+        val scale = linuxGetSystemDpiScale()
+        System.setProperty("sun.java2d.uiScale.enabled", "true")
+        System.setProperty("sun.java2d.uiScale", "$scale")
+    }
+}
+
+private external fun linuxGetSystemDpiScale(): Float

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/Setup.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/Setup.kt
@@ -3,11 +3,18 @@ package org.jetbrains.skiko
 import javax.swing.UIManager
 
 object Setup {
+    private var isInited = false
     fun init(
-        noEraseBackground: Boolean = true,
-        globalLAF: Boolean = false,
-        useScreenMenuBar: Boolean = true
+        noEraseBackground: Boolean = System.getProperty("skiko.rendering.noerasebackground") != "false",
+        globalLAF: Boolean = System.getProperty("skiko.rendering.laf.global") == "true",
+        useScreenMenuBar: Boolean = System.getProperty("skiko.rendering.useScreenMenuBar") != "false",
+        autoLinuxDpi: Boolean = System.getProperty("skiko.linux.autodpi") == "true"
     ) {
+        if (hostOs == OS.Linux && autoLinuxDpi) {
+            val scale = linuxGetSystemDpiScale()
+            System.setProperty("sun.java2d.uiScale.enabled", "true")
+            System.setProperty("sun.java2d.uiScale", "$scale")
+        }
         if (noEraseBackground) {
             // we have to set this property to avoid render flickering.
             System.setProperty("sun.awt.noerasebackground", "true")
@@ -23,14 +30,7 @@ object Setup {
         } catch (e: UnsupportedOperationException) {
             // Not all platforms allow this.
         }
-    }
-}
-
-fun tryEnableUIScaling() {
-    if (hostOs == OS.Linux) {
-        val scale = linuxGetSystemDpiScale()
-        System.setProperty("sun.java2d.uiScale.enabled", "true")
-        System.setProperty("sun.java2d.uiScale", "$scale")
+        isInited = true
     }
 }
 

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/Setup.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/Setup.kt
@@ -3,7 +3,6 @@ package org.jetbrains.skiko
 import javax.swing.UIManager
 
 object Setup {
-    private var isInited = false
     fun init(
         noEraseBackground: Boolean = System.getProperty("skiko.rendering.noerasebackground") != "false",
         globalLAF: Boolean = System.getProperty("skiko.rendering.laf.global") == "true",
@@ -30,7 +29,6 @@ object Setup {
         } catch (e: UnsupportedOperationException) {
             // Not all platforms allow this.
         }
-        isInited = true
     }
 }
 

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/Setup.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/Setup.kt
@@ -8,6 +8,11 @@ object Setup {
         globalLAF: Boolean = false,
         useScreenMenuBar: Boolean = true
     ) {
+        if (hostOs == OS.Linux) {
+            val scale = linuxGetSystemDpiScale()
+            System.setProperty("sun.java2d.uiScale.enabled", "true")
+            System.setProperty("sun.java2d.uiScale", "$scale")
+        }
         if (noEraseBackground) {
             // we have to set this property to avoid render flickering.
             System.setProperty("sun.awt.noerasebackground", "true")
@@ -25,3 +30,5 @@ object Setup {
         }
     }
 }
+
+external fun linuxGetSystemDpiScale(): Float


### PR DESCRIPTION
Force enable dpi support on Linux. To achieve this, we must set the system property "sun.java2d.uiScale" before initializing the AWT/Swing.