### PR TITLE
Revert customizing native artifacts coordinates

### DIFF
--- a/skiko/build.gradle.kts
+++ b/skiko/build.gradle.kts
@@ -364,13 +364,6 @@ kotlin {
 }
 
 fun configureNativeTarget(os: OS, arch: Arch, target: KotlinNativeTarget) {
-    publishing.publications.configureEach {
-        this as MavenPublication
-        if (name == target.name) {
-            artifactId = SkikoArtifacts.nativeArtifactIdFor(os, arch)
-        }
-    }
-
     if (!os.isCompatibleWithHost) return
 
     val targetString = "${os.id}-${arch.id}"

--- a/skiko/buildSrc/src/main/kotlin/properties.kt
+++ b/skiko/buildSrc/src/main/kotlin/properties.kt
@@ -195,6 +195,11 @@ object SkikoArtifacts {
     val jsWasmArtifactId = "skiko-js-wasm-runtime"
     fun jvmRuntimeArtifactIdFor(os: OS, arch: Arch) =
         "skiko-jvm-runtime-${targetId(os, arch)}"
+
+    // Using custom name like skiko-<Os>-<Arch> (with a dash)
+    // does not seem possible (at least without adding a dash to a target's tasks),
+    // so we're using the default naming pattern instead.
+    // See https://youtrack.jetbrains.com/issue/KT-50001.
     fun nativeArtifactIdFor(os: OS, arch: Arch) =
-        "skiko-${targetId(os, arch)}"
+        "skiko-${os.id}${arch.id}"
 }


### PR DESCRIPTION
Customizing native publication's names does not work,
when a target cannot be compiled on a host.
A customization might lead to the inconsistent behavior,
when a kotlin multiplatform publication contains
different artifacts names, depending on a host system.
E.g. customization breaks macOS artifacts links,
if a kotlin multiplatform publication is built on Linux.
https://youtrack.jetbrains.com/issue/KT-50001