### PR TITLE
withResult functions accept InteropScopeContext functions

### DIFF
--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/AnimationFrameInfo.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/AnimationFrameInfo.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.skia
 
-import org.jetbrains.skia.impl.InteropPointer
+import org.jetbrains.skia.impl.InteropScopeContext
 import org.jetbrains.skia.impl.withResult
 
 /**
@@ -86,15 +86,16 @@ class AnimationFrameInfo(
             )
         }
 
-        internal fun fromInteropPointer(block: (InteropPointer) -> Unit): AnimationFrameInfo {
+        internal fun fromInteropPointer(block: InteropScopeContext): AnimationFrameInfo {
             return fromIntArray(withResult(IntArray(REPR_SIZE), block))
         }
 
-        internal fun fromInteropArrayPointer(size: Int, block: (InteropPointer) -> Unit): Array<AnimationFrameInfo> {
+        internal fun fromInteropArrayPointer(size: Int, block: InteropScopeContext): Array<AnimationFrameInfo> {
             val repr = withResult(IntArray(REPR_SIZE * size), block)
             return Array(size) { fromIntArray(repr, it) }
         }
     }
+
     internal constructor(
         requiredFrame: Int,
         duration: Int,
@@ -114,6 +115,7 @@ class AnimationFrameInfo(
         BlendMode.values()[blendModeOrdinal],
         frameRect
     )
+
     override fun equals(other: Any?): Boolean {
         if (other === this) return true
         if (other !is AnimationFrameInfo) return false

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/AnimationFrameInfo.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/AnimationFrameInfo.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.skia
 
-import org.jetbrains.skia.impl.InteropScopeContext
+import org.jetbrains.skia.impl.InteropPointer
+import org.jetbrains.skia.impl.InteropScope
 import org.jetbrains.skia.impl.withResult
 
 /**
@@ -86,11 +87,11 @@ class AnimationFrameInfo(
             )
         }
 
-        internal fun fromInteropPointer(block: InteropScopeContext): AnimationFrameInfo {
+        internal fun fromInteropPointer(block: InteropScope.(InteropPointer) -> Unit): AnimationFrameInfo {
             return fromIntArray(withResult(IntArray(REPR_SIZE), block))
         }
 
-        internal fun fromInteropArrayPointer(size: Int, block: InteropScopeContext): Array<AnimationFrameInfo> {
+        internal fun fromInteropArrayPointer(size: Int, block: InteropScope.(InteropPointer) -> Unit): Array<AnimationFrameInfo> {
             val repr = withResult(IntArray(REPR_SIZE * size), block)
             return Array(size) { fromIntArray(repr, it) }
         }

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Matrix44.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Matrix44.kt
@@ -2,6 +2,7 @@ package org.jetbrains.skia
 
 import org.jetbrains.skia.impl.InteropPointer
 import org.jetbrains.skia.impl.InteropScope
+import org.jetbrains.skia.impl.InteropScopeContext
 import org.jetbrains.skia.impl.withResult
 
 /**
@@ -58,7 +59,7 @@ class Matrix44(vararg mat: Float) {
     companion object {
         val IDENTITY = Matrix44(1f, 0f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, 0f, 1f)
 
-        internal fun fromInteropPointer(block: InteropScope.(InteropPointer) -> Unit): Matrix44 {
+        internal fun fromInteropPointer(block: InteropScopeContext): Matrix44 {
             val result = withResult(FloatArray(16), block)
             return Matrix44(*result)
         }

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Matrix44.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Matrix44.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.skia
 
 import org.jetbrains.skia.impl.InteropPointer
+import org.jetbrains.skia.impl.InteropScope
 import org.jetbrains.skia.impl.withResult
 
 /**
@@ -57,7 +58,7 @@ class Matrix44(vararg mat: Float) {
     companion object {
         val IDENTITY = Matrix44(1f, 0f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, 0f, 1f)
 
-        internal fun fromInteropPointer(block: (InteropPointer) -> Unit): Matrix44 {
+        internal fun fromInteropPointer(block: InteropScope.(InteropPointer) -> Unit): Matrix44 {
             val result = withResult(FloatArray(16), block)
             return Matrix44(*result)
         }

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Matrix44.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Matrix44.kt
@@ -2,7 +2,6 @@ package org.jetbrains.skia
 
 import org.jetbrains.skia.impl.InteropPointer
 import org.jetbrains.skia.impl.InteropScope
-import org.jetbrains.skia.impl.InteropScopeContext
 import org.jetbrains.skia.impl.withResult
 
 /**
@@ -59,7 +58,7 @@ class Matrix44(vararg mat: Float) {
     companion object {
         val IDENTITY = Matrix44(1f, 0f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, 0f, 1f)
 
-        internal fun fromInteropPointer(block: InteropScopeContext): Matrix44 {
+        internal fun fromInteropPointer(block: InteropScope.(InteropPointer) -> Unit): Matrix44 {
             val result = withResult(FloatArray(16), block)
             return Matrix44(*result)
         }

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/PathSegmentIterator.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/PathSegmentIterator.kt
@@ -57,7 +57,7 @@ class PathSegmentIterator internal constructor(val _path: Path?, ptr: NativePoin
     }
 
     private fun nextSegment() = pathSegmentFromIntArray(withResult(IntArray(10)) {
-        PathSegmentIterator_nNext(this._ptr, it)
+        PathSegmentIterator_nNext(this@PathSegmentIterator._ptr, it)
     })
 }
 

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Point.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Point.kt
@@ -2,7 +2,6 @@ package org.jetbrains.skia
 
 import org.jetbrains.skia.impl.InteropPointer
 import org.jetbrains.skia.impl.InteropScope
-import org.jetbrains.skia.impl.InteropScopeContext
 import org.jetbrains.skia.impl.withResult
 
 class Point(val x: Float, val y: Float) {
@@ -65,7 +64,7 @@ class Point(val x: Float, val y: Float) {
             return arr
         }
 
-        internal fun fromInteropPointer(block: InteropScopeContext): Point {
+        internal fun fromInteropPointer(block: InteropScope.(InteropPointer) -> Unit): Point {
             val result = withResult(FloatArray(2), block)
             return Point(result[0], result[1])
         }

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Point.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Point.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.skia
 
 import org.jetbrains.skia.impl.InteropPointer
+import org.jetbrains.skia.impl.InteropScope
 import org.jetbrains.skia.impl.withResult
 
 class Point(val x: Float, val y: Float) {
@@ -63,7 +64,7 @@ class Point(val x: Float, val y: Float) {
             return arr
         }
 
-        internal fun fromInteropPointer(block: (InteropPointer) -> Unit): Point {
+        internal fun fromInteropPointer(block: InteropScope.(InteropPointer) -> Unit): Point {
             val result = withResult(FloatArray(2), block)
             return Point(result[0], result[1])
         }

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Point.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Point.kt
@@ -2,6 +2,7 @@ package org.jetbrains.skia
 
 import org.jetbrains.skia.impl.InteropPointer
 import org.jetbrains.skia.impl.InteropScope
+import org.jetbrains.skia.impl.InteropScopeContext
 import org.jetbrains.skia.impl.withResult
 
 class Point(val x: Float, val y: Float) {
@@ -64,7 +65,7 @@ class Point(val x: Float, val y: Float) {
             return arr
         }
 
-        internal fun fromInteropPointer(block: InteropScope.(InteropPointer) -> Unit): Point {
+        internal fun fromInteropPointer(block: InteropScopeContext): Point {
             val result = withResult(FloatArray(2), block)
             return Point(result[0], result[1])
         }

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/RRect.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/RRect.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.skia
 
 import org.jetbrains.skia.impl.InteropPointer
+import org.jetbrains.skia.impl.InteropScope
 import org.jetbrains.skia.impl.withResult
 import kotlin.jvm.JvmStatic
 import kotlin.math.abs
@@ -153,7 +154,7 @@ class RRect internal constructor(l: Float, t: Float, r: Float, b: Float, val rad
             return RRect(l, t, l + w, t + h, floatArrayOf(minOf(w, h) / 2.0f))
         }
 
-        internal fun fromInteropPointer(block: (InteropPointer) -> Unit): RRect {
+        internal fun fromInteropPointer(block: InteropScope.(InteropPointer) -> Unit): RRect {
             val result = withResult(FloatArray(12 /* 4 dimensions + 4 radii * 2 */), block)
             return RRect(result[0], result[1], result[2], result[3], result.copyOfRange(4, 12))
         }

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/RRect.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/RRect.kt
@@ -2,7 +2,6 @@ package org.jetbrains.skia
 
 import org.jetbrains.skia.impl.InteropPointer
 import org.jetbrains.skia.impl.InteropScope
