### PR TITLE
use ManagedString._nMake from toInterop(String)

### DIFF
--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/ManagedString.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/ManagedString.kt
@@ -10,7 +10,9 @@ class ManagedString internal constructor(ptr: NativePointer, managed: Boolean = 
         }
     }
 
-    constructor(s: String?) : this(_nMake(s)) {
+    constructor(s: String?) : this(
+        interopScope {  _nMake(toInterop(s)) }
+    ) {
         Stats.onNativeCall()
     }
 
@@ -28,13 +30,17 @@ class ManagedString internal constructor(ptr: NativePointer, managed: Boolean = 
 
     fun insert(offset: Int, s: String): ManagedString {
         Stats.onNativeCall()
-        _nInsert(_ptr, offset, s)
+        interopScope {
+            _nInsert(_ptr, offset, toInterop(s))
+        }
         return this
     }
 
     fun append(s: String): ManagedString {
         Stats.onNativeCall()
-        _nAppend(_ptr, s)
+        interopScope {
+            _nAppend(_ptr, toInterop(s))
+        }
         return this
     }
 
@@ -59,7 +65,7 @@ class ManagedString internal constructor(ptr: NativePointer, managed: Boolean = 
 private external fun ManagedString_nGetFinalizer(): NativePointer
 
 @ExternalSymbolName("org_jetbrains_skia_ManagedString__1nMake")
-private external fun _nMake(s: String?): NativePointer
+private external fun _nMake(s: InteropPointer): NativePointer
 
 @ExternalSymbolName("org_jetbrains_skia_ManagedString__nStringSize")
 private external fun _nStringSize(ptr: NativePointer): Int
@@ -68,10 +74,10 @@ private external fun _nStringSize(ptr: NativePointer): Int
 private external fun _nStringData(ptr: NativePointer, result: InteropPointer, size: Int): String
 
 @ExternalSymbolName("org_jetbrains_skia_ManagedString__1nInsert")
-private external fun _nInsert(ptr: NativePointer, offset: Int, s: String?)
+private external fun _nInsert(ptr: NativePointer, offset: Int, s: InteropPointer)
 
 @ExternalSymbolName("org_jetbrains_skia_ManagedString__1nAppend")
-private external fun _nAppend(ptr: NativePointer, s: String?)
+private external fun _nAppend(ptr: NativePointer, s: InteropPointer)
 
 @ExternalSymbolName("org_jetbrains_skia_ManagedString__1nRemoveSuffix")
 private external fun _nRemoveSuffix(ptr: NativePointer, from: Int)

--- a/skiko/src/commonTest/kotlin/org/jetbrains/skia/ManagedStringTest.kt
+++ b/skiko/src/commonTest/kotlin/org/jetbrains/skia/ManagedStringTest.kt
@@ -6,6 +6,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class ManagedStringTest {
+
     @Test
     fun basicTest() {
         val s1 = withStringResult {
@@ -20,5 +21,38 @@ class ManagedStringTest {
             nativeStringByIndex(2)
         }
         assertEquals("你好", s3)
+    }
+
+    @Test
+    fun canCreateAndReadManagedString() {
+        val ms1 = ManagedString("Hello")
+        assertEquals("Hello", ms1.toString())
+
+        val ms2 = ManagedString("Привет!")
+        assertEquals("Привет!", ms2.toString())
+
+        val ms3 = ManagedString("你好!")
+        assertEquals("你好!", ms3.toString())
+    }
+
+    @Test
+    fun canAppend() {
+        val ms = ManagedString("Hello").append(" World!")
+        assertEquals("Hello World!", ms.toString())
+    }
+
+    @Test
+    fun canInsert() {
+        val ms = ManagedString("World!").insert(0, "Hello ")
+        assertEquals("Hello World!", ms.toString())
+    }
+
+    @Test
+    fun canRemove() {
+        val ms = ManagedString("World!").remove(from = 2)
+        assertEquals("Wo", ms.toString())
+
+        val ms2 = ManagedString("World!").remove(from = 2, length = 2)
+        assertEquals("Wod!", ms2.toString())
     }
 }

--- a/skiko/src/commonTest/kotlin/org/jetbrains/skia/ManagedStringTest.kt
+++ b/skiko/src/commonTest/kotlin/org/jetbrains/skia/ManagedStringTest.kt
@@ -39,12 +39,24 @@ class ManagedStringTest {
     fun canAppend() {
         val ms = ManagedString("Hello").append(" World!")
         assertEquals("Hello World!", ms.toString())
+
+        val ms2 = ManagedString("Привет").append(" Мир!")
+        assertEquals("Привет Мир!", ms2.toString())
+
+        val ms3 = ManagedString("你好").append("，世界")
+        assertEquals("你好，世界", ms3.toString())
     }
 
     @Test
     fun canInsert() {
         val ms = ManagedString("World!").insert(0, "Hello ")
         assertEquals("Hello World!", ms.toString())
+
+        val ms2 = ManagedString("Мир!").insert(0, "Привет ")
+        assertEquals("Привет Мир!", ms2.toString())
+
+        val ms3 = ManagedString("世界").insert(0,"你好，")
+        assertEquals("你好，世界", ms3.toString())
     }
 
     @Test
@@ -54,5 +66,11 @@ class ManagedStringTest {
 
         val ms2 = ManagedString("World!").remove(from = 2, length = 2)
         assertEquals("Wod!", ms2.toString())
+
+        val ms3 = ManagedString("你好，世界!").remove(from = 2)
+        assertEquals("你好", ms3.toString())
+
+        val ms4 = ManagedString("你好，世界!").remove(from = 2, length = 3) // '，' is 1 symbol
+        assertEquals("你好!", ms4.toString())
     }
 }

--- a/skiko/src/nativeJsMain/cpp/ManagedString.cc
+++ b/skiko/src/nativeJsMain/cpp/ManagedString.cc
@@ -33,17 +33,10 @@ SKIKO_EXPORT void org_jetbrains_skia_ManagedString__nStringData
 
 SKIKO_EXPORT void org_jetbrains_skia_ManagedString__1nInsert
   (KNativePointer ptr, KInt offset, KInteropPointer s) {
-    TODO("implement org_jetbrains_skia_ManagedString__1nInsert");
-}
-     
-#if 0 
-SKIKO_EXPORT void org_jetbrains_skia_ManagedString__1nInsert
-  (KNativePointer ptr, KInt offset, KInteropPointer s) {
-    SkString* instance = reinterpret_cast<SkString*>((ptr));
+    SkString* instance = reinterpret_cast<SkString*>(ptr);
     skija::UtfIndicesConverter conv(*instance);
-    instance->insert(conv.from16To8(offset), skString(env, s));
+    instance->insert(conv.from16To8(offset), skString(s));
 }
-#endif
 
 SKIKO_EXPORT void org_jetbrains_skia_ManagedString__1nAppend
   (KNativePointer ptr, KInteropPointer s) {


### PR DESCRIPTION
the previous variant didn't crash, but the resulting SkString was invalid. 