### PR TITLE
Native-1.5.21-dev-329

### DIFF
--- a/samples/SkiaNativeSample/build.gradle.kts
+++ b/samples/SkiaNativeSample/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("multiplatform") version "1.4.30"
+    kotlin("multiplatform") version "1.5.21"
 }
 
 repositories {

--- a/samples/SkiaNativeSample/gradle.properties
+++ b/samples/SkiaNativeSample/gradle.properties
@@ -1,2 +1,3 @@
 kotlin.code.style=official
 kotlin.native.version=1.5.21-dev-329
+kotlin.native.cacheKind.macosX64=none

--- a/samples/SkiaNativeSample/gradle.properties
+++ b/samples/SkiaNativeSample/gradle.properties
@@ -1,2 +1,2 @@
 kotlin.code.style=official
-kotlin.native.version=1.5.21-dev-324
+kotlin.native.version=1.5.21-dev-329

--- a/skiko/build.gradle.kts
+++ b/skiko/build.gradle.kts
@@ -175,6 +175,8 @@ kotlin {
                     val skiaDir = skiaDir.get().absolutePath
                     compilerOpts("-I$skiaDir")
                     extraOpts("-staticLibrary", "libskia.a")
+                    extraOpts("-staticLibrary", "libskshaper.a")
+                    extraOpts("-staticLibrary", "libskparagraph.a")
                     extraOpts("-libraryPath", "$skiaDir/$skiaBinSubdir")
                 }
             }

--- a/skiko/gradle.properties
+++ b/skiko/gradle.properties
@@ -1,6 +1,6 @@
 kotlin.code.style=official
 deploy.version=0.0.0
-kotlin.native.version=1.5.21-dev-324
+kotlin.native.version=1.5.21-dev-329
 
 dependencies.skija.git.commit=37d3d6ec1dabf0528f4fcc2bcbe16f4c9b3f196b
 dependencies.skia.windows-x64=m92-81ce29695f

--- a/skiko/src/nativeInterop/cinterop/skia.def
+++ b/skiko/src/nativeInterop/cinterop/skia.def
@@ -16,9 +16,9 @@ compilerOpts.osx = -x c++ -std=c++14 \
     -DSK_SUPPORT_OPENCL=0 \
     -DSK_UNICODE_AVAILABLE
 
-headers = modules/skparagraph/include/ParagraphBuilder.h modules/skparagraph/include/TypefaceFontProvider.h modules/skparagraph/include/Paragraph.h modules/skparagraph/include/FontCollection.h modules/skparagraph/include/Metrics.h modules/skparagraph/include/ParagraphStyle.h modules/skparagraph/include/TextStyle.h include/core/SkFontMgr.h include/core/SkFilterQuality.h include/core/SkCanvas.h include/core/SkData.h include/core/SkImage.h include/core/SkMath.h include/core/SkStream.h include/core/SkSurface.h include/core/SkSurfaceProps.h include/core/SkTypes.h include/core/SkPaint.h include/core/SkPictureRecorder.h include/core/SkPoint3.h include/core/SkImageInfo.h include/core/SkColor.h include/core/SkColorSpace.h include/utils/SkShadowUtils.h include/gpu/GrDirectContext.h include/gpu/GrBackendSurface.h include/gpu/GrConfig.h include/gpu/gl/GrGLInterface.h
+headers = modules/skparagraph/include/ParagraphBuilder.h modules/skparagraph/include/TypefaceFontProvider.h modules/skparagraph/include/Paragraph.h modules/skparagraph/include/FontCollection.h modules/skparagraph/include/Metrics.h modules/skparagraph/include/ParagraphStyle.h modules/skparagraph/include/TextStyle.h include/core/SkFontMgr.h include/core/SkFilterQuality.h include/core/SkCanvas.h include/core/SkData.h include/core/SkImage.h include/core/SkMath.h include/core/SkPathMeasure.h include/core/SkStream.h include/core/SkSurface.h include/core/SkSurfaceProps.h include/core/SkTypes.h include/core/SkPaint.h include/core/SkPictureRecorder.h include/core/SkPoint3.h include/core/SkImageInfo.h include/core/SkColor.h include/core/SkColorSpace.h include/utils/SkShadowUtils.h include/gpu/GrDirectContext.h include/gpu/GrBackendSurface.h include/gpu/GrConfig.h include/gpu/gl/GrGLInterface.h
 
