### PR TITLE
fix Shaper functions 

### DIFF
--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/shaper/Shaper.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/shaper/Shaper.kt
@@ -192,12 +192,12 @@ class Shaper internal constructor(ptr: NativePointer) : Managed(ptr, _FinalizerH
     fun shapeLine(text: String?, font: Font?, opts: ShapingOptions): TextLine {
         return try {
             Stats.onNativeCall()
-            val manageString = ManagedString(text)
+            val managedString = ManagedString(text)
             interopScope {
                 TextLine(
                     _nShapeLine(
                         _ptr,
-                        manageString._ptr,
+                        managedString._ptr,
                         getPtr(font),
                         optsFeaturesLen = opts.features?.size ?: 0,
                         optsFeatures = arrayOfFontFeaturesToInterop(opts.features),

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/shaper/Shaper.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/shaper/Shaper.kt
@@ -188,14 +188,17 @@ class Shaper internal constructor(ptr: NativePointer) : Managed(ptr, _FinalizerH
         return this
     }
 
+    private var managedStringForShapeLine: ManagedString? = null
+
     fun shapeLine(text: String?, font: Font?, opts: ShapingOptions): TextLine {
         return try {
             Stats.onNativeCall()
+            managedStringForShapeLine = ManagedString(text)
             interopScope {
                 TextLine(
                     _nShapeLine(
                         _ptr,
-                        ManagedString(text)._ptr,
+                        managedStringForShapeLine!!._ptr,
                         getPtr(font),
                         optsFeaturesLen = opts.features?.size ?: 0,
                         optsFeatures = arrayOfFontFeaturesToInterop(opts.features),

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/shaper/Shaper.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/shaper/Shaper.kt
@@ -105,10 +105,11 @@ class Shaper internal constructor(ptr: NativePointer) : Managed(ptr, _FinalizerH
     fun shape(text: String?, font: Font?, opts: ShapingOptions, width: Float, offset: Point): TextBlob? {
         return try {
             Stats.onNativeCall()
+            val managedString = ManagedString(text)
             val ptr = interopScope {
                 _nShapeBlob(
                     _ptr,
-                    ManagedString(text)._ptr,
+                    managedString._ptr,
                     getPtr(font),
                     optsFeaturesLen = opts.features?.size ?: 0,
                     optsFeaturesIntArray = arrayOfFontFeaturesToInterop(opts.features),
@@ -188,17 +189,15 @@ class Shaper internal constructor(ptr: NativePointer) : Managed(ptr, _FinalizerH
         return this
     }
 
-    private var managedStringForShapeLine: ManagedString? = null
-
     fun shapeLine(text: String?, font: Font?, opts: ShapingOptions): TextLine {
         return try {
             Stats.onNativeCall()
-            managedStringForShapeLine = ManagedString(text)
+            val manageString = ManagedString(text)
             interopScope {
                 TextLine(
                     _nShapeLine(
                         _ptr,
-                        managedStringForShapeLine!!._ptr,
+                        manageString._ptr,
                         getPtr(font),
                         optsFeaturesLen = opts.features?.size ?: 0,
                         optsFeatures = arrayOfFontFeaturesToInterop(opts.features),


### PR DESCRIPTION
ensure ManageString instance is not collected by GC before using _ptr in native calls.