### PR TITLE
add `toInterop()` for arrays of InteropPointer

### DIFF
--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/impl/Native.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/impl/Native.kt
@@ -41,7 +41,7 @@ expect class InteropScope() {
     fun toInterop(stringArray: Array<String>?): InteropPointer
     fun InteropPointer.fromInteropNativePointerArray(): NativePointerArray
     inline fun <reified T> InteropPointer.fromInterop(decoder: ArrayInteropDecoder<T>): Array<T>
-    fun toInterop(interopPointers: Array<InteropPointer>): InteropPointer
+    fun toInteropForArraysOfPointers(interopPointers: Array<InteropPointer>): InteropPointer
     fun release()
 }
 

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/impl/Native.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/impl/Native.kt
@@ -41,6 +41,7 @@ expect class InteropScope() {
     fun toInterop(stringArray: Array<String>?): InteropPointer
     fun InteropPointer.fromInteropNativePointerArray(): NativePointerArray
     inline fun <reified T> InteropPointer.fromInterop(decoder: ArrayInteropDecoder<T>): Array<T>
+    fun toInterop(interopPointers: Array<InteropPointer>): InteropPointer
     fun release()
 }
 

--- a/skiko/src/commonTest/kotlin/org/jetbrains/skiko/tests/TestHelpers.kt
+++ b/skiko/src/commonTest/kotlin/org/jetbrains/skiko/tests/TestHelpers.kt
@@ -37,6 +37,19 @@ class TestHelpers {
         }
     }
 
+    fun writeArrayOfIntArrays(array: Array<IntArray>): NativePointer {
+        require(array.size == 3) {
+            "For testing purposes, the length of the array should be 3"
+        }
+        return interopScope {
+            _nWriteArraysOfInts(
+                toInteropForArraysOfPointers(
+                    array.map { toInterop(it) }.toTypedArray()
+                )
+            )
+        }
+    }
+
     init {
         Library.staticLoad()
     }
@@ -56,6 +69,9 @@ private external fun _nFillIntArrayOf5(interopPointer: InteropPointer)
 
 @ExternalSymbolName("org_jetbrains_skiko_tests_TestHelpers__1nFillDoubleArrayOf5")
 private external fun _nFillDoubleArrayOf5(interopPointer: InteropPointer)
+
+@ExternalSymbolName("org_jetbrains_skiko_tests_TestHelpers__1nWriteArraysOfInts")
+private external fun _nWriteArraysOfInts(interopPointer: InteropPointer): NativePointer
 
 @ExternalSymbolName("org_jetbrains_skiko_tests_TestHelpers__nStringByIndex")
 private external fun _nStringByIndex(index: Int): NativePointer

--- a/skiko/src/jsMain/kotlin/org/jetbrains/skia/impl/Native.js.kt
+++ b/skiko/src/jsMain/kotlin/org/jetbrains/skia/impl/Native.js.kt
@@ -190,7 +190,7 @@ actual class InteropScope actual constructor() {
         return result
     }
 
