### PR TITLE
[Gradle] Disable native dependency propagation

### DIFF
--- a/skiko/gradle.properties
+++ b/skiko/gradle.properties
@@ -1,6 +1,7 @@
 kotlin.code.style=official
 deploy.version=0.0.0
 kotlin.mpp.enableGranularSourceSetsMetadata=true
+kotlin.native.enableDependencyPropagation=false
 
 dependencies.skia.windows-x64=m96-fd5bb8d130
 dependencies.skia.linux-x64=m96-fd5bb8d130


### PR DESCRIPTION
This commit will 'enable' full hierarchical multiplatform support.
Native dependency propagation is not compatible anymore with
newer IDE versions and not maintained in the KGP