### PR TITLE
Improve tooling support for `jvmMain` source set

### DIFF
--- a/skiko/build.gradle.kts
+++ b/skiko/build.gradle.kts
@@ -253,7 +253,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(kotlin("stdlib-common"))
+                implementation(kotlin("stdlib"))
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
             }
         }
@@ -272,8 +272,10 @@ kotlin {
         } */
 
         val jvmMain by creating {
+            dependsOn(commonMain)
             dependencies {
                 implementation(kotlin("stdlib"))
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:$coroutinesVersion")
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-swing:$coroutinesVersion")
             }
         }


### PR DESCRIPTION
- Replace 'commonMain' dependency on 'stdlib-common' to 'stdlib'
Depending on 'stdlib-common' explicitly will leak this common artifact into
platform source sets which is known to cause several tooling issues

- Let 'jvmMain' depend on 'commonMain'