### PR TITLE
add Pattern and Matcher actual implementation for js and native

### DIFF
--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Expects.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Expects.kt
@@ -14,7 +14,9 @@ expect class Pattern {
 }
 
 expect class Matcher {
+    @Deprecated("Not supported in k/n. Consider using group(ix: Int)")
     fun group(name: String): String?
+    fun group(ix: Int): String?
     fun matches(): Boolean
 }
 

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Expects.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Expects.kt
@@ -9,13 +9,12 @@ expect fun defaultLanguageTag(): String
 expect abstract class OutputStream
 
 expect class Pattern {
-    fun split(input: CharSequence): Array<String?>?
+    fun split(input: CharSequence): Array<String>
     fun matcher(input: CharSequence): Matcher
 }
 
 expect class Matcher {
-    @Deprecated("Not supported in k/n. Consider using group(ix: Int)")
-    fun group(name: String): String?
+    // Named groups are not supported in k/n. That's why we can use only numeric groups
     fun group(ix: Int): String?
     fun matches(): Boolean
 }

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/FontFeature.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/FontFeature.kt
@@ -80,22 +80,26 @@ class FontFeature(val _tag: Int, val value: Int, val start: UInt, val end: UInt)
         val _featurePattern =
             compilePattern("([-+])?([a-z0-9]{4})(?:\\[(\\d+)?:(\\d+)?\\])?(?:=(\\d+))?")
 