-import org.jetbrains.skia.impl.InteropScopeContext
 import org.jetbrains.skia.impl.withResult
 import kotlin.jvm.JvmStatic
 import kotlin.math.abs
@@ -155,7 +154,7 @@ class RRect internal constructor(l: Float, t: Float, r: Float, b: Float, val rad
             return RRect(l, t, l + w, t + h, floatArrayOf(minOf(w, h) / 2.0f))
         }
 
-        internal fun fromInteropPointer(block: InteropScopeContext): RRect {
+        internal fun fromInteropPointer(block: InteropScope.(InteropPointer) -> Unit): RRect {
             val result = withResult(FloatArray(12 /* 4 dimensions + 4 radii * 2 */), block)
             return RRect(result[0], result[1], result[2], result[3], result.copyOfRange(4, 12))
         }

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/RRect.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/RRect.kt
@@ -2,6 +2,7 @@ package org.jetbrains.skia
 
 import org.jetbrains.skia.impl.InteropPointer
 import org.jetbrains.skia.impl.InteropScope
+import org.jetbrains.skia.impl.InteropScopeContext
 import org.jetbrains.skia.impl.withResult
 import kotlin.jvm.JvmStatic
 import kotlin.math.abs
@@ -154,7 +155,7 @@ class RRect internal constructor(l: Float, t: Float, r: Float, b: Float, val rad
             return RRect(l, t, l + w, t + h, floatArrayOf(minOf(w, h) / 2.0f))
         }
 
-        internal fun fromInteropPointer(block: InteropScope.(InteropPointer) -> Unit): RRect {
+        internal fun fromInteropPointer(block: InteropScopeContext): RRect {
             val result = withResult(FloatArray(12 /* 4 dimensions + 4 radii * 2 */), block)
             return RRect(result[0], result[1], result[2], result[3], result.copyOfRange(4, 12))
         }

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Rect.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Rect.kt
@@ -2,6 +2,7 @@ package org.jetbrains.skia
 
 import org.jetbrains.skia.ExternalSymbolName
 import org.jetbrains.skia.impl.InteropPointer
+import org.jetbrains.skia.impl.InteropScope
 import org.jetbrains.skia.impl.withResult
 import kotlin.jvm.JvmStatic
 
@@ -106,7 +107,7 @@ open class Rect constructor(val left: Float, val top: Float, val right: Float, v
             return Rect(l, t, l + w, t + h)
         }
 
-        internal fun fromInteropPointer(block: (InteropPointer) -> Unit): Rect {
+        internal fun fromInteropPointer(block: InteropScope.(InteropPointer) -> Unit): Rect {
             val result = withResult(FloatArray(4), block)
             return Rect(result[0], result[1], result[2], result[3])
         }

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Rect.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Rect.kt
@@ -3,6 +3,7 @@ package org.jetbrains.skia
 import org.jetbrains.skia.ExternalSymbolName
 import org.jetbrains.skia.impl.InteropPointer
 import org.jetbrains.skia.impl.InteropScope
+import org.jetbrains.skia.impl.InteropScopeContext
 import org.jetbrains.skia.impl.withResult
 import kotlin.jvm.JvmStatic
 
@@ -107,7 +108,7 @@ open class Rect constructor(val left: Float, val top: Float, val right: Float, v
             return Rect(l, t, l + w, t + h)
         }
 
-        internal fun fromInteropPointer(block: InteropScope.(InteropPointer) -> Unit): Rect {
+        internal fun fromInteropPointer(block: InteropScopeContext): Rect {
             val result = withResult(FloatArray(4), block)
             return Rect(result[0], result[1], result[2], result[3])
         }

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Rect.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Rect.kt
@@ -1,9 +1,7 @@
 package org.jetbrains.skia
 
-import org.jetbrains.skia.ExternalSymbolName
 import org.jetbrains.skia.impl.InteropPointer
 import org.jetbrains.skia.impl.InteropScope
-import org.jetbrains.skia.impl.InteropScopeContext
 import org.jetbrains.skia.impl.withResult
 import kotlin.jvm.JvmStatic
 
@@ -108,7 +106,7 @@ open class Rect constructor(val left: Float, val top: Float, val right: Float, v
             return Rect(l, t, l + w, t + h)
         }
 
-        internal fun fromInteropPointer(block: InteropScopeContext): Rect {
+        internal fun fromInteropPointer(block: InteropScope.(InteropPointer) -> Unit): Rect {
             val result = withResult(FloatArray(4), block)
             return Rect(result[0], result[1], result[2], result[3])
         }

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/impl/Native.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/impl/Native.kt
@@ -47,14 +47,14 @@ expect class InteropScope() {
 
 expect inline fun <T> interopScope(block: InteropScope.() -> T): T
 
-inline fun withResult(result: ByteArray, block: (InteropPointer) -> Unit): ByteArray = interopScope {
+inline fun withResult(result: ByteArray, block: InteropScope.(InteropPointer) -> Unit): ByteArray = interopScope {
     val handle = toInterop(result)
     block(handle)
     handle.fromInterop(result)
     result
 }
 
-inline fun withNullableResult(result: ByteArray, block: (InteropPointer) -> Boolean): ByteArray? = interopScope {
+inline fun withNullableResult(result: ByteArray, block: InteropScope.(InteropPointer) -> Boolean): ByteArray? = interopScope {
     val handle = toInterop(result)
     return if (block(handle)) {
         handle.fromInterop(result)
@@ -64,21 +64,21 @@ inline fun withNullableResult(result: ByteArray, block: (InteropPointer) -> Bool
     }
 }
 
-inline fun withResult(result: FloatArray, block: (InteropPointer) -> Unit): FloatArray = interopScope {
+inline fun withResult(result: FloatArray, block: InteropScope.(InteropPointer) -> Unit): FloatArray = interopScope {
     val handle = toInterop(result)
     block(handle)
     handle.fromInterop(result)
     result
 }
 
-inline fun withResult(result: IntArray, block: (InteropPointer) -> Unit): IntArray = interopScope {
+inline fun withResult(result: IntArray, block: InteropScope.(InteropPointer) -> Unit): IntArray = interopScope {
     val handle = toInterop(result)
     block(handle)
     handle.fromInterop(result)
     result
 }
 
-inline fun withNullableResult(result: IntArray, block: (InteropPointer) -> Boolean): IntArray? = interopScope {
+inline fun withNullableResult(result: IntArray, block: InteropScope.(InteropPointer) -> Boolean): IntArray? = interopScope {
     val handle = toInterop(result)
     return if (block(handle)) {
         handle.fromInterop(result)
@@ -88,21 +88,21 @@ inline fun withNullableResult(result: IntArray, block: (InteropPointer) -> Boole
     }
 }
 
-inline fun withResult(result: ShortArray, block: (InteropPointer) -> Unit): ShortArray = interopScope {
+inline fun withResult(result: ShortArray, block: InteropScope.(InteropPointer) -> Unit): ShortArray = interopScope {
     val handle = toInterop(result)
     block(handle)
     handle.fromInterop(result)
     result
 }
 
-inline fun withResult(result: DoubleArray, block: (InteropPointer) -> Unit): DoubleArray = interopScope {
+inline fun withResult(result: DoubleArray, block: InteropScope.(InteropPointer) -> Unit): DoubleArray = interopScope {
     val handle = toInterop(result)
     block(handle)
     handle.fromInterop(result)
     result
 }
 
-inline fun withResult(result: NativePointerArray, block: (InteropPointer) -> Unit): NativePointerArray = interopScope {
+inline fun withResult(result: NativePointerArray, block: InteropScope.(InteropPointer) -> Unit): NativePointerArray = interopScope {
     val handle = toInterop(result)
     block(handle)
     handle.fromInterop(result)

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/impl/Native.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/impl/Native.kt
@@ -45,9 +45,11 @@ expect class InteropScope() {
     fun release()
 }
 
+typealias InteropScopeContext = InteropScope.(InteropPointer) -> Unit
+
 expect inline fun <T> interopScope(block: InteropScope.() -> T): T
 
-inline fun withResult(result: ByteArray, block: InteropScope.(InteropPointer) -> Unit): ByteArray = interopScope {
+inline fun withResult(result: ByteArray, block: InteropScopeContext): ByteArray = interopScope {
     val handle = toInterop(result)
     block(handle)
     handle.fromInterop(result)
@@ -64,14 +66,14 @@ inline fun withNullableResult(result: ByteArray, block: InteropScope.(InteropPoi
     }
 }
 
-inline fun withResult(result: FloatArray, block: InteropScope.(InteropPointer) -> Unit): FloatArray = interopScope {
+inline fun withResult(result: FloatArray, block: InteropScopeContext): FloatArray = interopScope {
     val handle = toInterop(result)
     block(handle)
     handle.fromInterop(result)
     result
 }
 
-inline fun withResult(result: IntArray, block: InteropScope.(InteropPointer) -> Unit): IntArray = interopScope {
+inline fun withResult(result: IntArray, block: InteropScopeContext): IntArray = interopScope {
     val handle = toInterop(result)
     block(handle)
     handle.fromInterop(result)
@@ -88,21 +90,21 @@ inline fun withNullableResult(result: IntArray, block: InteropScope.(InteropPoin
     }
 }
 
-inline fun withResult(result: ShortArray, block: InteropScope.(InteropPointer) -> Unit): ShortArray = interopScope {
+inline fun withResult(result: ShortArray, block: InteropScopeContext): ShortArray = interopScope {
     val handle = toInterop(result)
     block(handle)
     handle.fromInterop(result)
     result
 }
 
-inline fun withResult(result: DoubleArray, block: InteropScope.(InteropPointer) -> Unit): DoubleArray = interopScope {
+inline fun withResult(result: DoubleArray, block: InteropScopeContext): DoubleArray = interopScope {
     val handle = toInterop(result)
     block(handle)
     handle.fromInterop(result)
     result
 }
 
-inline fun withResult(result: NativePointerArray, block: InteropScope.(InteropPointer) -> Unit): NativePointerArray = interopScope {
+inline fun withResult(result: NativePointerArray, block: InteropScopeContext): NativePointerArray = interopScope {
     val handle = toInterop(result)
     block(handle)
     handle.fromInterop(result)

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/impl/Native.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/impl/Native.kt
@@ -45,11 +45,9 @@ expect class InteropScope() {
     fun release()
 }
 
-typealias InteropScopeContext = InteropScope.(InteropPointer) -> Unit
-
 expect inline fun <T> interopScope(block: InteropScope.() -> T): T
 
-inline fun withResult(result: ByteArray, block: InteropScopeContext): ByteArray = interopScope {
+inline fun withResult(result: ByteArray, block: InteropScope.(InteropPointer) -> Unit): ByteArray = interopScope {
     val handle = toInterop(result)
     block(handle)
     handle.fromInterop(result)
@@ -66,14 +64,14 @@ inline fun withNullableResult(result: ByteArray, block: InteropScope.(InteropPoi
     }
 }
 
-inline fun withResult(result: FloatArray, block: InteropScopeContext): FloatArray = interopScope {
+inline fun withResult(result: FloatArray, block: InteropScope.(InteropPointer) -> Unit): FloatArray = interopScope {
     val handle = toInterop(result)
     block(handle)
     handle.fromInterop(result)
     result
 }
 
-inline fun withResult(result: IntArray, block: InteropScopeContext): IntArray = interopScope {
+inline fun withResult(result: IntArray, block: InteropScope.(InteropPointer) -> Unit): IntArray = interopScope {
     val handle = toInterop(result)
     block(handle)
     handle.fromInterop(result)
@@ -90,21 +88,21 @@ inline fun withNullableResult(result: IntArray, block: InteropScope.(InteropPoin
     }
 }
 
-inline fun withResult(result: ShortArray, block: InteropScopeContext): ShortArray = interopScope {
+inline fun withResult(result: ShortArray, block: InteropScope.(InteropPointer) -> Unit): ShortArray = interopScope {
     val handle = toInterop(result)
     block(handle)
     handle.fromInterop(result)
     result
 }
 
-inline fun withResult(result: DoubleArray, block: InteropScopeContext): DoubleArray = interopScope {
+inline fun withResult(result: DoubleArray, block: InteropScope.(InteropPointer) -> Unit): DoubleArray = interopScope {
     val handle = toInterop(result)
     block(handle)
     handle.fromInterop(result)
     result
 }
 
-inline fun withResult(result: NativePointerArray, block: InteropScopeContext): NativePointerArray = interopScope {
+inline fun withResult(result: NativePointerArray, block: InteropScope.(InteropPointer) -> Unit): NativePointerArray = interopScope {
     val handle = toInterop(result)
     block(handle)
     handle.fromInterop(result)

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/svg/SVGLength.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/svg/SVGLength.kt
@@ -2,12 +2,11 @@ package org.jetbrains.skia.svg
 
 import org.jetbrains.skia.impl.InteropPointer
 import org.jetbrains.skia.impl.InteropScope
-import org.jetbrains.skia.impl.InteropScopeContext
 import org.jetbrains.skia.impl.withResult
 
 class SVGLength(val value: Float, val unit: SVGLengthUnit) {
     companion object {
-        internal fun fromInterop(block: InteropScopeContext)
+        internal fun fromInterop(block: InteropScope.(InteropPointer) -> Unit)
             = withResult(IntArray(2), block).let {
                 SVGLength(Float.fromBits(it[0]), it[1])
             }

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/svg/SVGLength.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/svg/SVGLength.kt
@@ -1,11 +1,12 @@
 package org.jetbrains.skia.svg
 
 import org.jetbrains.skia.impl.InteropPointer
+import org.jetbrains.skia.impl.InteropScope
 import org.jetbrains.skia.impl.withResult
 
 class SVGLength(val value: Float, val unit: SVGLengthUnit) {
     companion object {
-        internal fun fromInterop(block: (InteropPointer) -> Unit)
+        internal fun fromInterop(block: InteropScope.(InteropPointer) -> Unit)
             = withResult(IntArray(2), block).let {
                 SVGLength(Float.fromBits(it[0]), it[1])
             }

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/svg/SVGLength.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/svg/SVGLength.kt
@@ -2,11 +2,12 @@ package org.jetbrains.skia.svg
 
 import org.jetbrains.skia.impl.InteropPointer
 import org.jetbrains.skia.impl.InteropScope
+import org.jetbrains.skia.impl.InteropScopeContext
 import org.jetbrains.skia.impl.withResult
 
 class SVGLength(val value: Float, val unit: SVGLengthUnit) {
     companion object {
-        internal fun fromInterop(block: InteropScope.(InteropPointer) -> Unit)
+        internal fun fromInterop(block: InteropScopeContext)
             = withResult(IntArray(2), block).let {
                 SVGLength(Float.fromBits(it[0]), it[1])
             }

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/svg/SVGPreserveAspectRatio.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/svg/SVGPreserveAspectRatio.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.skia.svg
 
 import org.jetbrains.skia.impl.InteropPointer
+import org.jetbrains.skia.impl.InteropScope
 import org.jetbrains.skia.impl.withResult
 
 class SVGPreserveAspectRatio(align: SVGPreserveAspectRatioAlign, scale: SVGPreserveAspectRatioScale) {
@@ -9,7 +10,7 @@ class SVGPreserveAspectRatio(align: SVGPreserveAspectRatioAlign, scale: SVGPrese
     internal val _scale: SVGPreserveAspectRatioScale
 
     companion object {
-        internal fun fromInterop(block: (InteropPointer) -> Unit) =
+        internal fun fromInterop(block: InteropScope.(InteropPointer) -> Unit) =
             withResult(IntArray(2), block).let {
                 SVGPreserveAspectRatio(it[0], it[1])
             }

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/svg/SVGPreserveAspectRatio.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/svg/SVGPreserveAspectRatio.kt
@@ -2,7 +2,6 @@ package org.jetbrains.skia.svg
 
 import org.jetbrains.skia.impl.InteropPointer
 import org.jetbrains.skia.impl.InteropScope
-import org.jetbrains.skia.impl.InteropScopeContext
 import org.jetbrains.skia.impl.withResult
 
 class SVGPreserveAspectRatio(align: SVGPreserveAspectRatioAlign, scale: SVGPreserveAspectRatioScale) {
@@ -11,7 +10,7 @@ class SVGPreserveAspectRatio(align: SVGPreserveAspectRatioAlign, scale: SVGPrese
     internal val _scale: SVGPreserveAspectRatioScale
 
     companion object {
-        internal fun fromInterop(block: InteropScopeContext) =
+        internal fun fromInterop(block: InteropScope.(InteropPointer) -> Unit) =
             withResult(IntArray(2), block).let {
                 SVGPreserveAspectRatio(it[0], it[1])
             }

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/svg/SVGPreserveAspectRatio.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/svg/SVGPreserveAspectRatio.kt
@@ -2,6 +2,7 @@ package org.jetbrains.skia.svg
 
 import org.jetbrains.skia.impl.InteropPointer
 import org.jetbrains.skia.impl.InteropScope
+import org.jetbrains.skia.impl.InteropScopeContext
 import org.jetbrains.skia.impl.withResult
 
 class SVGPreserveAspectRatio(align: SVGPreserveAspectRatioAlign, scale: SVGPreserveAspectRatioScale) {
@@ -10,7 +11,7 @@ class SVGPreserveAspectRatio(align: SVGPreserveAspectRatioAlign, scale: SVGPrese
     internal val _scale: SVGPreserveAspectRatioScale
 
     companion object {
-        internal fun fromInterop(block: InteropScope.(InteropPointer) -> Unit) =
+        internal fun fromInterop(block: InteropScopeContext) =
             withResult(IntArray(2), block).let {
                 SVGPreserveAspectRatio(it[0], it[1])
             }


### PR DESCRIPTION
Otherwise we have to write things like:

```
  withResult(ShortArray(uni.size)) {
     Typeface_nGetUTF32Glyphs(_ptr, interopScope { toInterop(uni) }, uni.size, it)
 }
```
Which can be error-prone and actualy misleading (because we shouldn't wrap separate params ito nteropScope - this works by accident.