### PR TITLE
Fixed `getCurrentSystemTheme` throwing UnsatisfiedLinkError

### DIFF
--- a/skiko/src/jvmMain/cpp/linux/drawlayer.cc
+++ b/skiko/src/jvmMain/cpp/linux/drawlayer.cc
@@ -88,7 +88,7 @@ extern "C"
         return (float) getDpiScaleByDisplay(dsi_x11->display);
     }
 
-    JNIEXPORT jint JNICALL Java_org_jetbrains_skiko_SystemTheme_1jvmKt_getCurrentSystemTheme(JNIEnv *env, jobject topLevel)
+    JNIEXPORT jint JNICALL Java_org_jetbrains_skiko_SystemTheme_1awtKt_getCurrentSystemTheme(JNIEnv *env, jobject topLevel)
     {
        // Unknown.
        return 2;

--- a/skiko/src/jvmMain/cpp/windows/drawlayer.cc
+++ b/skiko/src/jvmMain/cpp/windows/drawlayer.cc
@@ -28,7 +28,7 @@ extern "C"
         return (jlong) dsi_win->hwnd;
     }
 
-    JNIEXPORT jint JNICALL Java_org_jetbrains_skiko_SystemTheme_1jvmKt_getCurrentSystemTheme(JNIEnv *env, jobject topLevel)
+    JNIEXPORT jint JNICALL Java_org_jetbrains_skiko_SystemTheme_1awtKt_getCurrentSystemTheme(JNIEnv *env, jobject topLevel)
     {
         auto subkey = L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize";
         auto name = L"AppsUseLightTheme";

--- a/skiko/src/jvmMain/objectiveC/macos/Drawlayer.mm
+++ b/skiko/src/jvmMain/objectiveC/macos/Drawlayer.mm
@@ -385,7 +385,7 @@ JNIEXPORT void JNICALL Java_org_jetbrains_skiko_PlatformOperationsKt_osxDisableT
     }
 }
 
-JNIEXPORT jint JNICALL Java_org_jetbrains_skiko_SystemTheme_1jvmKt_getCurrentSystemTheme(JNIEnv *env, jobject topLevel)
+JNIEXPORT jint JNICALL Java_org_jetbrains_skiko_SystemTheme_1awtKt_getCurrentSystemTheme(JNIEnv *env, jobject topLevel)
 {
     @autoreleasepool {
         NSString *osxMode = [[NSUserDefaults standardUserDefaults] stringForKey:@"AppleInterfaceStyle"];


### PR DESCRIPTION
This is a pretty dumb fix for https://github.com/JetBrains/compose-jb/issues/1761.

The bug was caused by 242bf304 since `SystemTheme.jvm.kt` was renamed to `SystemTheme.awt.kt` and the corresponding native functions were not updated.