-        private val groupsIx = mapOf(
-            "sign" to 1, "tag" to 2, "start" to 3, "end" to 4, "value" to 5
-        )
+        // We can't use named groups (not supported in k/n), so we use numeric groups.
+        // These constants are group indexes of _featurePattern:
+        private const val signIx = 1
+        private const val tagIx = 2
+        private const val startIx = 3
+        private const val endIx = 4
+        private const val valueIx = 5
 
         fun parseOne(s: String): FontFeature {
             val m = _featurePattern.matcher(s)
             require(m.matches()) { "Can’t parse FontFeature: $s" }
-            val value = if (m.group(groupsIx["value"]!!) != null) m.group(groupsIx["value"]!!)!!
-                .toInt() else if (m.group(groupsIx["sign"]!!) == null) 1 else if ("-" == m.group(groupsIx["sign"]!!)) 0 else 1
-            val start = if (m.group(groupsIx["start"]!!) == null) 0u else m.group(groupsIx["start"]!!)!!.toUInt()
-            val end = if (m.group(groupsIx["end"]!!) == null) UInt.MAX_VALUE else m.group(groupsIx["end"]!!)!!.toUInt()
-            return FontFeature(m.group(groupsIx["tag"]!!)!!, value, start, end)
+            val value = if (m.group(valueIx) != null) m.group(valueIx)!!
+                .toInt() else if (m.group(signIx) == null) 1 else if ("-" == m.group(signIx)) 0 else 1
+            val start = if (m.group(startIx) == null) 0u else m.group(startIx)!!.toUInt()
+            val end = if (m.group(endIx) == null) GLOBAL_END else m.group(endIx)!!.toUInt()
+            return FontFeature(m.group(tagIx)!!, value, start, end)
         }
 
         fun parse(str: String): Array<FontFeature?> {
-            return _splitPattern.split(str)?.map { s -> parseOne(s!!) }?.toTypedArray() ?: emptyArray()
+            return _splitPattern.split(str).map { s -> parseOne(s) }.toTypedArray()
         }
 
         internal fun InteropScope.toInterop(fontFeatures: Array<FontFeature>?): InteropPointer {

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/FontFeature.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/FontFeature.kt
@@ -78,16 +78,20 @@ class FontFeature(val _tag: Int, val value: Int, val start: UInt, val end: UInt)
         val EMPTY = arrayOfNulls<FontFeature>(0)
         val _splitPattern = compilePattern("\\s+")
         val _featurePattern =
-            compilePattern("(?<sign>[-+])?(?<tag>[a-z0-9]{4})(?:\\[(?<start>\\d+)?:(?<end>\\d+)?\\])?(?:=(?<value>\\d+))?")
+            compilePattern("([-+])?([a-z0-9]{4})(?:\\[(\\d+)?:(\\d+)?\\])?(?:=(\\d+))?")
+
+        private val groupsIx = mapOf(
+            "sign" to 1, "tag" to 2, "start" to 3, "end" to 4, "value" to 5
+        )
 
         fun parseOne(s: String): FontFeature {
             val m = _featurePattern.matcher(s)
             require(m.matches()) { "Can’t parse FontFeature: $s" }
-            val value = if (m.group("value") != null) m.group("value")!!
-                .toInt() else if (m.group("sign") == null) 1 else if ("-" == m.group("sign")) 0 else 1
-            val start = if (m.group("start") == null) 0u else m.group("start")!!.toUInt()
-            val end = if (m.group("end") == null) UInt.MAX_VALUE else m.group("end")!!.toUInt()
-            return FontFeature(m.group("tag")!!, value, start, end)
+            val value = if (m.group(groupsIx["value"]!!) != null) m.group(groupsIx["value"]!!)!!
+                .toInt() else if (m.group(groupsIx["sign"]!!) == null) 1 else if ("-" == m.group(groupsIx["sign"]!!)) 0 else 1
+            val start = if (m.group(groupsIx["start"]!!) == null) 0u else m.group(groupsIx["start"]!!)!!.toUInt()
+            val end = if (m.group(groupsIx["end"]!!) == null) UInt.MAX_VALUE else m.group(groupsIx["end"]!!)!!.toUInt()
+            return FontFeature(m.group(groupsIx["tag"]!!)!!, value, start, end)
         }
 
         fun parse(str: String): Array<FontFeature?> {

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/FontVariation.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/FontVariation.kt
@@ -33,19 +33,21 @@ class FontVariation(val _tag: Int, val value: Float) {
 
         internal val _variationPattern = compilePattern("([a-z0-9]{4})=(\\d+)")
 
-        private val groupsIx = mapOf("tag" to 1, "value" to 2)
+        // We can't use named groups (not supported in k/n), so we use numeric groups.
+        // These constants are group indexes of _variationPattern:
+        private const val tagIx = 1
+        private const val valueIx = 2
 
         fun parseOne(s: String): FontVariation {
             val m = _variationPattern.matcher(s)
             require(m.matches()) { "Can’t parse FontVariation: $s" }
-            val value = m.group(groupsIx["value"]!!)!!.toFloat()
-            val tag = m.group(groupsIx["tag"]!!)!!
+            val value = m.group(valueIx)!!.toFloat()
+            val tag = m.group(tagIx)!!
             return FontVariation(tag, value)
         }
 
         fun parse(str: String): Array<FontVariation> {
-            return _splitPattern.split(str)!!.map { s -> parseOne(s!!) }
-                .toTypedArray()
+            return _splitPattern.split(str).map { s -> parseOne(s) }.toTypedArray()
         }
     }
 }

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/FontVariation.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/FontVariation.kt
@@ -31,13 +31,16 @@ class FontVariation(val _tag: Int, val value: Float) {
 
         internal val _splitPattern = compilePattern("\\s+")
 
-        internal val _variationPattern = compilePattern("(?<tag>[a-z0-9]{4})=(?<value>\\d+)")
+        internal val _variationPattern = compilePattern("([a-z0-9]{4})=(\\d+)")
+
+        private val groupsIx = mapOf("tag" to 1, "value" to 2)
 
         fun parseOne(s: String): FontVariation {
             val m = _variationPattern.matcher(s)
             require(m.matches()) { "Can’t parse FontVariation: $s" }
-            val value = m.group("value")!!.toFloat()
-            return FontVariation(m.group("tag")!!, value)
+            val value = m.group(groupsIx["value"]!!)!!.toFloat()
+            val tag = m.group(groupsIx["tag"]!!)!!
+            return FontVariation(tag, value)
         }
 
         fun parse(str: String): Array<FontVariation> {

--- a/skiko/src/commonTest/kotlin/org/jetbrains/skia/PatternMatcherTests.kt
+++ b/skiko/src/commonTest/kotlin/org/jetbrains/skia/PatternMatcherTests.kt
@@ -1,0 +1,106 @@
+package org.jetbrains.skia
+
+import org.jetbrains.skiko.tests.runTest
+import kotlin.test.*
+
+class PatternMatcherTests {
+
+    @Test
+    fun canSplit() = runTest {
+        val _splitPattern = compilePattern("\\s+")
+
+        val result = _splitPattern.split("a b   cd 1   23 -7.0  4   5")!!
+
+        assertContentEquals(
+            expected = arrayOf("a", "b", "cd", "1", "23", "-7.0", "4", "5"),
+            actual = result
+        )
+    }
+
+    @Test
+    fun matchesTrue() = runTest {
+        val pattern = compilePattern("[0-9]{3}-[a-z]{3}")
+
+        val result = pattern.matcher("123-abc")
+        assertTrue(result.matches())
+    }
+
+    @Test
+    fun matchesFalse() = runTest {
+        val pattern = compilePattern("[0-9]{3}-[a-z]{3}")
+
+        val result = pattern.matcher("1c23-abc")
+        assertFalse(result.matches())
+    }
+
+    @Test
+    fun findGroup() = runTest {
+        val pattern = compilePattern("([-+])?([a-z0-9]{4})(?:\\[(\\d+)?:(\\d+)?\\])?(?:=(\\d+))?")
+
+        val matcher1 = pattern.matcher("+abcd[1234:567891234]=10101010101")
+        assertTrue(matcher1.matches())
+
+        assertEquals("+", matcher1.group(1))
+        assertEquals("abcd", matcher1.group(2))
+        assertEquals("1234", matcher1.group(3))
+        assertEquals("567891234", matcher1.group(4))
+        assertEquals("10101010101", matcher1.group(5))
+
+        val matcher2 = pattern.matcher("abcd[:567891234]=10101010101")
+        assertTrue(matcher2.matches())
+
+        assertEquals(null, matcher2.group(1))
+        assertEquals("abcd", matcher2.group(2))
+        assertEquals(null, matcher2.group(3))
+        assertEquals("567891234", matcher2.group(4))
+        assertEquals("10101010101", matcher2.group(5))
+    }
+
+    @Test
+    fun fontFeatureCanBeParsed() = runTest {
+        val f1 = FontFeature.parseOne("abcd[5:15]=42")
+        assertEquals("abcd", f1.tag)
+        assertEquals(5u, f1.start)
+        assertEquals(15u, f1.end)
+        assertEquals(42, f1.value)
+
+        val f2 = FontFeature.parseOne("abcd[:15]=42")
+        assertEquals("abcd", f2.tag)
+        assertEquals(FontFeature.GLOBAL_START, f2.start)
+        assertEquals(15u, f2.end)
+        assertEquals(42, f2.value)
+
+        val f3 = FontFeature.parseOne("abcd=42")
+        assertEquals("abcd", f3.tag)
+        assertEquals(FontFeature.GLOBAL_START, f3.start)
+        assertEquals(FontFeature.GLOBAL_END, f3.end)
+        assertEquals(42, f3.value)
+
+        val f4 = FontFeature.parseOne("abcd[:]=42")
+        assertEquals("abcd", f4.tag)
+        assertEquals(FontFeature.GLOBAL_START, f4.start)
+        assertEquals(FontFeature.GLOBAL_END, f4.end)
+        assertEquals(42, f4.value)
+    }
+
+    @Test
+    fun fontVariationCanBeParsed() = runTest {
+        val f1 = FontVariation.parseOne("abcd=111")
+
+        assertEquals("abcd", f1.tag)
+        assertEquals(111f, f1.value)
+
+        val f2 = FontVariation.parseOne("a1c2=0")
+
+        assertEquals("a1c2", f2.tag)
+        assertEquals(0f, f2.value)
+
+        assertFailsWith<IllegalArgumentException> {
+           FontVariation.parseOne("acdd=")
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            FontVariation.parseOne("=123")
+        }
+    }
+}

--- a/skiko/src/jsMain/kotlin/org/jetbrains/skia/Actuals.js.kt
+++ b/skiko/src/jsMain/kotlin/org/jetbrains/skia/Actuals.js.kt
@@ -8,18 +8,31 @@ actual fun <R> commonSynchronized(lock: Any, block: () -> R) {
 
 actual fun String.intCodePoints(): IntArray = TODO()
 
-actual class Pattern {
-    actual fun split(input: CharSequence): Array<String?>? = TODO()
-    actual fun matcher(input: CharSequence): Matcher = TODO()
+actual class Pattern constructor(regex: String) {
+    private val _regex = Regex(regex)
+
+    actual fun split(input: CharSequence): Array<String?>? = _regex.split(input).toTypedArray()
+    actual fun matcher(input: CharSequence): Matcher = Matcher(_regex, input)
 }
 
-actual class Matcher {
-    actual fun group(name: String): String? = TODO()
-    actual fun matches(): Boolean = TODO()
+actual class Matcher constructor(private val regex: Regex, private val input: CharSequence) {
+
+    private val matches: Boolean by lazy {
+        regex.matches(input)
+    }
+
+    private val groups: MatchGroupCollection? by lazy { regex.matchEntire(input)?.groups }
+    private val namedGroups: MatchNamedGroupCollection? by lazy {
+        regex.matchEntire(input)?.groups as? MatchNamedGroupCollection
+    }
+
+    actual fun group(name: String): String? = namedGroups?.get(name)?.value
+    actual fun group(ix: Int): String? = groups?.get(ix)?.value
+    actual fun matches(): Boolean = matches
 }
 
 actual fun defaultLanguageTag(): String = TODO()
 
-actual fun compilePattern(regex: String): Pattern = TODO()
+actual fun compilePattern(regex: String): Pattern = Pattern(regex)
 
 actual typealias ExternalSymbolName = kotlin.js.JsName

--- a/skiko/src/jsMain/kotlin/org/jetbrains/skia/Actuals.js.kt
+++ b/skiko/src/jsMain/kotlin/org/jetbrains/skia/Actuals.js.kt
@@ -11,7 +11,7 @@ actual fun String.intCodePoints(): IntArray = TODO()
 actual class Pattern constructor(regex: String) {
     private val _regex = Regex(regex)
 
-    actual fun split(input: CharSequence): Array<String?>? = _regex.split(input).toTypedArray()
+    actual fun split(input: CharSequence): Array<String> = _regex.split(input).toTypedArray()
     actual fun matcher(input: CharSequence): Matcher = Matcher(_regex, input)
 }
 
@@ -22,11 +22,7 @@ actual class Matcher constructor(private val regex: Regex, private val input: Ch
     }
 
     private val groups: MatchGroupCollection? by lazy { regex.matchEntire(input)?.groups }
-    private val namedGroups: MatchNamedGroupCollection? by lazy {
-        regex.matchEntire(input)?.groups as? MatchNamedGroupCollection
-    }
 
-    actual fun group(name: String): String? = namedGroups?.get(name)?.value
     actual fun group(ix: Int): String? = groups?.get(ix)?.value
     actual fun matches(): Boolean = matches
 }

--- a/skiko/src/nativeMain/kotlin/org/jetbrains/skia/Actuals.native.kt
+++ b/skiko/src/nativeMain/kotlin/org/jetbrains/skia/Actuals.native.kt
@@ -11,7 +11,7 @@ actual fun String.intCodePoints(): IntArray = TODO()
 actual class Pattern constructor(regex: String) {
     private val _regex = Regex(regex)
 
-    actual fun split(input: CharSequence): Array<String?>? = _regex.split(input).toTypedArray()
+    actual fun split(input: CharSequence): Array<String> = _regex.split(input).toTypedArray()
     actual fun matcher(input: CharSequence): Matcher = Matcher(_regex, input)
 }
 
@@ -23,7 +23,6 @@ actual class Matcher constructor(private val regex: Regex, private val input: Ch
 
     private val groups: MatchGroupCollection? by lazy { regex.matchEntire(input)?.groups }
 
-    actual fun group(name: String): String? = error("named groups are not supported in k/n")
     actual fun group(ix: Int): String? = groups?.get(ix)?.value
     actual fun matches(): Boolean = matches
 }

--- a/skiko/src/nativeMain/kotlin/org/jetbrains/skia/Actuals.native.kt
+++ b/skiko/src/nativeMain/kotlin/org/jetbrains/skia/Actuals.native.kt
@@ -8,18 +8,28 @@ actual fun <R> commonSynchronized(lock: Any, block: () -> R) {
 
 actual fun String.intCodePoints(): IntArray = TODO()
 
-actual class Pattern {
-    actual fun split(input: CharSequence): Array<String?>? = TODO()
-    actual fun matcher(input: CharSequence): Matcher = TODO()
+actual class Pattern constructor(regex: String) {
+    private val _regex = Regex(regex)
+
+    actual fun split(input: CharSequence): Array<String?>? = _regex.split(input).toTypedArray()
+    actual fun matcher(input: CharSequence): Matcher = Matcher(_regex, input)
 }
 
-actual class Matcher {
-    actual fun group(name: String): String? = TODO()
-    actual fun matches(): Boolean = TODO()
+actual class Matcher constructor(private val regex: Regex, private val input: CharSequence) {
+
+    private val matches: Boolean by lazy {
+        regex.matches(input)
+    }
+
+    private val groups: MatchGroupCollection? by lazy { regex.matchEntire(input)?.groups }
+
+    actual fun group(name: String): String? = error("named groups are not supported in k/n")
+    actual fun group(ix: Int): String? = groups?.get(ix)?.value
+    actual fun matches(): Boolean = matches
 }
 
 actual fun defaultLanguageTag(): String = TODO()
 
-actual fun compilePattern(regex: String): Pattern = TODO()
+actual fun compilePattern(regex: String): Pattern = Pattern(regex)
 
 actual typealias ExternalSymbolName = kotlin.native.SymbolName


### PR DESCRIPTION
Update FontFeature.kt and FontVariation.kt parse functions to use regex numeric groups instead of named groups because [k/n doesn't support named groups](https://youtrack.jetbrains.com/issue/KT-41890)