### PR TITLE
Added feature to define particular gestures to be used in UIView.

### DIFF
--- a/samples/SkiaMultiplatformSample/src/iosMain/kotlin/org/jetbrains/skiko/sample/App.ios.kt
+++ b/samples/SkiaMultiplatformSample/src/iosMain/kotlin/org/jetbrains/skiko/sample/App.ios.kt
@@ -6,6 +6,7 @@ import org.jetbrains.skiko.GenericSkikoView
 import org.jetbrains.skiko.SkiaLayer
 import org.jetbrains.skiko.SkikoView
 import org.jetbrains.skiko.SkikoViewController
+import org.jetbrains.skiko.SkikoGestureEventKind
 import platform.UIKit.*
 import platform.Foundation.*
 
@@ -36,7 +37,7 @@ class SkikoAppDelegate : UIResponder, UIApplicationDelegateProtocol {
 
     override fun application(application: UIApplication, didFinishLaunchingWithOptions: Map<Any?, *>?): Boolean {
         window = UIWindow(frame = UIScreen.mainScreen.bounds)
-        window!!.rootViewController = SkikoViewController().apply {
+        window!!.rootViewController = SkikoViewController(SkikoGestureEventKind.values()).apply {
             setAppFactory { layer ->
                 GenericSkikoView(layer, makeApp(layer)).also {
                     layer.skikoView = it

--- a/skiko/src/iosMain/kotlin/org/jetbrains/skiko/SkiaLayer.ios.kt
+++ b/skiko/src/iosMain/kotlin/org/jetbrains/skiko/SkiaLayer.ios.kt
@@ -14,6 +14,12 @@ import platform.darwin.NSObject
 import kotlin.system.getTimeNanos
 
 actual open class SkiaLayer {
+    private val gestures: Array<SkikoGestureEventKind>?
+
+    constructor(gestures: Array<SkikoGestureEventKind>? = null) {
+        this.gestures = gestures
+    }
+
     fun isShowing(): Boolean {
         return true
     }
@@ -142,15 +148,29 @@ actual open class SkiaLayer {
                     )
                 )
             }
-
         }
-        // We have ':' in selector to take care of function argument.
-        view.addGestureRecognizer(UITapGestureRecognizer(controller, NSSelectorFromString("onTap:")))
-        view.addGestureRecognizer(UILongPressGestureRecognizer(controller, NSSelectorFromString("onLongPress:")))
-        view.addGestureRecognizer(UIPinchGestureRecognizer(controller, NSSelectorFromString("onPinch:")))
-        view.addGestureRecognizer(UIRotationGestureRecognizer(controller, NSSelectorFromString("onRotation:")))
-        view.addGestureRecognizer(UISwipeGestureRecognizer(controller, NSSelectorFromString("onSwipe:")))
-        view.addGestureRecognizer(UIPanGestureRecognizer(controller, NSSelectorFromString("onPan:")))
+
+        if (!gestures.isNullOrEmpty()) {
+            // We have ':' in selector to take care of function argument.
+            if (gestures.contains(SkikoGestureEventKind.TAP)) {
+                view.addGestureRecognizer(UITapGestureRecognizer(controller, NSSelectorFromString("onTap:")))
+            }
+            if (gestures.contains(SkikoGestureEventKind.LONGPRESS)) {
+                view.addGestureRecognizer(UILongPressGestureRecognizer(controller, NSSelectorFromString("onLongPress:")))
+            }
+            if (gestures.contains(SkikoGestureEventKind.PINCH)) {
+                view.addGestureRecognizer(UIPinchGestureRecognizer(controller, NSSelectorFromString("onPinch:")))
+            }
+            if (gestures.contains(SkikoGestureEventKind.ROTATION)) {
+                view.addGestureRecognizer(UIRotationGestureRecognizer(controller, NSSelectorFromString("onRotation:")))
+            }
+            if (gestures.contains(SkikoGestureEventKind.SWIPE)) {
+                view.addGestureRecognizer(UISwipeGestureRecognizer(controller, NSSelectorFromString("onSwipe:")))
+            }
+            if (gestures.contains(SkikoGestureEventKind.PAN)) {
+                view.addGestureRecognizer(UIPanGestureRecognizer(controller, NSSelectorFromString("onPan:")))
+            }
+        }
         // TODO: maybe add observer for view.viewDidDisappear() to detach us?
         redrawer = MetalRedrawer(this).apply {
             needRedraw()

--- a/skiko/src/iosMain/kotlin/org/jetbrains/skiko/SkikoViewController.kt
+++ b/skiko/src/iosMain/kotlin/org/jetbrains/skiko/SkikoViewController.kt
@@ -16,11 +16,17 @@ import platform.UIKit.UIPressesEvent
 
 @ExportObjCClass
 class SkikoViewController : UIViewController, UIKeyInputProtocol {
+    private var gestures: Array<SkikoGestureEventKind>? = null
+
     @OverrideInit
     constructor() : super(nibName = null, bundle = null)
 
     @OverrideInit
     constructor(coder: NSCoder) : super(coder)
+
+    constructor(gestures: Array<SkikoGestureEventKind>? = null) : this() {
+        this.gestures = gestures
+    }
 
     override fun canBecomeFirstResponder() = true
 
@@ -131,7 +137,7 @@ class SkikoViewController : UIViewController, UIKeyInputProtocol {
         val (width, height) = UIScreen.mainScreen.bounds.useContents {
             this.size.width to this.size.height
         }
-        skikoLayer = SkiaLayer().apply {
+        skikoLayer = SkiaLayer(gestures).apply {
             skikoView = appFactory(this)
         }
         view.contentScaleFactor = UIScreen.mainScreen.scale


### PR DESCRIPTION
Reason: adding gesture listeners prevents raw touch events from being used
Apple Doc https://developer.apple.com/documentation/uikit/uigesturerecognizer?language=objc:
```
If the gesture recognizer subsequently recognizes its gesture,
the touches are cancelled (in a touchesCancelled:withEvent: message).
```