### PR TITLE
js: resetMatrix on canvas before drawing a frame

### DIFF
--- a/skiko/src/jsMain/kotlin/org/jetbrains/skiko/CanvasRenderer.kt
+++ b/skiko/src/jsMain/kotlin/org/jetbrains/skiko/CanvasRenderer.kt
@@ -63,7 +63,9 @@ abstract class CanvasRenderer constructor(val htmlCanvas: HTMLCanvasElement) {
         window.requestAnimationFrame { timestamp ->
             redrawScheduled = false
             GL.makeContextCurrent(contextPointer)
+            // `clear` and `resetMatrix` make canvas not accumulate previous effects
             canvas?.clear(-1)
+            canvas?.resetMatrix()
             drawFrame(timestamp)
             surface?.flushAndSubmit()
             context.flush()


### PR DESCRIPTION
It makes canvas to not accumulate previous effects (e.g. scale).
Also, it makes canvas' state consistent with other platforms.