### PR TITLE
Fix deadlock in FrameLimiter

### DIFF
--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/FrameLimiter.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/FrameLimiter.kt
@@ -18,6 +18,8 @@ private const val NanosecondsPerMillisecond = 1_000_000L
  *      frameJob.cancelAndJoin()
  *  }
  * ```
+ *
+ * Can be accessed from multiple threads.
  */
 @OptIn(ExperimentalTime::class)
 @Suppress("UNUSED_PARAMETER")

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/RendezvousBroadcastChannel.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/RendezvousBroadcastChannel.kt
@@ -1,30 +1,45 @@
 package org.jetbrains.skiko
 
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.channels.Channel
-import java.util.concurrent.atomic.AtomicReference
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.resume
 
 /**
  * Behaves as Channel<Unit>(Channel.RENDEZVOUS), but with ability to send value to all current consumers
- * (which await on `receive` method)
+ * (which await on `receive` method).
  */
 internal class RendezvousBroadcastChannel<T> {
     private val onRequest = Channel<Unit>(Channel.CONFLATED)
-    private val onResult = AtomicReference(CompletableDeferred<T>())
+    private val receivers = mutableListOf<Continuation<T>>()
+    private val receiversCopy = mutableListOf<Continuation<T>>()
 
     /**
-     * Send value to all current consumers which await value on `receive` method, or await for the first one
+     * Send value to all current consumers which await value on `receive` method, or await for the first one.
+     *
+     * Can't be called concurrently from multiple threads.
      */
     suspend fun sendAll(value: T) {
         onRequest.receive()
-        onResult.getAndSet(CompletableDeferred()).complete(value)
+        synchronized(receivers) {
+            receiversCopy.addAll(receivers)
+            receivers.clear()
+        }
+        for (receiver in receiversCopy) {
+            receiver.resume(value)
+        }
+        receiversCopy.clear()
     }
 
     /**
      * Wait when the producer will send a value and return it.
+     *
+     * Can be called concurrently from multiple threads.
      */
-    suspend fun receive(): T {
+    suspend fun receive(): T = suspendCancellableCoroutine { continuation ->
+        synchronized(receivers) {
+            receivers.add(continuation)
+        }
         onRequest.trySend(Unit)
-        return onResult.get().await()
     }
 }


### PR DESCRIPTION
We run FrameLimiter in another thread in SoftwareRedrawer. So FrameLimiter should be thread-safe. It is not thread safe now.

We can run it from the Swing thread though, but probably it will be used in Compose directly, where can be multiple threads (in Application frame clock, for example)

Deadlock:
[couroutine 2] onRequest.trySend(Unit)
[couroutine 1] onRequest.receive()
[couroutine 1] onResult.getAndSet(CompletableDeferred()).complete(value)
[couroutine 2] onResult.get().await() // wait
[couroutine 1] onRequest.receive()  // wait