### PR TITLE
Don't confuse Array<NativePointer> actual implementations with LongArray and IntArray

### DIFF
--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/ImageFilter.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/ImageFilter.kt
@@ -8,6 +8,7 @@ import org.jetbrains.skia.impl.Stats
 import org.jetbrains.skia.impl.reachabilityBarrier
 import org.jetbrains.skia.ExternalSymbolName
 import org.jetbrains.skia.impl.NativePointer
+import org.jetbrains.skia.impl.NativePointerArray
 import org.jetbrains.skia.impl.getPtr
 import kotlin.jvm.JvmStatic
 
@@ -318,7 +319,8 @@ class ImageFilter internal constructor(ptr: NativePointer) : RefCnt(ptr) {
         fun makeMerge(filters: Array<ImageFilter?>, crop: IRect?): ImageFilter {
             return try {
                 Stats.onNativeCall()
-                val filterPtrs = filters.map { getPtr(it) }.toTypedArray()
+                val filterPtrs = NativePointerArray(filters.size)
+                for (i in filters.indices) filterPtrs[i] = getPtr(filters[i])
                 ImageFilter(_nMakeMerge(filterPtrs, crop))
             } finally {
                 reachabilityBarrier(filters)
@@ -727,7 +729,7 @@ class ImageFilter internal constructor(ptr: NativePointer) : RefCnt(ptr) {
         external fun _nMakeMatrixTransform(matrix: FloatArray?, samplingMode: Long, input: NativePointer): NativePointer
         @JvmStatic
         @ExternalSymbolName("org_jetbrains_skia_ImageFilter__1nMakeMerge")
-        external fun _nMakeMerge(filters: Array<NativePointer>?, crop: IRect?): NativePointer
+        external fun _nMakeMerge(filters: NativePointerArray?, crop: IRect?): NativePointer
         @JvmStatic
         @ExternalSymbolName("org_jetbrains_skia_ImageFilter__1nMakeOffset")
         external fun _nMakeOffset(dx: Float, dy: Float, input: NativePointer, crop: IRect?): NativePointer

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/RuntimeEffect.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/RuntimeEffect.kt
@@ -7,6 +7,7 @@ import org.jetbrains.skia.impl.Native
 import org.jetbrains.skia.impl.Stats
 import org.jetbrains.skia.ExternalSymbolName
 import org.jetbrains.skia.impl.NativePointer
+import org.jetbrains.skia.impl.NativePointerArray
 import org.jetbrains.skia.impl.getPtr
 import kotlin.jvm.JvmStatic
 
@@ -25,7 +26,7 @@ class RuntimeEffect internal constructor(ptr: NativePointer) : RefCnt(ptr) {
         @JvmStatic
         @ExternalSymbolName("org_jetbrains_skia_RuntimeEffect__1nMakeShader")
         external fun _nMakeShader(
-            runtimeEffectPtr: NativePointer, uniformPtr: NativePointer, childrenPtrs: Array<NativePointer>?,
+            runtimeEffectPtr: NativePointer, uniformPtr: NativePointer, childrenPtrs: NativePointerArray?,
             localMatrix: FloatArray?, isOpaque: Boolean
         ): NativePointer
 
@@ -47,7 +48,7 @@ class RuntimeEffect internal constructor(ptr: NativePointer) : RefCnt(ptr) {
     ): Shader {
         Stats.onNativeCall()
         val childCount = children?.size ?: 0
-        val childrenPtrs = arrayOf<NativePointer>()
+        val childrenPtrs = NativePointerArray(childCount)
         for (i in 0 until childCount) childrenPtrs[i] = getPtr(children!![i])
         val matrix = localMatrix?.mat
         return Shader(_nMakeShader(_ptr, getPtr(uniforms), childrenPtrs, matrix, isOpaque))

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/impl/NativePointerArray.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/impl/NativePointerArray.kt
@@ -1,3 +1,4 @@
 package org.jetbrains.skia.impl
 
-expect class NativePointerArray
+expect class NativePointerArray constructor(size: Int)
+

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/impl/NativePointerArray.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/impl/NativePointerArray.kt
@@ -1,0 +1,3 @@
+package org.jetbrains.skia.impl
+
+expect class NativePointerArray

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/impl/NativePointerArray.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/impl/NativePointerArray.kt
@@ -1,4 +1,9 @@
 package org.jetbrains.skia.impl
 
-expect class NativePointerArray constructor(size: Int)
+expect class NativePointerArray constructor(size: Int) {
+    operator fun get(index: Int): NativePointer
+    operator fun set(index: Int, value: NativePointer)
+    val size: Int
+}
+
 

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/paragraph/FontCollection.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/paragraph/FontCollection.kt
@@ -8,6 +8,7 @@ import org.jetbrains.skia.impl.Stats
 import org.jetbrains.skia.impl.reachabilityBarrier
 import org.jetbrains.skia.ExternalSymbolName
 import org.jetbrains.skia.impl.NativePointer
+import org.jetbrains.skia.impl.NativePointerArray
 import org.jetbrains.skia.impl.getPtr
 import kotlin.jvm.JvmStatic
 
@@ -36,7 +37,7 @@ class FontCollection internal constructor(ptr: NativePointer) : RefCnt(ptr) {
         external fun _nGetFallbackManager(ptr: NativePointer): NativePointer
         @JvmStatic
         @ExternalSymbolName("org_jetbrains_skia_FontCollection__1nFindTypefaces")
-        external fun _nFindTypefaces(ptr: NativePointer, familyNames: Array<String?>?, fontStyle: Int): Array<NativePointer>
+        external fun _nFindTypefaces(ptr: NativePointer, familyNames: Array<String?>?, fontStyle: Int): NativePointerArray
         @JvmStatic
         @ExternalSymbolName("org_jetbrains_skia_FontCollection__1nDefaultFallbackChar")
         external fun _nDefaultFallbackChar(ptr: NativePointer, unicode: Int, fontStyle: Int, locale: String?): NativePointer
@@ -132,7 +133,7 @@ class FontCollection internal constructor(ptr: NativePointer) : RefCnt(ptr) {
             Stats.onNativeCall()
             val ptrs = _nFindTypefaces(_ptr, familyNames, style._value)
             val res = arrayOfNulls<Typeface>(ptrs.size)
-            for (i in ptrs.indices) res[i] = Typeface(ptrs[i])
+            for (i in 0 until ptrs.size) res[i] = Typeface(ptrs[i])
             res
         } finally {
             reachabilityBarrier(this)

--- a/skiko/src/jsMain/kotlin/org/jetbrains/skia/impl/NativePointerArray.kt
+++ b/skiko/src/jsMain/kotlin/org/jetbrains/skia/impl/NativePointerArray.kt
@@ -1,0 +1,3 @@
+package org.jetbrains.skia.impl
+
+actual typealias NativePointerArray = IntArray

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skia/impl/NativePointerArray.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skia/impl/NativePointerArray.kt
@@ -1,0 +1,3 @@
+package org.jetbrains.skia.impl
+
+actual typealias NativePointerArray = LongArray

--- a/skiko/src/jvmTest/kotlin/org/jetbrains/skiko/ParagraphTest.kt
+++ b/skiko/src/jvmTest/kotlin/org/jetbrains/skiko/ParagraphTest.kt
@@ -1,0 +1,15 @@
+package org.jetbrains.skiko
+
+import org.jetbrains.skia.FontMgr
+import org.jetbrains.skia.FontStyle
+import org.jetbrains.skia.impl.NativePointer
+import org.jetbrains.skia.paragraph.FontCollection
+import org.junit.Test
+
+class ParagraphTest {
+    @Test
+    fun findTypefaces() {
+        val fontCollection = FontCollection().setDefaultFontManager(FontMgr.default)
+        fontCollection.findTypefaces(emptyArray(), FontStyle.NORMAL)
+    }
+}


### PR DESCRIPTION
Actually, as far as I understand LongArray is the only entity we should care of, IntArray supposed to be the same as Array<Int> on js (but I might be wrong)