### PR TITLE
Fixed case when user get low refresh rate with VRR capable display.

### DIFF
--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt
@@ -90,16 +90,6 @@ actual open class SkiaLayer internal constructor(
         add(backedLayer)
         backedLayer.addHierarchyListener {
             if (it.changeFlags and HierarchyEvent.SHOWING_CHANGED.toLong() != 0L) {
-                if (
-                    vrrDisplayLocker == null
-                    && hostOs == OS.Windows
-                    && (renderApi == GraphicsApi.DIRECT3D || renderApi == GraphicsApi.OPENGL)
-                ) {
-                    vrrDisplayLocker = JPanel().apply {
-                        background = Color(0, 0, 0, 0)
-                    }
-                    add(vrrDisplayLocker, Integer.valueOf(0))
-                }
                 checkShowing()
             }
         }
@@ -259,6 +249,13 @@ actual open class SkiaLayer internal constructor(
                 renderApi = fallbackRenderApiQueue.removeAt(0)
                 redrawer?.dispose()
                 redrawer = renderFactory.createRedrawer(this, renderApi, properties)
+                vrrDisplayLocker?.let { remove(it) }
+                if (hostOs == OS.Windows && (renderApi == GraphicsApi.DIRECT3D || renderApi == GraphicsApi.OPENGL)) {
+                    vrrDisplayLocker = JPanel().apply {
+                        background = Color(0, 0, 0, 0)
+                    }
+                    add(vrrDisplayLocker, Integer.valueOf(0))
+                }
                 redrawer?.syncSize()
             } catch (e: RenderException) {
                 println(e.message)

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt
@@ -253,6 +253,7 @@ actual open class SkiaLayer internal constructor(
                 if (hostOs == OS.Windows && (renderApi == GraphicsApi.DIRECT3D || renderApi == GraphicsApi.OPENGL)) {
                     vrrDisplayLocker = JPanel().apply {
                         background = Color(0, 0, 0, 0)
+                        setBounds(0, 0, 1, 1)
                     }
                     add(vrrDisplayLocker, Integer.valueOf(0))
                 }


### PR DESCRIPTION
To disable VRR support, we create a transparent `JPanel` with size (1, 1) and add it on top of the `SkiaLayer`. This causes mixed rendering technologies (java2d and OpenGL/DirectX) to work simultaneously in the same window and VRR cannot be enabled.
see:
- https://github.com/JetBrains/compose-jb/issues/1648
- https://youtrack.jetbrains.com/issue/TBX-6507#focus=Comments-27-5482439.0-0