### PR TITLE
Fix paragraph.getRectsForRange crash on Windows

### DIFF
--- a/skiko/src/commonTest/kotlin/org/jetbrains/skia/ParagraphTest.kt
+++ b/skiko/src/commonTest/kotlin/org/jetbrains/skia/ParagraphTest.kt
@@ -105,4 +105,17 @@ class ParagraphTest {
         )
     }
 
+    @Test
+    fun getRectsForRange() {
+        val fontCollection = FontCollection().setDefaultFontManager(FontMgr.default)
+
+        repeat(1000) { // the bug is flaky, and isn't always reproducible
+            val para = ParagraphBuilder(ParagraphStyle(), fontCollection).use {
+                it.addText("xxx\r\nxxx")
+                it.build()
+            }.layout(Float.POSITIVE_INFINITY)
+
+            para.getRectsForRange(2, 8, RectHeightMode.MAX, RectWidthMode.MAX)
+        }
+    }
 }

--- a/skiko/src/jvmMain/cpp/common/paragraph/Paragraph.cc
+++ b/skiko/src/jvmMain/cpp/common/paragraph/Paragraph.cc
@@ -86,6 +86,11 @@ extern "C" JNIEXPORT jobjectArray JNICALL Java_org_jetbrains_skia_paragraph_Para
     jobjectArray rectsArray = env->NewObjectArray((jsize) rects.size(), skija::paragraph::TextBox::cls, nullptr);
     for (int i = 0; i < rects.size(); ++i) {
         TextBox box = rects[i];
+        // TODO fix https://github.com/JetBrains/compose-jb/issues/1308 another way, we just masking the issue
+        // (but experiments show, that the result of GetRectsForRange is correct after that)
+        if (isnan(box.rect.fLeft) || isnan(box.rect.fTop) || isnan(box.rect.fRight) || isnan(box.rect.fBottom)) {
+            continue;
+        }
         jobject boxObj = env->NewObject(skija::paragraph::TextBox::cls, skija::paragraph::TextBox::ctor, box.rect.fLeft, box.rect.fTop, box.rect.fRight, box.rect.fBottom, static_cast<jint>(box.direction));
         env->SetObjectArrayElement(rectsArray, i, boxObj);
         env->DeleteLocalRef(boxObj);

--- a/skiko/src/nativeJsMain/cpp/paragraph/Paragraph.cc
+++ b/skiko/src/nativeJsMain/cpp/paragraph/Paragraph.cc
@@ -81,7 +81,16 @@ SKIKO_EXPORT void org_jetbrains_skia_paragraph_Paragraph__1nPaint
 SKIKO_EXPORT KInteropPointerArray org_jetbrains_skia_paragraph_Paragraph__1nGetRectsForRange
   (KNativePointer ptr, KInt start, KInt end, KInt rectHeightStyle, KInt rectWidthStyle) {
     Paragraph* instance = reinterpret_cast<Paragraph*>((ptr));
-    std::vector<TextBox> *rects = new std::vector<TextBox>(instance->getRectsForRange(start, end, static_cast<RectHeightStyle>(rectHeightStyle), static_cast<RectWidthStyle>(rectWidthStyle)));
+    std::vector<TextBox> originalRects = instance->getRectsForRange(start, end, static_cast<RectHeightStyle>(rectHeightStyle), static_cast<RectWidthStyle>(rectWidthStyle));
+    std::vector<TextBox> *rects = new std::vector<TextBox>();
+    for (TextBox& box : originalRects) {
+        // TODO fix https://github.com/JetBrains/compose-jb/issues/1308 another way, we just masking the issue
+        // (but experiments show, that the result of GetRectsForRange is correct after that)
+        if (isnan(box.rect.fLeft) || isnan(box.rect.fTop) || isnan(box.rect.fRight) || isnan(box.rect.fBottom)) {
+            continue;
+        }
+        rects->push_back(box);
+    }
     return rects;
 }
 


### PR DESCRIPTION
Fixes https://github.com/JetBrains/compose-jb/issues/1308