### PR TITLE
Fix Windows build

### DIFF
--- a/skiko/buildSrc/src/main/kotlin/CompileSkikoCppTask.kt
+++ b/skiko/buildSrc/src/main/kotlin/CompileSkikoCppTask.kt
@@ -261,7 +261,7 @@ abstract class CompileSkikoCppTask() : AbstractSkikoNativeToolTask() {
     override fun configureArgs() =
         super.configureArgs().apply {
             arg("-c")
-            repeatedArg("-I", headersDirs.map { it.absolutePath.replace("\\", "/") })
+            repeatedArg("-I", headersDirs)
             // todo: ensure that flags do not start with '-I' (all headers should be added via [headersDirs])
             rawArgs(flags.get())
         }


### PR DESCRIPTION
```
> SVGCanvas.cc
    > C:/tools/x64/jdk11.0.12_7/include\jni.h(39): fatal error C1083: Cannot open include file: 'stdio.h': No such file or directory
```

This change was for Android. Android can't build on Windows for now, will fix it later.

We probably need to check targetOs and replace slash inside https://github.com/JetBrains/skiko/blob/eaf6793bc672dd4cf357b5a0adef26585fd9c712/skiko/buildSrc/src/main/kotlin/internal/utils/ArgBuilder.kt#L79, not here