### PR TITLE
Fix getRectsForRange (attempt 2)

### DIFF
--- a/skiko/src/commonTest/kotlin/org/jetbrains/skia/ParagraphTest.kt
+++ b/skiko/src/commonTest/kotlin/org/jetbrains/skia/ParagraphTest.kt
@@ -115,7 +115,13 @@ class ParagraphTest {
                 it.build()
             }.layout(Float.POSITIVE_INFINITY)
 
-            para.getRectsForRange(2, 8, RectHeightMode.MAX, RectWidthMode.MAX)
+            val rects = para.getRectsForRange(2, 8, RectHeightMode.MAX, RectWidthMode.MAX)
+            for (rect in rects) {
+                rect.rect.left
+                rect.rect.right
+                rect.rect.top
+                rect.rect.bottom
+            }
         }
     }
 }


### PR DESCRIPTION
The previous fix was wrong, we don't fill all indices of the array

Fixes https://github.com/JetBrains/compose-jb/issues/1308#issuecomment-981139635