### PR TITLE
Fixed fallback and transparency support on VM linux on OpenGL.

### DIFF
--- a/skiko/src/jvmMain/cpp/linux/redrawer.cc
+++ b/skiko/src/jvmMain/cpp/linux/redrawer.cc
@@ -78,7 +78,6 @@ extern "C"
                 GLX_GREEN_SIZE, 8,
                 GLX_BLUE_SIZE, 8,
                 GLX_ALPHA_SIZE, 8,
-                GLX_DEPTH_SIZE, 32,
                 GLX_DOUBLEBUFFER, True, None
             };
             vi = glXChooseVisual(display, 0, att);

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/GraphicsApi.jvm.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/GraphicsApi.jvm.kt
@@ -15,7 +15,9 @@ internal fun isVideoCardSupported(renderApi: GraphicsApi): Boolean {
             val adaptersList = notSupportedAdapters.filter { it.startsWith("opengl:") }.map {
                 it.replace("opengl:", "")
             }
-            var adapter = gl.glGetString(gl.GL_RENDERER)
+            var adapter = gl.glGetString(gl.GL_RENDERER).also {
+                if (it == null) { return false }
+            }
             adaptersList.forEach {
                 if (adapter.startsWith(it)) {
                     return false


### PR DESCRIPTION
Tested on VirtualBox with Fedora/Ubuntu with 3D graphics acceleration.