### PR TITLE
Transparency in window support.

### DIFF
--- a/samples/SkiaJvmSample/build.gradle.kts
+++ b/samples/SkiaJvmSample/build.gradle.kts
@@ -71,6 +71,11 @@ tasks.register("runSoftware") {
     dependsOn(casualRun)
 }
 
+tasks.register("runWithTransparency") {
+    additionalArguments += mapOf("skiko.transparency" to "true")
+    dependsOn(casualRun)
+}
+
 tasks.withType<KotlinCompile>().configureEach {
     kotlinOptions.freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
 }

--- a/samples/SkiaJvmSample/src/main/kotlin/SkiaJvmSample/App.kt
+++ b/samples/SkiaJvmSample/src/main/kotlin/SkiaJvmSample/App.kt
@@ -110,6 +110,16 @@ fun createWindow(title: String, exitOnClose: Boolean) = SwingUtilities.invokeLat
         }
     })
 
+    // Window transparency
+    if (System.getProperty("skiko.transparency") == "true") {
+        window.setUndecorated(true)
+        // On Windows we don't set transparent background to avoid event input issues (JDK specific)
+        if (hostOs != OS.Windows) {
+            window.background = java.awt.Color(0, 0, 0, 0)
+        }
+        window.layer.transparency = true
+    }
+
     // MANDATORY: set window preferred size before calling pack()
     window.preferredSize = Dimension(800, 600)
     window.pack()

--- a/skiko/src/jvmMain/cpp/include/window_util.h
+++ b/skiko/src/jvmMain/cpp/include/window_util.h
@@ -1,0 +1,6 @@
+#if SK_BUILD_FOR_WIN
+#include <dwmapi.h>
+
+void enableTransparentWindow(HWND hwnd);
+
+#endif

--- a/skiko/src/jvmMain/cpp/linux/redrawer.cc
+++ b/skiko/src/jvmMain/cpp/linux/redrawer.cc
@@ -68,7 +68,15 @@ extern "C"
         Display *display = fromJavaPointer<Display *>(displayPtr);
         if (!display) return 0;
 
-        GLint att[] = {GLX_RGBA, GLX_DOUBLEBUFFER, True, None};
+        GLint att[] = {
+            GLX_RGBA,
+            GLX_RED_SIZE, 8,
+            GLX_GREEN_SIZE, 8,
+            GLX_BLUE_SIZE, 8,
+            GLX_ALPHA_SIZE, 8,
+            GLX_DEPTH_SIZE, 32,
+            GLX_DOUBLEBUFFER, True, None
+        };
         XVisualInfo *vi = glXChooseVisual(display, 0, att);
 
         if (!vi) return 0;

--- a/skiko/src/jvmMain/cpp/windows/SoftwareRedrawer.cc
+++ b/skiko/src/jvmMain/cpp/windows/SoftwareRedrawer.cc
@@ -2,6 +2,7 @@
 #include <jawt_md.h>
 #include "jni_helpers.h"
 #include "exceptions_handler.h"
+#include "window_util.h"
 
 #include "SkSurface.h"
 #include "src/core/SkAutoMalloc.h"
@@ -20,10 +21,15 @@ public:
 extern "C"
 {
     JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_redrawer_WindowsSoftwareRedrawer_createDevice(
-        JNIEnv *env, jobject redrawer, jlong contentHandle)
+        JNIEnv *env, jobject redrawer, jlong contentHandle, jboolean transparency)
     {
         SoftwareDevice *device = new SoftwareDevice();
         device->window = (HWND)contentHandle;
+        if (transparency)
+        {
+            HWND parent = GetAncestor(device->window, GA_PARENT);
+            enableTransparentWindow(parent);
+        }
         GetClientRect(device->window, &device->clientRect);
         return toJavaPointer(device);
     }

--- a/skiko/src/jvmMain/cpp/windows/directXRedrawer.cc
+++ b/skiko/src/jvmMain/cpp/windows/directXRedrawer.cc
@@ -4,6 +4,7 @@
 #include <jawt_md.h>
 #include "jni_helpers.h"
 #include "exceptions_handler.h"
+#include "window_util.h"
 
 #include "GrBackendSurface.h"
 #include "GrDirectContext.h"
