### PR TITLE
tune `disableTitleBar`

### DIFF
--- a/skiko/src/jvmMain/objectiveC/macos/Drawlayer.mm
+++ b/skiko/src/jvmMain/objectiveC/macos/Drawlayer.mm
@@ -185,9 +185,6 @@ JNIEXPORT void JNICALL Java_org_jetbrains_skiko_PlatformOperationsKt_osxDisableT
         [window setTitlebarAppearsTransparent:YES];
         [window setTitleVisibility:NSWindowTitleHidden];
         [window setStyleMask:[window styleMask]|NSWindowStyleMaskFullSizeContentView];
-        // always show `fullscreen` green traffic light button instead of `maximize/zoom` button
-        [window setCollectionBehavior:[window collectionBehavior]|NSWindowCollectionBehaviorFullScreenPrimary];
-        [window setMovable:NO];
     });
 }
 


### PR DESCRIPTION
`[window setMovable:NO]` breaks window positioning when display configuration changed