### PR TITLE
pack SamplingMode into IntArray with 2 Int values.

### DIFF
--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Bitmap.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Bitmap.kt
@@ -1021,7 +1021,8 @@ class Bitmap internal constructor(ptr: NativePointer) : Managed(ptr, _FinalizerH
                         _ptr,
                         tmx.ordinal,
                         tmy.ordinal,
-                        toInterop(sampling._packAs2Ints()),
+                        sampling._packedInt1(),
+                        sampling._packedInt2(),
                         toInterop(localMatrix?.mat)
                     )
                 }
@@ -1196,4 +1197,4 @@ private external fun _nExtractAlpha(ptr: NativePointer, dstPtr: NativePointer, p
 private external fun _nPeekPixels(ptr: NativePointer): NativePointer
 
 @ExternalSymbolName("org_jetbrains_skia_Bitmap__1nMakeShader")
-private external fun _nMakeShader(ptr: NativePointer, tmx: Int, tmy: Int, samplingMode: InteropPointer, localMatrix: InteropPointer): NativePointer
+private external fun _nMakeShader(ptr: NativePointer, tmx: Int, tmy: Int, samplingModeValue1: Int, samplingModeValue2: Int, localMatrix: InteropPointer): NativePointer

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Canvas.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Canvas.kt
@@ -417,23 +417,22 @@ open class Canvas internal constructor(ptr: NativePointer, managed: Boolean, int
         strict: Boolean
     ): Canvas {
         Stats.onNativeCall()
-        interopScope {
-            _nDrawImageRect(
-                _ptr,
-                getPtr(image),
-                src.left,
-                src.top,
-                src.right,
-                src.bottom,
-                dst.left,
-                dst.top,
-                dst.right,
-                dst.bottom,
-                toInterop(samplingMode._packAs2Ints()),
-                getPtr(paint),
-                strict
-            )
-        }
+        _nDrawImageRect(
+            _ptr,
+            getPtr(image),
+            src.left,
+            src.top,
+            src.right,
+            src.bottom,
+            dst.left,
+            dst.top,
+            dst.right,
+            dst.bottom,
+            samplingMode._packedInt1(),
+            samplingMode._packedInt2(),
+            getPtr(paint),
+            strict
+        )
         reachabilityBarrier(image)
         reachabilityBarrier(paint)
         return this
@@ -1552,7 +1551,8 @@ private external fun _nDrawImageRect(
     dt: Float,
     dr: Float,
     db: Float,
-    samplingMode: InteropPointer,
+    samplingModeVal1: Int,
+    samplingModeVal2: Int,
     paintPtr: NativePointer,
     strict: Boolean
 )

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/CubicResampler.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/CubicResampler.kt
@@ -25,11 +25,8 @@ class CubicResampler(val b: Float, val c: Float) : SamplingMode {
 
     override fun _pack(): Long = (0x8L shl 60) or ((b.toBits().toULong() shl 32) or c.toBits().toULong()).toLong()
 
-    override fun _packAs2Ints(): IntArray {
-        val intC = b.toBits() or (0x8 shl 28)
-        val intB = c.toBits()
-        return intArrayOf(intC, intB)
-    }
+    override fun _packedInt1(): Int = b.toBits() or (0x8 shl 28)
+    override fun _packedInt2(): Int = c.toBits()
 
     override fun equals(other: Any?): Boolean {
         if (other === this) return true

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/FilterMipmap.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/FilterMipmap.kt
@@ -7,9 +7,8 @@ class FilterMipmap constructor(
 
     override fun _pack() = filterMode.ordinal.toLong() shl 32 or mipmapMode.ordinal.toLong()
 
-    override fun _packAs2Ints(): IntArray {
-        return intArrayOf(filterMode.ordinal, mipmapMode.ordinal)
-    }
+    override fun _packedInt1(): Int = filterMode.ordinal
+    override fun _packedInt2(): Int = mipmapMode.ordinal
 
     override fun equals(other: Any?): Boolean {
         if (other === this) return true

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Image.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Image.kt
@@ -235,7 +235,8 @@ class Image internal constructor(ptr: NativePointer) : RefCnt(ptr), IHasImageInf
                         _ptr,
                         tmx.ordinal,
                         tmy.ordinal,
-                        toInterop(sampling._packAs2Ints()),
+                        sampling._packedInt1(),
+                        sampling._packedInt2(),
                         toInterop(localMatrix?.mat)
                     )
                 }
@@ -358,14 +359,13 @@ class Image internal constructor(ptr: NativePointer) : RefCnt(ptr), IHasImageInf
 
     fun scalePixels(dst: Pixmap, samplingMode: SamplingMode, cache: Boolean): Boolean {
         return try {
-            interopScope {
-                _nScalePixels(
-                    _ptr,
-                    getPtr(dst),
-                    toInterop(samplingMode._packAs2Ints()),
-                    cache
-                )
-            }
+            _nScalePixels(
+                _ptr,
+                getPtr(dst),
+                samplingMode._packedInt1(),
+                samplingMode._packedInt2(),
+                cache
+            )
         } finally {
             reachabilityBarrier(this)
             reachabilityBarrier(dst)
@@ -377,7 +377,7 @@ class Image internal constructor(ptr: NativePointer) : RefCnt(ptr), IHasImageInf
 private external fun Image_nGetImageInfo(ptr: NativePointer, imageInfo: InteropPointer, colorSpacePtrs: InteropPointer)
 
 @ExternalSymbolName("org_jetbrains_skia_Image__1nMakeShader")
-private external fun Image_nMakeShader(ptr: NativePointer, tmx: Int, tmy: Int, samplingMode: InteropPointer, localMatrix: InteropPointer): NativePointer
+private external fun Image_nMakeShader(ptr: NativePointer, tmx: Int, tmy: Int, samplingModeVal1: Int, samplingModeVal2: Int, localMatrix: InteropPointer): NativePointer
 
 @ExternalSymbolName("org_jetbrains_skia_Image__1nPeekPixels")
 private external fun Image_nPeekPixels(ptr: NativePointer): NativePointer
@@ -422,7 +422,7 @@ private external fun _nEncodeToData(ptr: NativePointer, format: Int, quality: In
 private external fun _nPeekPixelsToPixmap(ptr: NativePointer, pixmapPtr: NativePointer): Boolean
 
 @ExternalSymbolName("org_jetbrains_skia_Image__1nScalePixels")
-private external fun _nScalePixels(ptr: NativePointer, pixmapPtr: NativePointer, samplingOptions: InteropPointer, cache: Boolean): Boolean
+private external fun _nScalePixels(ptr: NativePointer, pixmapPtr: NativePointer, samplingOptionsVal1: Int, samplingOptionsVal2: Int, cache: Boolean): Boolean
 
 @ExternalSymbolName("org_jetbrains_skia_Image__1nReadPixelsBitmap")
 private external fun _nReadPixelsBitmap(

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/ImageFilter.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/ImageFilter.kt
@@ -217,24 +217,21 @@ class ImageFilter internal constructor(ptr: NativePointer) : RefCnt(ptr) {
         fun makeImage(image: Image?, src: Rect, dst: Rect, mode: SamplingMode): ImageFilter {
             return try {
                 Stats.onNativeCall()
-                interopScope {
-                    ImageFilter(
-                        _nMakeImage(
-                            getPtr(
-                                image
-                            ),
-                            src.left,
-                            src.top,
-                            src.right,
-                            src.bottom,
-                            dst.left,
-                            dst.top,
-                            dst.right,
-                            dst.bottom,
-                            toInterop(mode._packAs2Ints())
-                        )
+                ImageFilter(
+                    _nMakeImage(
+                        getPtr(image),
+                        src.left,
+                        src.top,
+                        src.right,
+                        src.bottom,
+                        dst.left,
+                        dst.top,
+                        dst.right,
+                        dst.bottom,
+                        mode._packedInt1(),
+                        mode._packedInt2()
                     )
-                }
+                )
             } finally {
                 reachabilityBarrier(image)
             }
@@ -303,7 +300,8 @@ class ImageFilter internal constructor(ptr: NativePointer) : RefCnt(ptr) {
                     interopScope {
                         _nMakeMatrixTransform(
                             toInterop(matrix.mat),
-                            toInterop(mode._packAs2Ints()),
+                            mode._packedInt1(),
+                            mode._packedInt2(),
                             getPtr(input)
                         )
                     }
@@ -688,7 +686,8 @@ private external fun _nMakeImage(
     t1: Float,
     r1: Float,
     b1: Float,
-    samplingMode: InteropPointer
+    samplingModeVal1: Int,
+    samplingModeVal2: Int,
 ): NativePointer
 
 @ExternalSymbolName("org_jetbrains_skia_ImageFilter__1nMakeMagnifier")
@@ -718,7 +717,7 @@ private external fun _nMakeMatrixConvolution(
 ): NativePointer
 
 @ExternalSymbolName("org_jetbrains_skia_ImageFilter__1nMakeMatrixTransform")
-private external fun _nMakeMatrixTransform(matrix: InteropPointer, samplingMode: InteropPointer, input: NativePointer): NativePointer
+private external fun _nMakeMatrixTransform(matrix: InteropPointer, samplingModeVal1: Int, samplingModeVal2: Int, input: NativePointer): NativePointer
 @ExternalSymbolName("org_jetbrains_skia_ImageFilter__1nMakeMerge")
 private external fun _nMakeMerge(filters: InteropPointer, crop: IRect?): NativePointer
 @ExternalSymbolName("org_jetbrains_skia_ImageFilter__1nMakeOffset")

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Pixmap.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Pixmap.kt
@@ -213,13 +213,12 @@ class Pixmap internal constructor(ptr: NativePointer, managed: Boolean) :
     fun scalePixels(dstPixmap: Pixmap?, samplingMode: SamplingMode): Boolean {
         Stats.onNativeCall()
         return try {
-            interopScope {
-                _nScalePixels(
-                    _ptr,
-                    getPtr(dstPixmap),
-                    toInterop(samplingMode._packAs2Ints())
-                )
-            }
+            _nScalePixels(
+                _ptr,
+                getPtr(dstPixmap),
+                samplingMode._packedInt1(),
+                samplingMode._packedInt2()
+            )
         } finally {
             reachabilityBarrier(this)
             reachabilityBarrier(dstPixmap)
@@ -394,7 +393,7 @@ private external fun _nReadPixelsToPixmap(ptr: NativePointer, dstPixmapPtr: Nati
 private external fun _nReadPixelsToPixmapFromPoint(ptr: NativePointer, dstPixmapPtr: NativePointer, srcX: Int, srcY: Int): Boolean
 
 @ExternalSymbolName("org_jetbrains_skia_Pixmap__1nScalePixels")
-private external fun _nScalePixels(ptr: NativePointer, dstPixmapPtr: NativePointer, samplingOptions: InteropPointer): Boolean
+private external fun _nScalePixels(ptr: NativePointer, dstPixmapPtr: NativePointer, samplingOptionsVal1: Int, samplingOptionsVal2: Int): Boolean
 
 @ExternalSymbolName("org_jetbrains_skia_Pixmap__1nErase")
 private external fun _nErase(ptr: NativePointer, color: Int): Boolean

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/SamplingMode.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/SamplingMode.kt
@@ -6,8 +6,12 @@ package org.jetbrains.skia
  * @see org.jetbrains.skia.CubicResampler
  */
 interface SamplingMode {
+    @Deprecated("Long can't be used because Long is an object in kotlin/js. Consider using _packedInt1 and _packedInt2")
     fun _pack(): Long
-    fun _packAs2Ints(): IntArray
+
+    // _packedInt1 and _packedInt2 are used to serialize SamplingMode instances for interop
+    fun _packedInt1(): Int
+    fun _packedInt2(): Int
 
     companion object {
         val DEFAULT: SamplingMode = FilterMipmap(FilterMode.NEAREST, MipmapMode.NONE)

--- a/skiko/src/commonTest/kotlin/org/jetbrains/skia/SamplingModeTest.kt
+++ b/skiko/src/commonTest/kotlin/org/jetbrains/skia/SamplingModeTest.kt
@@ -19,9 +19,8 @@ class SamplingModeTest {
                 assertEquals(filterMode.ordinal, l1)
                 assertEquals(mipmapMode.ordinal, l2)
 
-                val ints = samplingMode._packAs2Ints()
-                assertEquals(l1, ints[0])
-                assertEquals(l2, ints[1])
+                assertEquals(l1, samplingMode._packedInt1())
+                assertEquals(l2, samplingMode._packedInt2())
             }
         }
     }
@@ -43,8 +42,9 @@ class SamplingModeTest {
                 assertEquals(((long and 0x7FFFFFFFFFFFFFFF) shr 32).toInt(), bBits)
                 assertEquals((long and 0xFFFFFFFF).toInt() , cBits)
 
-                val ints = samplingMode._packAs2Ints()
-                assertEquals(long, (ints[0].toULong() shl 32 or ints[1].toULong()).toLong())
+                val int1 = samplingMode._packedInt1()
+                val int2 = samplingMode._packedInt2()
+                assertEquals(long, (int1.toULong() shl 32 or int2.toULong()).toLong())
             }
         }
     }

--- a/skiko/src/jvmMain/cpp/common/Bitmap.cc
+++ b/skiko/src/jvmMain/cpp/common/Bitmap.cc
@@ -272,9 +272,9 @@ extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_BitmapKt__1nPeekPixel
 }
 
 extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_BitmapKt__1nMakeShader
-  (JNIEnv* env, jclass jclass, jlong ptr, jint tmx, jint tmy, jintArray samplingMode, jfloatArray localMatrixArr) {
+  (JNIEnv* env, jclass jclass, jlong ptr, jint tmx, jint tmy, jint samplingModeVal1, jint samplingModeVal2, jfloatArray localMatrixArr) {
     SkBitmap* instance = reinterpret_cast<SkBitmap*>(static_cast<uintptr_t>(ptr));
     std::unique_ptr<SkMatrix> localMatrix = skMatrix(env, localMatrixArr);
-    sk_sp<SkShader> shader = instance->makeShader(static_cast<SkTileMode>(tmx), static_cast<SkTileMode>(tmy), skija::SamplingMode::unpackFrom2Ints(env, samplingMode), localMatrix.get());
+    sk_sp<SkShader> shader = instance->makeShader(static_cast<SkTileMode>(tmx), static_cast<SkTileMode>(tmy), skija::SamplingMode::unpackFrom2Ints(env, samplingModeVal1, samplingModeVal2), localMatrix.get());
     return reinterpret_cast<jlong>(shader.release());
 }

--- a/skiko/src/jvmMain/cpp/common/Canvas.cc
+++ b/skiko/src/jvmMain/cpp/common/Canvas.cc
@@ -96,14 +96,14 @@ extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_CanvasKt__1nDrawPath
 }
 
 extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_CanvasKt__1nDrawImageRect
-  (JNIEnv* env, jclass jclass, jlong canvasPtr, jlong imagePtr, jfloat sl, jfloat st, jfloat sr, jfloat sb, jfloat dl, jfloat dt, jfloat dr, jfloat db, jintArray samplingMode, jlong paintPtr, jboolean strict) {
+  (JNIEnv* env, jclass jclass, jlong canvasPtr, jlong imagePtr, jfloat sl, jfloat st, jfloat sr, jfloat sb, jfloat dl, jfloat dt, jfloat dr, jfloat db, jint samplingModeVal1, jint samplingModeVal2, jlong paintPtr, jboolean strict) {
     SkCanvas* canvas = reinterpret_cast<SkCanvas*>(static_cast<uintptr_t>(canvasPtr));
     SkImage* image = reinterpret_cast<SkImage*>(static_cast<uintptr_t>(imagePtr));
     SkRect src {sl, st, sr, sb};
     SkRect dst {dl, dt, dr, db};
     SkPaint* paint = reinterpret_cast<SkPaint*>(static_cast<uintptr_t>(paintPtr));
     SkCanvas::SrcRectConstraint constraint = strict ? SkCanvas::SrcRectConstraint::kStrict_SrcRectConstraint : SkCanvas::SrcRectConstraint::kFast_SrcRectConstraint;
-    canvas->drawImageRect(image, src, dst, skija::SamplingMode::unpackFrom2Ints(env, samplingMode), paint, constraint);
+    canvas->drawImageRect(image, src, dst, skija::SamplingMode::unpackFrom2Ints(env, samplingModeVal1, samplingModeVal2), paint, constraint);
 }
 
 extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_CanvasKt__1nDrawImageNine

--- a/skiko/src/jvmMain/cpp/common/Image.cc
+++ b/skiko/src/jvmMain/cpp/common/Image.cc
@@ -74,10 +74,10 @@ extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_ImageKt__1nEncodeToDa
 }
 
 extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_ImageKt_Image_1nMakeShader
-  (JNIEnv* env, jclass jclass, jlong ptr, jint tmx, jint tmy, jintArray sampling, jfloatArray localMatrixArr) {
+  (JNIEnv* env, jclass jclass, jlong ptr, jint tmx, jint tmy, jint samplingVal1, jint samplingVal2, jfloatArray localMatrixArr) {
     SkImage* instance = reinterpret_cast<SkImage*>(static_cast<uintptr_t>(ptr));
     std::unique_ptr<SkMatrix> localMatrix = skMatrix(env, localMatrixArr);
-    sk_sp<SkShader> shader = instance->makeShader(static_cast<SkTileMode>(tmx), static_cast<SkTileMode>(tmy), skija::SamplingMode::unpackFrom2Ints(env, sampling), localMatrix.get());
+    sk_sp<SkShader> shader = instance->makeShader(static_cast<SkTileMode>(tmx), static_cast<SkTileMode>(tmy), skija::SamplingMode::unpackFrom2Ints(env, samplingVal1, samplingVal2), localMatrix.get());
     return reinterpret_cast<jlong>(shader.release());
 }
 
@@ -119,9 +119,9 @@ extern "C" JNIEXPORT jboolean JNICALL Java_org_jetbrains_skia_ImageKt__1nReadPix
 }
 
 extern "C" JNIEXPORT jboolean JNICALL Java_org_jetbrains_skia_ImageKt__1nScalePixels
-  (JNIEnv* env, jclass jclass, jlong ptr, jlong pixmapPtr, jintArray samplingOptions, jboolean cache) {
+  (JNIEnv* env, jclass jclass, jlong ptr, jlong pixmapPtr, jint samplingOptionsVal1, jint samplingOptionsVal2, jboolean cache) {
     SkImage* instance = reinterpret_cast<SkImage*>(static_cast<uintptr_t>(ptr));
     SkPixmap* pixmap = reinterpret_cast<SkPixmap*>(static_cast<uintptr_t>(pixmapPtr));
     auto cachingHint = cache ? SkImage::CachingHint::kAllow_CachingHint : SkImage::CachingHint::kDisallow_CachingHint;
-    return instance->scalePixels(*pixmap, skija::SamplingMode::unpackFrom2Ints(env, samplingOptions), cachingHint);
+    return instance->scalePixels(*pixmap, skija::SamplingMode::unpackFrom2Ints(env, samplingOptionsVal1, samplingOptionsVal2), cachingHint);
 }

--- a/skiko/src/jvmMain/cpp/common/ImageFilter.cc
+++ b/skiko/src/jvmMain/cpp/common/ImageFilter.cc
@@ -90,9 +90,9 @@ extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_ImageFilterKt__1nMake
 }
 
 extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_ImageFilterKt__1nMakeImage
-  (JNIEnv* env, jclass jclass, jlong imagePtr, jfloat l0, jfloat t0, jfloat r0, jfloat b0, jfloat l1, jfloat t1, jfloat r1, jfloat b1, jintArray samplingMode) {
+  (JNIEnv* env, jclass jclass, jlong imagePtr, jfloat l0, jfloat t0, jfloat r0, jfloat b0, jfloat l1, jfloat t1, jfloat r1, jfloat b1, jint samplingModeVal1, jint samplingModeVal2) {
     SkImage* image = reinterpret_cast<SkImage*>(static_cast<uintptr_t>(imagePtr));
-    SkImageFilter* ptr = SkImageFilters::Image(sk_ref_sp(image), SkRect{l0, t0, r0, b0}, SkRect{l1, t1, r1, b1}, skija::SamplingMode::unpackFrom2Ints(env, samplingMode)).release();
+    SkImageFilter* ptr = SkImageFilters::Image(sk_ref_sp(image), SkRect{l0, t0, r0, b0}, SkRect{l1, t1, r1, b1}, skija::SamplingMode::unpackFrom2Ints(env, samplingModeVal1, samplingModeVal2)).release();
     return reinterpret_cast<jlong>(ptr);
 }
 
@@ -116,10 +116,10 @@ extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_ImageFilterKt__1nMake
 }
 
 extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_ImageFilterKt__1nMakeMatrixTransform
-  (JNIEnv* env, jclass jclass, jfloatArray matrixArray, jintArray samplingMode, jlong inputPtr) {
+  (JNIEnv* env, jclass jclass, jfloatArray matrixArray, jint samplingModeVal1, jint samplingModeVal2, jlong inputPtr) {
     std::unique_ptr<SkMatrix> matrix = skMatrix(env, matrixArray);
     SkImageFilter* input = reinterpret_cast<SkImageFilter*>(static_cast<uintptr_t>(inputPtr));
-    SkImageFilter* ptr = SkImageFilters::MatrixTransform(*matrix, skija::SamplingMode::unpackFrom2Ints(env, samplingMode), sk_ref_sp(input)).release();
+    SkImageFilter* ptr = SkImageFilters::MatrixTransform(*matrix, skija::SamplingMode::unpackFrom2Ints(env, samplingModeVal1, samplingModeVal2), sk_ref_sp(input)).release();
     return reinterpret_cast<jlong>(ptr);
 }
 

--- a/skiko/src/jvmMain/cpp/common/Pixmap.cc
+++ b/skiko/src/jvmMain/cpp/common/Pixmap.cc
@@ -161,10 +161,10 @@ extern "C" {
     }
 
     JNIEXPORT jboolean JNICALL Java_org_jetbrains_skia_PixmapKt__1nScalePixels
-      (JNIEnv *env, jclass klass, jlong ptr, jlong dstPixmapPtr, jintArray samplingOptions) {
+      (JNIEnv *env, jclass klass, jlong ptr, jlong dstPixmapPtr, jint samplingOptionsVal1, jint samplingOptionsVal2) {
         SkPixmap* pixmap = jlongToPtr<SkPixmap*>(ptr);
         SkPixmap* dstPixmap = jlongToPtr<SkPixmap*>(dstPixmapPtr);
-        return static_cast<jboolean>(pixmap->scalePixels(*dstPixmap, skija::SamplingMode::unpackFrom2Ints(env, samplingOptions)));
+        return static_cast<jboolean>(pixmap->scalePixels(*dstPixmap, skija::SamplingMode::unpackFrom2Ints(env, samplingOptionsVal1, samplingOptionsVal2)));
     }
 
     JNIEXPORT jboolean JNICALL Java_org_jetbrains_skia_PixmapKt__1nErase

--- a/skiko/src/jvmMain/cpp/common/interop.cc
+++ b/skiko/src/jvmMain/cpp/common/interop.cc
@@ -1067,20 +1067,16 @@ namespace skija {
             }
         }
 
-        SkSamplingOptions unpackFrom2Ints(JNIEnv* env, jintArray packed) {
-            jint *twoInts = env->GetIntArrayElements(packed, NULL);
-            if (0x80000000 & twoInts[0]) {
-                uint64_t val1 = twoInts[0] & 0x7FFFFFFF;
-                uint64_t val = (val1 << 32) | twoInts[1];
-                env->ReleaseIntArrayElements(packed, twoInts, 0);
+        SkSamplingOptions unpackFrom2Ints(JNIEnv* env, jint samplingModeVal1, jint samplingModeVal2) {
+            if (0x80000000 & samplingModeVal1) {
+                uint64_t val1 = samplingModeVal1 & 0x7FFFFFFF;
+                uint64_t val = (val1 << 32) | samplingModeVal2;
 
                 float* ptr = reinterpret_cast<float*>(&val);
                 return SkSamplingOptions(SkCubicResampler {ptr[1], ptr[0]});
             } else {
-                int32_t filter = twoInts[0];
-                int32_t mipmap = twoInts[1];
-                env->ReleaseIntArrayElements(packed, twoInts, 0);
-
+                int32_t filter = samplingModeVal1;
+                int32_t mipmap = samplingModeVal2;
                 return SkSamplingOptions(static_cast<SkFilterMode>(filter), static_cast<SkMipmapMode>(mipmap));
             }
         }

--- a/skiko/src/jvmMain/cpp/common/interop.hh
+++ b/skiko/src/jvmMain/cpp/common/interop.hh
@@ -299,7 +299,7 @@ namespace skija {
 
     namespace SamplingMode {
             SkSamplingOptions unpack(jlong val);
-            SkSamplingOptions unpackFrom2Ints(JNIEnv* env, jintArray val);
+            SkSamplingOptions unpackFrom2Ints(JNIEnv* env, jint val1, jint val2);
         }
 
     class UtfIndicesConverter {

--- a/skiko/src/nativeJsMain/cpp/Bitmap.cc
+++ b/skiko/src/nativeJsMain/cpp/Bitmap.cc
@@ -290,13 +290,13 @@ SKIKO_EXPORT KInteropPointer org_jetbrains_skia_Bitmap__1nPeekPixels
 }
 
 SKIKO_EXPORT KNativePointer org_jetbrains_skia_Bitmap__1nMakeShader
-  (KNativePointer ptr, KInt tmx, KInt tmy, KLong samplingMode, KFloat* localMatrixArr) {
+  (KNativePointer ptr, KInt tmx, KInt tmy, KInt samplingModeValue1, KInt samplingModeValue2, KFloat* localMatrixArr) {
     SkBitmap* instance = reinterpret_cast<SkBitmap*>(ptr);
     std::unique_ptr<SkMatrix> localMatrix = skMatrix(localMatrixArr);
     sk_sp<SkShader> shader = instance->makeShader(
         static_cast<SkTileMode>(tmx),
         static_cast<SkTileMode>(tmy),
-        skija::SamplingMode::unpack(samplingMode),
+        skija::SamplingMode::unpackFrom2Ints(samplingModeValue1, samplingModeValue2),
         localMatrix.get()
     );
     return reinterpret_cast<KNativePointer>(shader.release());

--- a/skiko/src/nativeJsMain/cpp/Canvas.cc
+++ b/skiko/src/nativeJsMain/cpp/Canvas.cc
@@ -96,14 +96,14 @@ SKIKO_EXPORT void org_jetbrains_skia_Canvas__1nDrawPath
 }
 
 SKIKO_EXPORT void org_jetbrains_skia_Canvas__1nDrawImageRect
-  (KNativePointer canvasPtr, KNativePointer imagePtr, KFloat sl, KFloat st, KFloat sr, KFloat sb, KFloat dl, KFloat dt, KFloat dr, KFloat db, KInt* samplingMode, KNativePointer paintPtr, KBoolean strict) {
+  (KNativePointer canvasPtr, KNativePointer imagePtr, KFloat sl, KFloat st, KFloat sr, KFloat sb, KFloat dl, KFloat dt, KFloat dr, KFloat db, KInt samplingModeVal1, KInt samplingModeVal2, KNativePointer paintPtr, KBoolean strict) {
     SkCanvas* canvas = reinterpret_cast<SkCanvas*>((canvasPtr));
     SkImage* image = reinterpret_cast<SkImage*>((imagePtr));
     SkRect src {sl, st, sr, sb};
     SkRect dst {dl, dt, dr, db};
     SkPaint* paint = reinterpret_cast<SkPaint*>((paintPtr));
     SkCanvas::SrcRectConstraint constraint = strict ? SkCanvas::SrcRectConstraint::kStrict_SrcRectConstraint : SkCanvas::SrcRectConstraint::kFast_SrcRectConstraint;
-    canvas->drawImageRect(image, src, dst, skija::SamplingMode::unpackFrom2Ints(samplingMode), paint, constraint);
+    canvas->drawImageRect(image, src, dst, skija::SamplingMode::unpackFrom2Ints(samplingModeVal1, samplingModeVal2), paint, constraint);
 }
 
 SKIKO_EXPORT void org_jetbrains_skia_Canvas__1nDrawImageNine

--- a/skiko/src/nativeJsMain/cpp/Image.cc
+++ b/skiko/src/nativeJsMain/cpp/Image.cc
@@ -72,13 +72,13 @@ SKIKO_EXPORT KNativePointer org_jetbrains_skia_Image__1nEncodeToData
 
 
 SKIKO_EXPORT KNativePointer org_jetbrains_skia_Image__1nMakeShader
-  (KNativePointer ptr, KInt tmx, KInt tmy, KInt* samplingMode, KFloat* localMatrixArr) {
+  (KNativePointer ptr, KInt tmx, KInt tmy, KInt samplingModeVal1, KInt samplingModeVal2, KFloat* localMatrixArr) {
     SkImage* instance = reinterpret_cast<SkImage*>(ptr);
     std::unique_ptr<SkMatrix> localMatrix = skMatrix(localMatrixArr);
     sk_sp<SkShader> shader = instance->makeShader(
         static_cast<SkTileMode>(tmx),
         static_cast<SkTileMode>(tmy),
-        skija::SamplingMode::unpackFrom2Ints(samplingMode),
+        skija::SamplingMode::unpackFrom2Ints(samplingModeVal1, samplingModeVal2),
         localMatrix.get()
     );
     return reinterpret_cast<KNativePointer>(shader.release());
@@ -121,9 +121,9 @@ SKIKO_EXPORT KBoolean org_jetbrains_skia_Image__1nReadPixelsPixmap
 }
 
 SKIKO_EXPORT KBoolean org_jetbrains_skia_Image__1nScalePixels
-  (KNativePointer ptr, KNativePointer pixmapPtr, KInt* samplingOptions, KBoolean cache) {
+  (KNativePointer ptr, KNativePointer pixmapPtr, KInt samplingOptionsVal1, KInt samplingOptionsVal2, KBoolean cache) {
     SkImage* instance = reinterpret_cast<SkImage*>((ptr));
     SkPixmap* pixmap = reinterpret_cast<SkPixmap*>((pixmapPtr));
     auto cachingHint = cache ? SkImage::CachingHint::kAllow_CachingHint : SkImage::CachingHint::kDisallow_CachingHint;
-    return instance->scalePixels(*pixmap, skija::SamplingMode::unpackFrom2Ints(samplingOptions), cachingHint);
+    return instance->scalePixels(*pixmap, skija::SamplingMode::unpackFrom2Ints(samplingOptionsVal1, samplingOptionsVal2), cachingHint);
 }

--- a/skiko/src/nativeJsMain/cpp/ImageFilter.cc
+++ b/skiko/src/nativeJsMain/cpp/ImageFilter.cc
@@ -163,9 +163,9 @@ SKIKO_EXPORT KNativePointer org_jetbrains_skia_ImageFilter__1nMakeDropShadowOnly
 
 
 SKIKO_EXPORT KNativePointer org_jetbrains_skia_ImageFilter__1nMakeImage
-  (KNativePointer imagePtr, KFloat l0, KFloat t0, KFloat r0, KFloat b0, KFloat l1, KFloat t1, KFloat r1, KFloat b1, KInt* samplingMode) {
+  (KNativePointer imagePtr, KFloat l0, KFloat t0, KFloat r0, KFloat b0, KFloat l1, KFloat t1, KFloat r1, KFloat b1, KInt samplingModeVal1, KInt samplingModeVal2) {
     SkImage* image = reinterpret_cast<SkImage*>((imagePtr));
-    SkImageFilter* ptr = SkImageFilters::Image(sk_ref_sp(image), SkRect{l0, t0, r0, b0}, SkRect{l1, t1, r1, b1}, skija::SamplingMode::unpackFrom2Ints(samplingMode)).release();
+    SkImageFilter* ptr = SkImageFilters::Image(sk_ref_sp(image), SkRect{l0, t0, r0, b0}, SkRect{l1, t1, r1, b1}, skija::SamplingMode::unpackFrom2Ints(samplingModeVal1, samplingModeVal2)).release();
     return reinterpret_cast<KNativePointer>(ptr);
 }
 
@@ -208,16 +208,16 @@ SKIKO_EXPORT KNativePointer org_jetbrains_skia_ImageFilter__1nMakeMatrixConvolut
 
 
 SKIKO_EXPORT KNativePointer org_jetbrains_skia_ImageFilter__1nMakeMatrixTransform
-  (KFloat* matrixArray, KNativePointer samplingMode, KNativePointer inputPtr) {
+  (KFloat* matrixArray, KInt samplingModeVal1, KInt samplingModeVal2, KNativePointer inputPtr) {
     TODO("implement org_jetbrains_skia_ImageFilter__1nMakeMatrixTransform");
 }
 
 #if 0
 SKIKO_EXPORT KNativePointer org_jetbrains_skia_ImageFilter__1nMakeMatrixTransform
-  (KFloat* matrixArray, KNativePointer samplingMode, KNativePointer inputPtr) {
+  (KFloat* matrixArray, KInt samplingModeVal1, KInt samplingModeVal2, KNativePointer inputPtr) {
     std::unique_ptr<SkMatrix> matrix = skMatrix(env, matrixArray);
     SkImageFilter* input = reinterpret_cast<SkImageFilter*>((inputPtr));
-    SkImageFilter* ptr = SkImageFilters::MatrixTransform(*matrix, skija::SamplingMode::unpack(samplingMode), sk_ref_sp(input)).release();
+    SkImageFilter* ptr = SkImageFilters::MatrixTransform(*matrix, skija::SamplingMode::unpackFrom2Ints(samplingModeVal1, samplingModeVal2), sk_ref_sp(input)).release();
     return reinterpret_cast<KNativePointer>(ptr);
 }
 #endif

--- a/skiko/src/nativeJsMain/cpp/Pixmap.cc
+++ b/skiko/src/nativeJsMain/cpp/Pixmap.cc
@@ -159,10 +159,10 @@ SKIKO_EXPORT KBoolean org_jetbrains_skia_Pixmap__1nReadPixelsToPixmapFromPoint
 }
 
 SKIKO_EXPORT KBoolean org_jetbrains_skia_Pixmap__1nScalePixels
-  (KNativePointer ptr, KNativePointer dstPixmapPtr, KInt* samplingOptions) {
+  (KNativePointer ptr, KNativePointer dstPixmapPtr, KInt samplingOptionsVal1, KInt samplingOptionsVal2) {
     SkPixmap* pixmap = interopToPtr<SkPixmap*>(ptr);
     SkPixmap* dstPixmap = interopToPtr<SkPixmap*>(dstPixmapPtr);
-    return static_cast<KBoolean>(pixmap->scalePixels(*dstPixmap, skija::SamplingMode::unpackFrom2Ints(samplingOptions)));
+    return static_cast<KBoolean>(pixmap->scalePixels(*dstPixmap, skija::SamplingMode::unpackFrom2Ints(samplingOptionsVal1, samplingOptionsVal2)));
 }
 
 SKIKO_EXPORT KBoolean org_jetbrains_skia_Pixmap__1nErase

--- a/skiko/src/nativeJsMain/cpp/common.h
+++ b/skiko/src/nativeJsMain/cpp/common.h
@@ -31,7 +31,7 @@ KLong packISize(SkISize p);
 namespace skija {
     namespace SamplingMode {
         SkSamplingOptions unpack(KLong val);
-        SkSamplingOptions unpackFrom2Ints(KInt* val);
+        SkSamplingOptions unpackFrom2Ints(KInt val1, KInt val2);
     }
 
     class UtfIndicesConverter {

--- a/skiko/src/nativeJsMain/cpp/common_interop.cc
+++ b/skiko/src/nativeJsMain/cpp/common_interop.cc
@@ -30,16 +30,16 @@ namespace skija {
             }
         }
 
-        SkSamplingOptions unpackFrom2Ints(KInt* twoInts) {
-            if (0x80000000 & twoInts[0]) {
-                uint64_t val1 = twoInts[0] & 0x7FFFFFFF;
-                uint64_t val = (val1 << 32) | twoInts[1];
+        SkSamplingOptions unpackFrom2Ints(KInt samplingModeVal1, KInt samplingModeVal2) {
+            if (0x80000000 & samplingModeVal1) {
+                uint64_t val1 = samplingModeVal1 & 0x7FFFFFFF;
+                uint64_t val = (val1 << 32) | samplingModeVal2;
 
                 float* ptr = reinterpret_cast<float*>(&val);
                 return SkSamplingOptions(SkCubicResampler {ptr[1], ptr[0]});
             } else {
-                int32_t filter = twoInts[0];
-                int32_t mipmap = twoInts[1];
+                int32_t filter = samplingModeVal1;
+                int32_t mipmap = samplingModeVal2;
 
                 return SkSamplingOptions(static_cast<SkFilterMode>(filter), static_cast<SkMipmapMode>(mipmap));
             }


### PR DESCRIPTION
Use IntArray instead of Long to pass SamplingMode through interop border.

Reason: Long in kotlin/js is an object. 