@@ -289,7 +290,7 @@ extern "C"
     }
 
     JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_redrawer_Direct3DRedrawer_createDirectXDevice(
-        JNIEnv *env, jobject redrawer, jint adapterPriority, jlong contentHandle)
+        JNIEnv *env, jobject redrawer, jint adapterPriority, jlong contentHandle, jboolean transparency)
     {
         gr_cp<IDXGIFactory4> deviceFactory;
         if (!SUCCEEDED(CreateDXGIFactory1(IID_PPV_ARGS(&deviceFactory))))
@@ -328,6 +329,14 @@ extern "C"
         d3dDevice->device = device;
         d3dDevice->queue = queue;
         d3dDevice->window = (HWND)contentHandle;
+
+        if (transparency)
+        {
+            //TODO: curent swapChain does not support transparency
+            return 0;
+            // HWND wnd = GetAncestor(d3dDevice->window, GA_PARENT);
+            // enableTransparentWindow(wnd);
+        }
 
         return toJavaPointer(d3dDevice);
     }

--- a/skiko/src/jvmMain/cpp/windows/openGLRedrawer.cc
+++ b/skiko/src/jvmMain/cpp/windows/openGLRedrawer.cc
@@ -5,6 +5,7 @@
 #include <dwmapi.h>
 #include "jni_helpers.h"
 #include "exceptions_handler.h"
+#include "window_util.h"
 
 extern "C"
 {
@@ -20,10 +21,11 @@ extern "C"
             memset(&pixFormatDscr, 0, sizeof(PIXELFORMATDESCRIPTOR));
             pixFormatDscr.nSize = sizeof(PIXELFORMATDESCRIPTOR);
             pixFormatDscr.nVersion = 1;
-            pixFormatDscr.dwFlags = PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER;
+            pixFormatDscr.dwFlags = PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER | PFD_SUPPORT_COMPOSITION;
 
             pixFormatDscr.iPixelType = PFD_TYPE_RGBA;
             pixFormatDscr.cColorBits = 32;
+            pixFormatDscr.cAlphaBits = 8;
             int iPixelFormat = ChoosePixelFormat(device, &pixFormatDscr);
             SetPixelFormat(device, iPixelFormat, &pixFormatDscr);
             DescribePixelFormat(device, iPixelFormat, sizeof(PIXELFORMATDESCRIPTOR), &pixFormatDscr);
@@ -76,10 +78,16 @@ extern "C"
         wglMakeCurrent(device, context);
     }
 