-headerFilter = modules/skparagraph/include/ParagraphBuilder.h modules/skparagraph/include/TypefaceFontProvider.h modules/skparagraph/include/Paragraph.h modules/skparagraph/include/FontCollection.h modules/skparagraph/include/Metrics.h modules/skparagraph/include/ParagraphStyle.h modules/skparagraph/include/TextStyle.h include/core/SkFontMgr.h include/core/SkFilterQuality.h include/core/SkCanvas.h include/core/SkData.h include/core/SkImage.h include/core/SkMath.h include/core/SkStream.h include/core/SkSurface.h include/core/SkSurfaceProps.h include/core/SkTypes.h include/core/SkPaint.h include/core/SkPictureRecorder.h include/core/SkPoint3.h include/core/SkImageInfo.h include/core/SkColor.h include/core/SkColorSpace.h include/utils/SkShadowUtils.h include/gpu/GrDirectContext.h include/gpu/GrBackendSurface.h include/gpu/GrConfig.h include/gpu/gl/GrGLInterface.h
+headerFilter = modules/skparagraph/include/ParagraphBuilder.h modules/skparagraph/include/TypefaceFontProvider.h modules/skparagraph/include/Paragraph.h modules/skparagraph/include/FontCollection.h modules/skparagraph/include/Metrics.h modules/skparagraph/include/ParagraphStyle.h modules/skparagraph/include/TextStyle.h include/core/SkFontMgr.h include/core/SkFilterQuality.h include/core/SkCanvas.h include/core/SkData.h include/core/SkImage.h include/core/SkMath.h include/core/SkPathMeasure.h include/core/SkStream.h include/core/SkSurface.h include/core/SkSurfaceProps.h include/core/SkTypes.h include/core/SkPaint.h include/core/SkPictureRecorder.h include/core/SkPoint3.h include/core/SkImageInfo.h include/core/SkColor.h include/core/SkColorSpace.h include/utils/SkShadowUtils.h include/gpu/GrDirectContext.h include/gpu/GrBackendSurface.h include/gpu/GrConfig.h include/gpu/gl/GrGLInterface.h
 
 # const overloads are not supported yet
 excludedFunctions = mapRect ptr priv
@@ -31,8 +31,22 @@ static inline skia::textlayout::Paragraph* __ParagraphBuilder__Build(skia::textl
     return paragraphBuilder->Build().release();
 }
 
+static inline skia::textlayout::ParagraphBuilder* __ParagraphBuilder__make(const skia::textlayout::ParagraphStyle* style, sk_sp<skia::textlayout::FontCollection> fontCollection) {
+    return skia::textlayout::ParagraphBuilder::make(*style, fontCollection).release();
+}
+
 // This is to wrokaround skia interop's inability to pass c++ classes by value
 static inline void __TextStyle__setFontStyle(skia::textlayout::TextStyle* textStyle, SkFontStyle& fontStyle) {
-    textStyle->setFontStyle(fontStyle)
+    textStyle->setFontStyle(fontStyle);
+}
+
+
+// static inline SkFontStyle* __SkFontStyle__Normal() {
+//     return &SkFontStyle::Normal();
+// }
+
+// This is to workaround our inability to construct the default constructor for TypefaceFontProvider
+static inline skia::textlayout::TypefaceFontProvider* __TypefaceFontProvider() {
+    return new skia::textlayout::TypefaceFontProvider();
 }
 

--- a/skiko/src/nativeInterop/cinterop/skia.def
+++ b/skiko/src/nativeInterop/cinterop/skia.def
@@ -31,3 +31,8 @@ static inline skia::textlayout::Paragraph* __ParagraphBuilder__Build(skia::textl
     return paragraphBuilder->Build().release();
 }
 
+// This is to wrokaround skia interop's inability to pass c++ classes by value
+static inline void __TextStyle__setFontStyle(skia::textlayout::TextStyle* textStyle, SkFontStyle& fontStyle) {
+    textStyle->setFontStyle(fontStyle)
+}
+


### PR DESCRIPTION
Added Paragraph headers into the .def file.
Some workarounds in the .def file.
`libskshaper.a` and `libskparagraph.a` encapsulated in the klib
Moved to k/n 1.5.21-dev-329.