-    actual fun toInterop(interopPointers: Array<InteropPointer>): InteropPointer {
+    actual fun toInteropForArraysOfPointers(interopPointers: Array<InteropPointer>): InteropPointer {
         return toInterop(interopPointers.toIntArray())
     }
 

--- a/skiko/src/jsMain/kotlin/org/jetbrains/skia/impl/Native.js.kt
+++ b/skiko/src/jsMain/kotlin/org/jetbrains/skia/impl/Native.js.kt
@@ -190,6 +190,10 @@ actual class InteropScope actual constructor() {
         return result
     }
 
+    actual fun toInterop(interopPointers: Array<InteropPointer>): InteropPointer {
+        return toInterop(interopPointers.toIntArray())
+    }
+
     actual fun release()  {
         elements.forEach {
             _free(it)

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skia/impl/Native.jvm.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skia/impl/Native.jvm.kt
@@ -77,6 +77,7 @@ actual open class InteropScope actual constructor() {
         NativePointerArray((this as LongArray).size, this)
     actual inline fun <reified T> InteropPointer.fromInterop(decoder: ArrayInteropDecoder<T>): Array<T> =
         this@fromInterop as Array<T>
+    actual fun toInterop(interopPointers: Array<InteropPointer>): InteropPointer = interopPointers
     actual fun release() {}
 }
 

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skia/impl/Native.jvm.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skia/impl/Native.jvm.kt
@@ -77,7 +77,7 @@ actual open class InteropScope actual constructor() {
         NativePointerArray((this as LongArray).size, this)
     actual inline fun <reified T> InteropPointer.fromInterop(decoder: ArrayInteropDecoder<T>): Array<T> =
         this@fromInterop as Array<T>
-    actual fun toInterop(interopPointers: Array<InteropPointer>): InteropPointer = interopPointers
+    actual fun toInteropForArraysOfPointers(interopPointers: Array<InteropPointer>): InteropPointer = interopPointers
     actual fun release() {}
 }
 

--- a/skiko/src/jvmTest/cpp/TestHelpers.cc
+++ b/skiko/src/jvmTest/cpp/TestHelpers.cc
@@ -1,4 +1,5 @@
 #include <jni.h>
+#include <stdlib.h>
 
 #include "SkString.h"
 
@@ -71,3 +72,21 @@ extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_tests_TestHelpersKt_
     }
 }
 
+extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_tests_TestHelpersKt__1nWriteArraysOfInts
+(JNIEnv* env, jclass jclass, jobjectArray arrayOfIntArray) {
+    // hardcoded length is ok for testing purposes
+    jsize len = 3; //(*env)->GetArrayLength(env, arrayOfIntArray);
+
+    int *mem = reinterpret_cast<int*>(malloc(3 * 4 * 4)); // 3 arrays. each array consists of 4 ints
+
+    for (int i = 0; i < len; i++) {
+        jintArray array = (jintArray) env->GetObjectArrayElement(arrayOfIntArray, i);
+        jint *result_int = env->GetIntArrayElements(array, NULL);
+        for (int j = 0; j < 4; j++) {
+            mem[(i * 4) + j] = result_int[j];
+        }
+        env->ReleaseIntArrayElements(array, result_int, 0);
+    }
+
+    return reinterpret_cast<jlong>(mem);
+}

--- a/skiko/src/nativeJsTest/cpp/TestHelpers.cc
+++ b/skiko/src/nativeJsTest/cpp/TestHelpers.cc
@@ -54,3 +54,20 @@ SKIKO_EXPORT KNativePointer org_jetbrains_skiko_tests_TestHelpers__nStringByInde
         default: TODO("unknown");
     }
 }
+
+SKIKO_EXPORT KNativePointer org_jetbrains_skiko_tests_TestHelpers__1nWriteArraysOfInts(KNativePointer* arrayOfIntArray) {
+    // hardcoded length is ok for testing purposes
+    size_t len = 3; //(*env)->GetArrayLength(env, arrayOfIntArray);
+
+    int *mem = reinterpret_cast<int *>(malloc(3 * 4 * 4)); // 3 arrays. each array consists of 4 ints
+
+    for (int i = 0; i < len; i++) {
+        KNativePointer* array = reinterpret_cast<KNativePointer*>(arrayOfIntArray[i]);
+        int *ints = reinterpret_cast<int*>(array);
+        for (int j = 0; j < 4; j++) {
+            mem[(i * 4) + j] = ints[j];
+        }
+    }
+
+    return reinterpret_cast<KNativePointer>(mem);
+}

--- a/skiko/src/nativeMain/kotlin/org/jetbrains/skia/impl/Native.native.kt
+++ b/skiko/src/nativeMain/kotlin/org/jetbrains/skia/impl/Native.native.kt
@@ -190,6 +190,10 @@ actual class InteropScope actual constructor() {
         TODO("implement native fromInteropNativePointerArray")
     }
 
+    actual fun toInterop(interopPointers: Array<InteropPointer>): InteropPointer {
+        return toInterop(interopPointers.map { it.toLong() }.toLongArray())
+    }
+
     actual fun release()  {
         elements.forEach {
             it.unpin()

--- a/skiko/src/nativeMain/kotlin/org/jetbrains/skia/impl/Native.native.kt
+++ b/skiko/src/nativeMain/kotlin/org/jetbrains/skia/impl/Native.native.kt
@@ -190,7 +190,7 @@ actual class InteropScope actual constructor() {
         TODO("implement native fromInteropNativePointerArray")
     }
 
-    actual fun toInterop(interopPointers: Array<InteropPointer>): InteropPointer {
+    actual fun toInteropForArraysOfPointers(interopPointers: Array<InteropPointer>): InteropPointer {
         return toInterop(interopPointers.map { it.toLong() }.toLongArray())
     }
 


### PR DESCRIPTION
`fun toInteropForArraysOfPointers(interopPointers: Array<InteropPointer>): InteropPointer` 

This fun will be useful for example in `ShapingOptions.kt` to pass `Array<FontFeature>` to interop where FontFeature itself is going to be presented as IntArray.

