### PR TITLE
Fixed crash when [redrawImmediately] invoked while fallback process.

### DIFF
--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/LinuxOpenGLRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/LinuxOpenGLRedrawer.kt
@@ -71,13 +71,15 @@ internal class LinuxOpenGLRedrawer(
 
     override fun redrawImmediately() = layer.backedLayer.lockLinuxDrawingSurface {
         check(!isDisposed) { "LinuxOpenGLRedrawer is disposed" }
-        update(System.nanoTime())
-        it.makeCurrent(context)
-        draw()
-        it.setSwapInterval(0)
-        it.swapBuffers()
-        OpenGLApi.instance.glFinish()
-        it.setSwapInterval(swapInterval)
+        layer.inDrawScope {
+            update(System.nanoTime())
+            it.makeCurrent(context)
+            contextHandler.draw()
+            it.setSwapInterval(0)
+            it.swapBuffers()
+            OpenGLApi.instance.glFinish()
+            it.setSwapInterval(swapInterval)
+        }
     }
 
     private fun update(nanoTime: Long) {

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
@@ -55,10 +55,12 @@ internal class MetalRedrawer(
 
     override fun redrawImmediately() {
         check(!isDisposed) { "MetalRedrawer is disposed" }
-        setVSyncEnabled(device, enabled = false)
-        update(System.nanoTime())
-        layer.inDrawScope(::performDraw)
-        setVSyncEnabled(device, properties.isVsyncEnabled)
+        layer.inDrawScope {
+            setVSyncEnabled(device, enabled = false)
+            update(System.nanoTime())
+            performDraw()
+            setVSyncEnabled(device, properties.isVsyncEnabled)
+        }
     }
 
     private fun update(nanoTime: Long) {

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/WindowsOpenGLRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/WindowsOpenGLRedrawer.kt
@@ -51,11 +51,13 @@ internal class WindowsOpenGLRedrawer(
 
     override fun redrawImmediately() {
         check(!isDisposed) { "WindowsOpenGLRedrawer is disposed" }
-        update(System.nanoTime())
-        makeCurrent()
-        draw()
-        swapBuffers()
-        OpenGLApi.instance.glFinish()
+        layer.inDrawScope {
+            update(System.nanoTime())
+            makeCurrent()
+            contextHandler.draw()
+            swapBuffers()
+            OpenGLApi.instance.glFinish()
+        }
     }
 
     private fun update(nanoTime: Long) {

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/redrawer/Direct3DRedrawer.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/redrawer/Direct3DRedrawer.kt
@@ -46,8 +46,8 @@ internal class Direct3DRedrawer(
 
     override fun redrawImmediately() {
         check(!isDisposed) { "Direct3DRedrawer is disposed" }
-        layer.update(System.nanoTime())
         layer.inDrawScope {
+        layer.update(System.nanoTime())
             drawAndSwap(withVsync = false)
         }
     }


### PR DESCRIPTION
issue: https://github.com/JetBrains/compose-jb/issues/1267