### PR TITLE
Maybe fix type in App.ios.kt

### DIFF
--- a/samples/SkiaNativeSample/src/iosMain/kotlin/org/jetbrains/skiko/sample/App.ios.kt
+++ b/samples/SkiaNativeSample/src/iosMain/kotlin/org/jetbrains/skiko/sample/App.ios.kt
@@ -1,4 +1,4 @@
-// Use `xcodegen` first, then `open ./SkikoSample.xcodeproj` and then Rub
+// Use `xcodegen` first, then `open ./SkikoSample.xcodeproj` and then Run
 
 package org.jetbrains.skiko.sample
 


### PR DESCRIPTION
there appears to be a typo in App.ios.kt
```kotlin
/ /Use `xcodegen` first, then `open ./SkikoSample.xcodeproj` and then Rub
```
it looks like it should be
```kotlin
/ /Use `xcodegen` first, then `open ./SkikoSample.xcodeproj` and then Run
```