-    JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_redrawer_WindowsOpenGLRedrawerKt_createContext(JNIEnv *env, jobject redrawer, jlong devicePtr)
+    JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_redrawer_WindowsOpenGLRedrawerKt_createContext(JNIEnv *env, jobject redrawer, jlong devicePtr, jlong contentHandle, jboolean transparency)
     {
         __try
         {
+            if (transparency)
+            {
+                HWND parent = GetAncestor(fromJavaPointer<HWND>(contentHandle), GA_PARENT);
+                enableTransparentWindow(parent);
+            }
+
             HDC device = fromJavaPointer<HDC>(devicePtr);
             return toJavaPointer(wglCreateContext(device));
         }

--- a/skiko/src/jvmMain/cpp/windows/window_util.cc
+++ b/skiko/src/jvmMain/cpp/windows/window_util.cc
@@ -1,0 +1,16 @@
+#if SK_BUILD_FOR_WIN
+
+#include "window_util.h"
+
+void enableTransparentWindow(HWND hwnd)
+{
+    HRGN region = CreateRectRgn(0, 0, -1, -1);
+    DWM_BLURBEHIND bb = {0};
+    bb.dwFlags = DWM_BB_ENABLE | DWM_BB_BLURREGION;
+    bb.hRgnBlur = region;
+    bb.fEnable = TRUE;
+    DwmEnableBlurBehindWindow(hwnd, &bb);
+    DeleteObject(region);
+}
+
+#endif

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/SkiaLayer.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/SkiaLayer.kt
@@ -1,8 +1,19 @@
 package org.jetbrains.skiko
 
-import org.jetbrains.skia.*
+import org.jetbrains.skia.Canvas
+import org.jetbrains.skia.Bitmap
+import org.jetbrains.skia.ColorAlphaType
+import org.jetbrains.skia.ColorInfo
+import org.jetbrains.skia.ColorType
+import org.jetbrains.skia.ColorSpace
+import org.jetbrains.skia.ClipMode
+import org.jetbrains.skia.ImageInfo
+import org.jetbrains.skia.Picture
+import org.jetbrains.skia.PictureRecorder
+import org.jetbrains.skia.Rect
 import org.jetbrains.skiko.context.ContextHandler
 import org.jetbrains.skiko.redrawer.Redrawer
+import java.awt.Color
 import java.awt.Graphics
 import java.awt.event.*
 import java.awt.im.InputMethodRequests
@@ -31,6 +42,8 @@ open class SkiaLayer internal constructor(
         ContentScale,
     }
 
+    var transparency: Boolean = false
+
     internal val backedLayer: HardwareLayer
 
     constructor(
@@ -42,6 +55,7 @@ open class SkiaLayer internal constructor(
 
     init {
         isOpaque = false
+        background = Color(0, 0, 0, 0)
         layout = null
         backedLayer = object : HardwareLayer() {
             override fun paint(g: Graphics) {

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/context/ContextHandler.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/context/ContextHandler.kt
@@ -6,15 +6,13 @@ import org.jetbrains.skia.DirectContext
 import org.jetbrains.skia.Picture
 import org.jetbrains.skia.Surface
 import org.jetbrains.skiko.GraphicsApi
-import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.SkiaLayer
-import org.jetbrains.skiko.hostOs
 import org.jetbrains.skiko.hostFullName
 import org.jetbrains.skiko.javaLocation
 import org.jetbrains.skiko.javaVendor
 
 internal abstract class ContextHandler(val layer: SkiaLayer) {
-    open val bleachConstant = if (hostOs == OS.MacOS) 0 else -1
+    open val clearColor = 0 //transparent
     var context: DirectContext? = null
     var renderTarget: BackendRenderTarget? = null
     var surface: Surface? = null
@@ -24,7 +22,7 @@ internal abstract class ContextHandler(val layer: SkiaLayer) {
     abstract fun initCanvas()
 
     fun clearCanvas() {
-        canvas?.clear(bleachConstant)
+        canvas?.clear(clearColor)
     }
 
     open fun drawOnCanvas(picture: Picture) {

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/context/DirectSoftwareContextHandler.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/context/DirectSoftwareContextHandler.kt
@@ -8,7 +8,6 @@ import org.jetbrains.skiko.redrawer.AbstractDirectSoftwareRedrawer
 import java.lang.ref.Reference
 
 internal class DirectSoftwareContextHandler(layer: SkiaLayer) : ContextHandler(layer) {
-    override val bleachConstant = -1
     var isInited = false
 
     val softwareRedrawer: AbstractDirectSoftwareRedrawer

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/context/SoftwareContextHandler.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/context/SoftwareContextHandler.kt
@@ -6,6 +6,8 @@ import org.jetbrains.skia.ColorAlphaType
 import org.jetbrains.skia.ImageInfo
 import org.jetbrains.skia.Picture
 import org.jetbrains.skiko.SkiaLayer
+import org.jetbrains.skiko.hostOs
+import org.jetbrains.skiko.OS
 import java.awt.Transparency
 import java.awt.Color
 import java.awt.color.ColorSpace
@@ -17,7 +19,7 @@ import java.awt.image.Raster
 import java.awt.image.WritableRaster
 
 internal class SoftwareContextHandler(layer: SkiaLayer) : ContextHandler(layer) {
-    override val clearColor = if (layer.transparency) 0 else -1 // it looks like java.awt.Canvas doesn't support transparency
+    override val clearColor = if (layer.transparency && hostOs == OS.MacOS) 0 else -1
 
     val colorModel = ComponentColorModel(
         ColorSpace.getInstance(ColorSpace.CS_sRGB),
@@ -78,11 +80,11 @@ internal class SoftwareContextHandler(layer: SkiaLayer) : ContextHandler(layer) 
             )
             image = BufferedImage(colorModel, raster!!, false, null)
             val graphics = layer.backedLayer.getGraphics()
-            if (graphics != null) {
-                graphics.setColor(Color(0, 0, 0, 0))
-                graphics.clearRect(0,0,w,h)
+            if (layer.transparency && hostOs == OS.MacOS) {
+                graphics?.setColor(Color(0, 0, 0, 0))
+                graphics?.clearRect(0, 0, w, h)
             }
-            layer.backedLayer.getGraphics()?.drawImage(image!!, 0, 0, layer.width, layer.height, null)
+            graphics?.drawImage(image!!, 0, 0, layer.width, layer.height, null)
         }
     }
 

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/context/SoftwareContextHandler.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/context/SoftwareContextHandler.kt
@@ -16,7 +16,7 @@ import java.awt.image.Raster
 import java.awt.image.WritableRaster
 
 internal class SoftwareContextHandler(layer: SkiaLayer) : ContextHandler(layer) {
-    override val bleachConstant = -1 // it looks like java.awt.Canvas doesn't support transparency
+    override val clearColor = 0 // it looks like java.awt.Canvas doesn't support transparency
 
     val colorModel = ComponentColorModel(
         ColorSpace.getInstance(ColorSpace.CS_sRGB),

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/context/SoftwareContextHandler.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/context/SoftwareContextHandler.kt
@@ -7,6 +7,7 @@ import org.jetbrains.skia.ImageInfo
 import org.jetbrains.skia.Picture
 import org.jetbrains.skiko.SkiaLayer
 import java.awt.Transparency
+import java.awt.Color
 import java.awt.color.ColorSpace
 import java.awt.image.BufferedImage
 import java.awt.image.ComponentColorModel
@@ -16,7 +17,7 @@ import java.awt.image.Raster
 import java.awt.image.WritableRaster
 
 internal class SoftwareContextHandler(layer: SkiaLayer) : ContextHandler(layer) {
-    override val clearColor = 0 // it looks like java.awt.Canvas doesn't support transparency
+    override val clearColor = if (layer.transparency) 0 else -1 // it looks like java.awt.Canvas doesn't support transparency
 
     val colorModel = ComponentColorModel(
         ColorSpace.getInstance(ColorSpace.CS_sRGB),
@@ -76,6 +77,11 @@ internal class SoftwareContextHandler(layer: SkiaLayer) : ContextHandler(layer) 
                 null
             )
             image = BufferedImage(colorModel, raster!!, false, null)
+            val graphics = layer.backedLayer.getGraphics()
+            if (graphics != null) {
+                graphics.setColor(Color(0, 0, 0, 0))
+                graphics.clearRect(0,0,w,h)
+            }
             layer.backedLayer.getGraphics()?.drawImage(image!!, 0, 0, layer.width, layer.height, null)
         }
     }

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/redrawer/Direct3DRedrawer.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/redrawer/Direct3DRedrawer.kt
@@ -15,7 +15,7 @@ internal class Direct3DRedrawer(
     private var isDisposed = false
     private var drawLock = Any()
 
-    private val device = createDirectXDevice(getAdapterPriority(), layer.contentHandle).also {
+    private val device = createDirectXDevice(getAdapterPriority(), layer.contentHandle, layer.transparency).also {
         if (it == 0L || !isVideoCardSupported(layer.renderApi)) {
             throw RenderException("Failed to create DirectX12 device.")
         }
@@ -92,7 +92,7 @@ internal class Direct3DRedrawer(
     val adapterName get() = getAdapterName(device)
     val adapterMemorySize get() = getAdapterMemorySize(device)
 
-    private external fun createDirectXDevice(adapterPriority: Int, contentHandle: Long): Long
+    private external fun createDirectXDevice(adapterPriority: Int, contentHandle: Long, transparency: Boolean): Long
     private external fun makeDirectXContext(device: Long): Long
     private external fun makeDirectXSurface(device: Long, context: Long, width: Int, height: Int, index: Int): Long
     private external fun resizeBuffers(device: Long, width: Int, height: Int)

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
@@ -21,7 +21,7 @@ internal class MetalRedrawer(
     private var isDisposed = false
     private var drawLock = Any()
     private val device = layer.backedLayer.useDrawingSurfacePlatformInfo {
-        createMetalDevice(getAdapterPriority(), it)
+        createMetalDevice(layer.windowHandle, layer.transparency, getAdapterPriority(), it)
     }
     private val windowHandle = layer.windowHandle
 
@@ -131,7 +131,7 @@ internal class MetalRedrawer(
     fun getAdapterName(): String = getAdapterName(device)
     fun getAdapterMemorySize(): Long = getAdapterMemorySize(device)
 
-    private external fun createMetalDevice(adapterPriority: Int, platformInfo: Long): Long
+    private external fun createMetalDevice(window:Long, transparency: Boolean, adapterPriority: Int, platformInfo: Long): Long
     private external fun makeMetalContext(device: Long): Long
     private external fun makeMetalRenderTarget(device: Long, width: Int, height: Int): Long
     private external fun disposeDevice(device: Long)

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/redrawer/WindowsOpenGLRedrawer.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/redrawer/WindowsOpenGLRedrawer.kt
@@ -11,7 +11,7 @@ internal class WindowsOpenGLRedrawer(
     private val properties: SkiaLayerProperties
 ) : Redrawer {
     private val device = layer.backedLayer.useDrawingSurfacePlatformInfo(::getDevice)
-    private val context = createContext(device).also {
+    private val context = createContext(device, layer.contentHandle, layer.transparency).also {
         if (it == 0L) {
             throw RenderException("Cannot create Windows GL context")
         }
@@ -112,7 +112,7 @@ internal class WindowsOpenGLRedrawer(
 
 private external fun makeCurrent(device: Long, context: Long)
 private external fun getDevice(platformInfo: Long): Long
-private external fun createContext(device: Long): Long
+private external fun createContext(device: Long, contentHandle:Long, transparency: Boolean): Long
 private external fun deleteContext(context: Long)
 private external fun setSwapInterval(interval: Int)
 private external fun swapBuffers(device: Long)

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/redrawer/WindowsSoftwareRedrawer.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/redrawer/WindowsSoftwareRedrawer.kt
@@ -15,12 +15,12 @@ internal class WindowsSoftwareRedrawer(
 ) : AbstractDirectSoftwareRedrawer(layer, properties) {
 
     init {
-        device = createDevice(layer.contentHandle).also {
+        device = createDevice(layer.contentHandle, layer.transparency).also {
             if (it == 0L) {
                 throw RenderException("Failed to create Software device")
             }
         }
     }
 
-    private external fun createDevice(contentHandle: Long): Long
+    private external fun createDevice(contentHandle: Long, transparency: Boolean): Long
 }

--- a/skiko/src/jvmMain/objectiveC/macos/MetalRedrawer.mm
+++ b/skiko/src/jvmMain/objectiveC/macos/MetalRedrawer.mm
@@ -183,7 +183,7 @@ id<MTLDevice> MTLCreateIntegratedDevice(int adapterPriority) {
 }
 
 JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_redrawer_MetalRedrawer_createMetalDevice(
-    JNIEnv *env, jobject redrawer, jint adapterPriority, jlong platformInfoPtr)
+    JNIEnv *env, jobject redrawer, jlong windowPtr, jboolean transparency, jint adapterPriority, jlong platformInfoPtr)
 {
     MetalDevice *device = [MetalDevice new];
 
@@ -213,6 +213,12 @@ JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_redrawer_MetalRedrawer_createMe
     CGFloat transparent[] = { 0.0f, 0.0f, 0.0f, 0.0f };
     device.layer.backgroundColor = CGColorCreate(CGColorSpaceCreateDeviceRGB(), transparent);
     device.layer.opaque = NO;
+    
+    if (transparency)
+    {
+        NSWindow* window = (NSWindow*)windowPtr;
+        window.hasShadow = NO;
+    }
 
     return (jlong) device;
 }


### PR DESCRIPTION
List of supported renders:
 - OpenGL (Windows and Linux)
 - Metal
 - Direct software
 - Software (MacOS)

In DirectX we have problems in creating render buffer with transparency support. It is kind hard to explain but the main reason is that choosen function that creates `swapChain` - `CreateSwapChainForHwnd` does no support alpha channel and for now we it is the only function that we can use. Thai is why if current renderer is DirectX and transparency is enabled skiko fallbacks to OpenGL renderer.