### PR TITLE
Support linux system theme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
           sudo apt-get install gcc-9 g++-9 -y
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-9
           sudo update-alternatives --config gcc
-          sudo apt-get install ninja-build fontconfig libfontconfig1-dev libglu1-mesa-dev libxrandr-dev zip xvfb -y
+          sudo apt-get install ninja-build fontconfig libfontconfig1-dev libglu1-mesa-dev libxrandr-dev libdbus-1-dev zip xvfb -y
           sudo Xvfb :0 -screen 0 1280x720x24 &
           export DISPLAY=:0
           ./gradlew --stacktrace --info -Pskiko.native.enabled=true :skiko:linuxX64Test :skiko:awtTest

--- a/skiko/build.gradle.kts
+++ b/skiko/build.gradle.kts
@@ -911,7 +911,6 @@ fun createLinkJvmBindings(
                     "-lGL",
                     "-lX11",
                     "-lfontconfig",
-                    "-ldbus-1",
                     // A fix for https://github.com/JetBrains/compose-jb/issues/413.
                     // Dynamic position independent linking uses PLT thunks relying on jump targets in GOT (Global Offsets Table).
                     // GOT entries marked as (for example) R_X86_64_JUMP_SLOT in the relocation table. So, if there's code loading

--- a/skiko/build.gradle.kts
+++ b/skiko/build.gradle.kts
@@ -806,6 +806,7 @@ fun createCompileJvmBindingsTask(
         }
         OS.Linux -> {
             includeHeadersNonRecursive(jdkHome.resolve("include/linux"))
+            includeHeadersNonRecursive(runPkgConfig("dbus-1"))
             osFlags = arrayOf(
                 *buildType.clangFlags,
                 "-fPIC",
@@ -910,6 +911,7 @@ fun createLinkJvmBindings(
                     "-lGL",
                     "-lX11",
                     "-lfontconfig",
+                    "-ldbus-1",
                     // A fix for https://github.com/JetBrains/compose-jb/issues/413.
                     // Dynamic position independent linking uses PLT thunks relying on jump targets in GOT (Global Offsets Table).
                     // GOT entries marked as (for example) R_X86_64_JUMP_SLOT in the relocation table. So, if there's code loading

--- a/skiko/buildSrc/src/main/kotlin/pkgConfigTool.kt
+++ b/skiko/buildSrc/src/main/kotlin/pkgConfigTool.kt
@@ -1,0 +1,23 @@
+import java.io.File
+import java.util.concurrent.TimeUnit
+import org.gradle.api.GradleException
+
+// https://github.com/JetBrains/kotlin-native/issues/3484
+fun runPkgConfig(
+    vararg packageNames: String,
+): List<File> {
+    val process = ProcessBuilder(
+        "pkg-config", "--cflags", *packageNames
+    ).run {
+        environment()["PKG_CONFIG_ALLOW_SYSTEM_LIBS"] = "1"
+        start()
+    }.also { it.waitFor(10, TimeUnit.SECONDS) }
+
+    if (process.exitValue() != 0) {
+        throw GradleException("Error executing pkg-config: ${process.errorStream.bufferedReader().readText()}")
+    }
+
+    return process.inputStream.bufferedReader().readText().split(" ").map { it.trim() }
+        .map { it.removePrefix("-I") }
+        .map(::File)
+}

--- a/skiko/buildSrc/src/main/kotlin/pkgConfigTool.kt
+++ b/skiko/buildSrc/src/main/kotlin/pkgConfigTool.kt
@@ -2,7 +2,6 @@ import java.io.File
 import java.util.concurrent.TimeUnit
 import org.gradle.api.GradleException
 
-// https://github.com/JetBrains/kotlin-native/issues/3484
 fun runPkgConfig(
     vararg packageNames: String,
 ): List<File> {

--- a/skiko/docker/linux-amd64/Dockerfile
+++ b/skiko/docker/linux-amd64/Dockerfile
@@ -17,7 +17,7 @@ ENV PATH=/usr/lib/binutils-2.26/bin:$PATH
 ENV DEPOT_TOOLS=/usr/depot_tools
 ENV PATH=$DEPOT_TOOLS:$PATH
 RUN apt-get install git python wget -y && \
-    apt-get install fontconfig libfontconfig1-dev libglu1-mesa-dev libxrandr-dev curl zip -y && \
+    apt-get install fontconfig libfontconfig1-dev libglu1-mesa-dev libxrandr-dev libdbus-1-dev curl zip -y && \
     git clone 'https://chromium.googlesource.com/chromium/tools/depot_tools.git' $DEPOT_TOOLS
 
 # Install Java

--- a/skiko/docker/linux-arm64/Dockerfile
+++ b/skiko/docker/linux-arm64/Dockerfile
@@ -3,7 +3,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y
 RUN apt-get install binutils build-essential -y
 RUN apt-get install software-properties-common -y
-RUN apt-get install python git fontconfig libfontconfig1-dev libglu1-mesa-dev libxrandr-dev curl wget -y
+RUN apt-get install python git fontconfig libfontconfig1-dev libglu1-mesa-dev libxrandr-dev libdbus-1-dev curl wget -y
 RUN apt-get install openjdk-11-jdk -y
 RUN apt-get install clang-11 -y && \
     apt-get remove g++ -y && \

--- a/skiko/docker/linux-emscripten-amd64/Dockerfile
+++ b/skiko/docker/linux-emscripten-amd64/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:focal-20211006
 SHELL ["/bin/bash", "-c", "-l"]
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y && \
-    apt-get install binutils build-essential software-properties-common libdbus-1-dev -y && \
+    apt-get install binutils build-essential software-properties-common -y && \
     apt-get install git curl wget -y && \
     apt-get install python -y && \
     apt-get install openjdk-11-jdk -y

--- a/skiko/docker/linux-emscripten-amd64/Dockerfile
+++ b/skiko/docker/linux-emscripten-amd64/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:focal-20211006
 SHELL ["/bin/bash", "-c", "-l"]
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y && \
-    apt-get install binutils build-essential software-properties-common -y && \
+    apt-get install binutils build-essential software-properties-common libdbus-1-dev -y && \
     apt-get install git curl wget -y && \
     apt-get install python -y && \
     apt-get install openjdk-11-jdk -y

--- a/skiko/src/jvmMain/cpp/linux/drawlayer.cc
+++ b/skiko/src/jvmMain/cpp/linux/drawlayer.cc
@@ -7,7 +7,6 @@
 #include <cstdlib>
 #include <unistd.h>
 #include <stdio.h>
-#include <dbus/dbus.h>
 #include <iostream>
 #include "jni_helpers.h"
 
@@ -89,87 +88,6 @@ extern "C"
         JAWT_X11DrawingSurfaceInfo *dsi_x11 = fromJavaPointer<JAWT_X11DrawingSurfaceInfo *>(platformInfoPtr);
         return (float) getDpiScaleByDisplay(dsi_x11->display);
     }
-
-    DBusMessage *readSetting(DBusConnection *connection, std::string key, std::string value)
-    {
-        DBusError error;
-        dbus_error_init(&error);
-
-        DBusMessage *message = dbus_message_new_method_call(
-                "org.freedesktop.portal.Desktop",
-                "/org/freedesktop/portal/desktop",
-                "org.freedesktop.portal.Settings",
-                "Read"
-        );
-
-        dbus_bool_t wasSuccessfully = dbus_message_append_args(
-                message,
-                DBUS_TYPE_STRING, &key,
-                DBUS_TYPE_STRING, &value,
-                DBUS_TYPE_INVALID
-        );
-
-        if (!wasSuccessfully) return nullptr;
-
-        DBusMessage *result = dbus_connection_send_with_reply_and_block(
-                connection,
-                message,
-                DBUS_TIMEOUT_USE_DEFAULT,
-                &error
-        );
-
-        dbus_message_unref(message);
-
-        if (dbus_error_is_set(&error)) return nullptr;
-
-        return result;
-    }
-
-    bool parseSettingValue(DBusMessage *message, int type, void *value)
-    {
-        DBusMessageIter messageIter[3];
-
-        dbus_message_iter_init(message, &messageIter[0]);
-        if (dbus_message_iter_get_arg_type(&messageIter[0]) != DBUS_TYPE_VARIANT) return false;
-
-        dbus_message_iter_recurse(&messageIter[0], &messageIter[1]);
-        if (dbus_message_iter_get_arg_type(&messageIter[1]) != DBUS_TYPE_VARIANT) return false;
-
-        dbus_message_iter_recurse(&messageIter[1], &messageIter[2]);
-        if (dbus_message_iter_get_arg_type(&messageIter[2]) != type) return false;
-
-        dbus_message_iter_get_basic(&messageIter[2], value);
-
-        return true;
-    }
-
-    JNIEXPORT jint JNICALL Java_org_jetbrains_skiko_SystemTheme_1awtKt_getCurrentSystemTheme(JNIEnv *env, jobject topLevel)
-    {
-        int systemTheme = 0;
-
-        DBusError error;
-        dbus_error_init(&error);
-
-        DBusConnection *connection = dbus_bus_get(DBUS_BUS_SESSION, &error);
-
-        if (dbus_error_is_set(&error)) return 2; // Unknown.
-
-        DBusMessage *valueMessage = readSetting(connection, "org.freedesktop.appearance", "color-scheme");
-        if (valueMessage == nullptr) return 2; // Unknown.
-
-        parseSettingValue(valueMessage, DBUS_TYPE_UINT32, &systemTheme);
-        dbus_message_unref(valueMessage);
-
-        switch (systemTheme) {
-            case 1:
-                return 1; // Dark.
-            case 2:
-                return 0; // Light.
-            default:
-                return 2; // Unknown.
-        }
-    }
-
 
     JNIEXPORT jfloat JNICALL Java_org_jetbrains_skiko_SetupKt_linuxGetSystemDpiScale(JNIEnv *env, jobject layer)
     {

--- a/skiko/src/jvmMain/cpp/linux/drawlayer.cc
+++ b/skiko/src/jvmMain/cpp/linux/drawlayer.cc
@@ -7,6 +7,8 @@
 #include <cstdlib>
 #include <unistd.h>
 #include <stdio.h>
+#include <dbus/dbus.h>
+#include <iostream>
 #include "jni_helpers.h"
 
 typedef GLXContext (*glXCreateContextAttribsARBProc)(Display *, GLXFBConfig, GLXContext, Bool, const int *);
@@ -88,10 +90,84 @@ extern "C"
         return (float) getDpiScaleByDisplay(dsi_x11->display);
     }
 
+    DBusMessage *readSetting(DBusConnection *connection, std::string key, std::string value)
+    {
+        DBusError error;
+        dbus_error_init(&error);
+
+        DBusMessage *message = dbus_message_new_method_call(
+                "org.freedesktop.portal.Desktop",
+                "/org/freedesktop/portal/desktop",
+                "org.freedesktop.portal.Settings",
+                "Read"
+        );
+
+        dbus_bool_t wasSuccessfully = dbus_message_append_args(
+                message,
+                DBUS_TYPE_STRING, &key,
+                DBUS_TYPE_STRING, &value,
+                DBUS_TYPE_INVALID
+        );
+
+        if (!wasSuccessfully) return nullptr;
+
+        DBusMessage *result = dbus_connection_send_with_reply_and_block(
+                connection,
+                message,
+                DBUS_TIMEOUT_USE_DEFAULT,
+                &error
+        );
+
+        dbus_message_unref(message);
+
+        if (dbus_error_is_set(&error)) return nullptr;
+
+        return result;
+    }
+
+    bool parseSettingValue(DBusMessage *message, int type, void *value)
+    {
+        DBusMessageIter messageIter[3];
+
+        dbus_message_iter_init(message, &messageIter[0]);
+        if (dbus_message_iter_get_arg_type(&messageIter[0]) != DBUS_TYPE_VARIANT) return false;
+
+        dbus_message_iter_recurse(&messageIter[0], &messageIter[1]);
+        if (dbus_message_iter_get_arg_type(&messageIter[1]) != DBUS_TYPE_VARIANT) return false;
+
+        dbus_message_iter_recurse(&messageIter[1], &messageIter[2]);
+        if (dbus_message_iter_get_arg_type(&messageIter[2]) != type) return false;
+
+        dbus_message_iter_get_basic(&messageIter[2], value);
+
+        return true;
+    }
+
     JNIEXPORT jint JNICALL Java_org_jetbrains_skiko_SystemTheme_1awtKt_getCurrentSystemTheme(JNIEnv *env, jobject topLevel)
     {
-       // Unknown.
-       return 2;
+        int systemTheme = 0;
+
+        DBusError error;
+        dbus_error_init(&error);
+
+        DBusConnection *connection = dbus_bus_get(DBUS_BUS_SESSION, &error);
+
+        if (dbus_error_is_set(&error)) return 2; // Unknown.
+
+        DBusMessage *valueMessage = readSetting(connection, "org.freedesktop.appearance", "color-scheme");
+        if (valueMessage == nullptr) return 2; // Unknown.
+
+        parseSettingValue(valueMessage, DBUS_TYPE_UINT32, &systemTheme);
+        dbus_message_unref(valueMessage);
+
+        switch (systemTheme) {
+            case 1:
+                return 1; // Dark.
+            case 2:
+                return 0; // Light.
+            default:
+                return 2; // Unknown.
+        }
     }
 
 

--- a/skiko/src/jvmMain/cpp/linux/drawlayer.cc
+++ b/skiko/src/jvmMain/cpp/linux/drawlayer.cc
@@ -7,7 +7,6 @@
 #include <cstdlib>
 #include <unistd.h>
 #include <stdio.h>
-#include <iostream>
 #include "jni_helpers.h"
 
 typedef GLXContext (*glXCreateContextAttribsARBProc)(Display *, GLXFBConfig, GLXContext, Bool, const int *);

--- a/skiko/src/jvmMain/cpp/linux/theme.cc
+++ b/skiko/src/jvmMain/cpp/linux/theme.cc
@@ -1,0 +1,239 @@
+#include <jawt_md.h>
+#include <dbus/dbus.h>
+#include <iostream>
+#include <dlfcn.h>
+
+#include "jni_helpers.h"
+
+static void* loadLibDbus() {
+    static void* result = nullptr;
+    if (result != nullptr) return result;
+    result = dlopen("libdbus-1.so", RTLD_LAZY | RTLD_LOCAL);
+    return result;
+}
+
+static DBusMessage* dbus_message_new_method_call_dynamic(const char *bus_name, const char *path, const char *iface, const char *method) {
+    typedef DBusMessage* (*dbus_message_new_method_call_t)(const char*, const char*, const char*, const char*);
+    static dbus_message_new_method_call_t func = nullptr;
+    if(!func) {
+        void* lib = loadLibDbus();
+        if(!lib) return nullptr;
+        func = (dbus_message_new_method_call_t) dlsym(lib, "dbus_message_new_method_call");
+    }
+    if(!func) return nullptr;
+    return func(bus_name, path, iface, method);
+}
+
+static dbus_bool_t dbus_message_append_args_dynamic(DBusMessage *message, int first_arg_type, ...) {
+    typedef dbus_bool_t (*dbus_message_append_args_valist_t)(DBusMessage *, int, va_list);
+    static dbus_message_append_args_valist_t func = nullptr;
+    if (!func) {
+        void *lib = loadLibDbus();
+        if (!lib) return false;
+        func = (dbus_message_append_args_valist_t) dlsym(lib, "dbus_message_append_args_valist");
+    }
+    if (!func) return false;
+    va_list var_args;
+    va_start(var_args, first_arg_type);
+    dbus_bool_t result = func(message, first_arg_type, var_args);
+    va_end(var_args);
+    return result;
+}
+
+static DBusMessage* dbus_connection_send_with_reply_and_block_dynamic(DBusConnection *connection, DBusMessage *message, int timeout_milliseconds, DBusError *error) {
+    typedef DBusMessage* (*dbus_connection_send_with_reply_and_block_t)(DBusConnection*, DBusMessage*, int, DBusError*);
+    static dbus_connection_send_with_reply_and_block_t func = nullptr;
+    if(!func) {
+        void* lib = loadLibDbus();
+        if(!lib) return nullptr;
+        func = (dbus_connection_send_with_reply_and_block_t) dlsym(lib, "dbus_connection_send_with_reply_and_block");
+    }
+    if(!func) return nullptr;
+    return func(connection, message, timeout_milliseconds, error);
+}
+
+static bool dbus_message_unref_dynamic(DBusMessage *message) {
+    typedef void* (*dbus_message_unref_t)(DBusMessage*);
+    static dbus_message_unref_t func = nullptr;
+    if(!func) {
+        void* lib = loadLibDbus();
+        if(!lib) return false;
+        func = (dbus_message_unref_t) dlsym(lib, "dbus_message_unref");
+    }
+    if(!func) return false;
+    func(message);
+    return true;
+}
+
+static dbus_bool_t dbus_error_is_set_dynamic(const DBusError *error) {
+    typedef dbus_bool_t (*dbus_error_is_set_t)(const DBusError*);
+    static dbus_error_is_set_t func = nullptr;
+    if(!func) {
+        void* lib = loadLibDbus();
+        if(!lib) return true;
+        func = (dbus_error_is_set_t) dlsym(lib, "dbus_error_is_set");
+    }
+    if(!func) return true;
+    return func(error);
+}
+
+static dbus_bool_t dbus_message_iter_init_dynamic(DBusMessage *message, DBusMessageIter *iter) {
+    typedef dbus_bool_t (*dbus_message_iter_init_t)(DBusMessage*, DBusMessageIter*);
+    static dbus_message_iter_init_t func = nullptr;
+    if(!func) {
+        void* lib = loadLibDbus();
+        if(!lib) return false;
+        func = (dbus_message_iter_init_t) dlsym(lib, "dbus_message_iter_init");
+    }
+    if(!func) return false;
+    return func(message, iter);
+}
+
+static int dbus_message_iter_get_arg_type_dynamic(DBusMessageIter *iter) {
+    typedef int (*dbus_message_iter_get_arg_type_t)(DBusMessageIter*);
+    static dbus_message_iter_get_arg_type_t func = nullptr;
+    if(!func) {
+        void* lib = loadLibDbus();
+        if(!lib) return -1;
+        func = (dbus_message_iter_get_arg_type_t) dlsym(lib, "dbus_message_iter_get_arg_type");
+    }
+    if(!func) return -1;
+    return func(iter);
+}
+
+static bool dbus_message_iter_recurse_dynamic(DBusMessageIter *iter, DBusMessageIter *sub) {
+    typedef void (*dbus_message_iter_recurse_t)(DBusMessageIter*, DBusMessageIter*);
+    static dbus_message_iter_recurse_t func = nullptr;
+    if(!func) {
+        void* lib = loadLibDbus();
+        if(!lib) return false;
+        func = (dbus_message_iter_recurse_t) dlsym(lib, "dbus_message_iter_recurse");
+    }
+    if(!func) return false;
+    func(iter, sub);
+    return true;
+}
+
+static bool dbus_message_iter_get_basic_dynamic(DBusMessageIter *iter, void *value) {
+    typedef void (*dbus_message_iter_get_basic_t)(DBusMessageIter*, void*);
+    static dbus_message_iter_get_basic_t func = nullptr;
+    if(!func) {
+        void* lib = loadLibDbus();
+        if(!lib) return false;
+        func = (dbus_message_iter_get_basic_t) dlsym(lib, "dbus_message_iter_get_basic");
+    }
+    if(!func) return false;
+    func(iter, value);
+    return true;
+}
+
+static DBusConnection* dbus_bus_get_dynamic(DBusBusType type, DBusError *error) {
+    typedef DBusConnection* (*dbus_bus_get_t)(DBusBusType, DBusError*);
+    static dbus_bus_get_t func = nullptr;
+    if(!func) {
+        void* lib = loadLibDbus();
+        if(!lib) return nullptr;
+        func = (dbus_bus_get_t) dlsym(lib, "dbus_bus_get");
+    }
+    if(!func) return nullptr;
+    return func(type, error);
+}
+
+static bool dbus_error_init_dynamic(DBusError *error) {
+    typedef void (*dbus_error_init_t)(DBusError*);
+    static dbus_error_init_t func = nullptr;
+    if(!func) {
+        void* lib = loadLibDbus();
+        if(!lib) return false;
+        func = (dbus_error_init_t) dlsym(lib, "dbus_error_init");
+    }
+    if(!func) return false;
+    func(error);
+    return true;
+}
+
+extern "C"
+{
+    static DBusMessage *getSetting(DBusConnection *connection, std::string key, std::string value)
+    {
+        DBusError error;
+        if(!dbus_error_init_dynamic(&error)) return nullptr;
+
+        DBusMessage *message = dbus_message_new_method_call_dynamic(
+                "org.freedesktop.portal.Desktop",
+                "/org/freedesktop/portal/desktop",
+                "org.freedesktop.portal.Settings",
+                "Read"
+        );
+        if(!message) return nullptr;
+
+        dbus_bool_t wasSuccessfully = dbus_message_append_args_dynamic(
+                message,
+                DBUS_TYPE_STRING, &key,
+                DBUS_TYPE_STRING, &value,
+                DBUS_TYPE_INVALID
+        );
+
+        if (!wasSuccessfully) return nullptr;
+
+        DBusMessage *result = dbus_connection_send_with_reply_and_block_dynamic(
+                connection,
+                message,
+                DBUS_TIMEOUT_USE_DEFAULT,
+                &error
+        );
+        if(!result) return nullptr;
+
+        if(!dbus_message_unref_dynamic(message)) return nullptr;
+
+        if (dbus_error_is_set_dynamic(&error)) return nullptr;
+
+        return result;
+    }
+
+    static bool parseSettingValue(DBusMessage *message, int type, void *value)
+    {
+        DBusMessageIter messageIter[3];
+
+        if(!dbus_message_iter_init_dynamic(message, &messageIter[0])) return false;
+        if (dbus_message_iter_get_arg_type_dynamic(&messageIter[0]) != DBUS_TYPE_VARIANT) return false;
+
+        if(!dbus_message_iter_recurse_dynamic(&messageIter[0], &messageIter[1])) return false;
+        if (dbus_message_iter_get_arg_type_dynamic(&messageIter[1]) != DBUS_TYPE_VARIANT) return false;
+
+        if(!dbus_message_iter_recurse_dynamic(&messageIter[1], &messageIter[2])) return false;
+        if (dbus_message_iter_get_arg_type_dynamic(&messageIter[2]) != type) return false;
+
+        if(!dbus_message_iter_get_basic_dynamic(&messageIter[2], value)) return false;
+
+        return true;
+    }
+
+    JNIEXPORT jint JNICALL Java_org_jetbrains_skiko_SystemTheme_1awtKt_getCurrentSystemTheme(JNIEnv *env, jobject topLevel)
+    {
+        int systemTheme = 0;
+
+        DBusError error;
+        if(!dbus_error_init_dynamic(&error)) return 2; // Unknown.
+
+        DBusConnection *connection = dbus_bus_get_dynamic(DBUS_BUS_SESSION, &error);
+        if(!connection) return 2; // Unknown.
+
+        if (dbus_error_is_set_dynamic(&error)) return 2; // Unknown.
+
+        DBusMessage *valueMessage = getSetting(connection, "org.freedesktop.appearance", "color-scheme");
+        if (!valueMessage) return 2; // Unknown.
+
+        parseSettingValue(valueMessage, DBUS_TYPE_UINT32, &systemTheme);
+        if(!dbus_message_unref_dynamic(valueMessage)) return 2; // Unknown.
+
+        switch (systemTheme) {
+            case 1:
+                return 1; // Dark.
+            case 2:
+                return 0; // Light.
+            default:
+                return 2; // Unknown.
+        }
+    }
+}


### PR DESCRIPTION
This PR adds implementation for Linux System Theme (#403)

Resources
   - [Provide a standard dark style preference key in the settings portal](https://github.com/flatpak/xdg-desktop-portal/issues/629)
   - [Elementary article](https://blog.elementary.io/the-need-for-a-freedesktop-dark-style-preference/)
   - [Gnome 42 Dark Style Preference](https://blogs.gnome.org/alexm/2021/10/04/dark-style-preference/)
   - [KDE Plasma 5.24 adds this new standard](https://kde.org/announcements/plasma/5/5.24.0/)
   - [KDE implementation](https://invent.kde.org/plasma/xdg-desktop-portal-kde/-/merge_requests/49)
   - [Elementary implementation](https://github.com/elementary/settings-daemon/pull/38)

This is the most Multi Desktop Environment approach so far with a non hacky way (like checking if the GTK theme end with `-dark`)

Testing:

Theme switch environment on Gnome 40 (my current gnome version - POPOS 2021.10):
- On Gnome
- Clone: https://gitlab.gnome.org/exalm/color-scheme-simulator
- Follow the instructions for build/install and run `systemctl --user restart xdg-desktop-portal`
- Open the project cloned on Gnome Builder application and run.

Testing Skiko:
- Install dbus header files: `sudo apt install libdbus-1-dev`
- on Skiko project folder, switch branch to this PR
- Build and publish to maven local: `cd skiko && ./gradlew publishToMavenLocal`
- Run sample with: `cd ../samples/SkiaAwtSample/ && ./gradlew run`

https://user-images.githubusercontent.com/29736164/153731894-9db8d357-c5d6-4165-a9ae-a83ea9c18bcc.mp4

Works on the latest  version of Elementary OS out of the box.

https://user-images.githubusercontent.com/29736164/153732554-d512ec94-0443-4100-a3a9-aa998711cf39.mp4
 