### PR TITLE
change Long to Int in Line Metrics

### DIFF
--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/paragraph/LineMetrics.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/paragraph/LineMetrics.kt
@@ -7,19 +7,19 @@ class LineMetrics(
     /**
      * The index in the text buffer the line begins.
      */
-    val startIndex: Long,
+    val startIndex: Int,
     /**
      * The index in the text buffer the line ends.
      */
-    val endIndex: Long,
+    val endIndex: Int,
     /**
      * The index in the text buffer the line ends.
      */
-    val endExcludingWhitespaces: Long,
+    val endExcludingWhitespaces: Int,
     /**
      * The index in the text buffer the line begins.
      */
-    val endIncludingNewline: Long,
+    val endIncludingNewline: Int,
     val isHardBreak: Boolean,
     /**
      * The final computed ascent for the line. This can be impacted by the strut, height,
@@ -61,7 +61,7 @@ class LineMetrics(
     /**
      * Zero indexed line number
      */
-    val lineNumber: Long
+    val lineNumber: Int
 ) {
     /**
      * The final computed ascent for the line. This can be impacted by the strut, height,
@@ -156,17 +156,17 @@ class LineMetrics(
         override fun getArraySize(array: InteropPointer) = LineMetrics_nGetArraySize(array)
         override fun disposeArray(array: InteropPointer) = LineMetrics_nDisposeArray(array)
         override fun getArrayElement(array: InteropPointer, index: Int): LineMetrics {
-            val longArray = LongArray(6)
+            val intArray = IntArray(6)
             val doubleArray = DoubleArray(7)
             val result = interopScope {
-                LineMetrics_nGetArrayElement(array, index, toInterop(longArray), toInterop(doubleArray))
+                LineMetrics_nGetArrayElement(array, index, toInterop(intArray), toInterop(doubleArray))
             }
             return LineMetrics(
-                longArray[0],
-                longArray[1],
-                longArray[2],
-                longArray[3],
-                longArray[4] != 0L,
+                intArray[0],
+                intArray[1],
+                intArray[2],
+                intArray[3],
+                intArray[4] != 0,
                 doubleArray[0],
                 doubleArray[1],
                 doubleArray[2],
@@ -174,7 +174,7 @@ class LineMetrics(
                 doubleArray[4],
                 doubleArray[5],
                 doubleArray[6],
-                longArray[5]
+                intArray[5]
             )
         }
     }

--- a/skiko/src/jvmMain/cpp/common/paragraph/interop.cc
+++ b/skiko/src/jvmMain/cpp/common/paragraph/interop.cc
@@ -10,7 +10,7 @@ namespace skija {
             void onLoad(JNIEnv* env) {
                 jclass local = env->FindClass("org/jetbrains/skia/paragraph/LineMetrics");
                 cls  = static_cast<jclass>(env->NewGlobalRef(local));
-                ctor = env->GetMethodID(cls, "<init>", "(JJJJZDDDDDDDJ)V");
+                ctor = env->GetMethodID(cls, "<init>", "(IIIIZDDDDDDDI)V");
             }
 
             void onUnload(JNIEnv* env) {
@@ -75,6 +75,6 @@ namespace skija {
             DecorationStyle::onUnload(env);
             TextBox::onUnload(env);
             LineMetrics::onUnload(env);
-        } 
+        }
     }
 }

--- a/skiko/src/jvmTest/kotlin/org/jetbrains/skiko/SkiaWindowTest.kt
+++ b/skiko/src/jvmTest/kotlin/org/jetbrains/skiko/SkiaWindowTest.kt
@@ -302,6 +302,16 @@ class SkiaWindowTest {
             window.isVisible = true
             delay(1000)
 
+            // check the line metrics
+            val lineMetrics = paragraph.lineMetrics
+            assertTrue(lineMetrics.isNotEmpty())
+            assertEquals(0, lineMetrics.first().startIndex)
+            assertEquals(5, lineMetrics.first().endIndex)
+            assertEquals(5, lineMetrics.first().endExcludingWhitespaces)
+            assertEquals(5, lineMetrics.first().endIncludingNewline)
+            assertEquals(true, lineMetrics.first().isHardBreak)
+            assertEquals(0, lineMetrics.first().lineNumber)
+
             screenshots.assert(window.bounds)
         } finally {
             window.close()


### PR DESCRIPTION
Motivation for this PR: We would prefer to avoid Long where it's possible, since `kotlin.Long is not mapped to any JavaScript object, as there is no 64-bit integer number type in JavaScript. It is emulated by a Kotlin class.`
In this case (Line Metrics) Int should be sufficient. 

Also added some asserts for line metrics in `testRenderText` (jvm only). 
The tests for native and js will follow as soon as we set up rendering in tests there. 

