### PR TITLE
Throw an exception if the user tries to create a SkiaLayer with an inappropriate [renderApi] on the current OS.

### DIFF
--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/SkikoProperties.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/SkikoProperties.kt
@@ -62,6 +62,26 @@ internal object SkikoProperties {
     }
 
     fun fallbackRenderApiQueue(initialApi: GraphicsApi) : List<GraphicsApi> {
+        when(initialApi) {
+            GraphicsApi.DIRECT3D -> {
+                when(hostOs) {
+                    OS.JS,
+                    OS.Ios,
+                    OS.Android,
+                    OS.Linux,
+                    OS.MacOS -> throw Exception("$hostOs does not support DirectX rendering API.")
+                }
+            }
+            GraphicsApi.METAL -> {
+                when(hostOs) {
+                    OS.JS,
+                    OS.Android,
+                    OS.Linux,
+                    OS.Windows -> throw Exception("$hostOs does not support Metal rendering API.")
+                }
+            }
+        }
+
         var fallbackApis = when (hostOs) {
             OS.Linux -> listOf(GraphicsApi.OPENGL, GraphicsApi.SOFTWARE_FAST, GraphicsApi.SOFTWARE_COMPAT)
             OS.MacOS -> listOf(GraphicsApi.METAL, GraphicsApi.SOFTWARE_COMPAT)

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/SkikoProperties.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/SkikoProperties.kt
@@ -62,26 +62,6 @@ internal object SkikoProperties {
     }
 
     fun fallbackRenderApiQueue(initialApi: GraphicsApi) : List<GraphicsApi> {
-        when(initialApi) {
-            GraphicsApi.DIRECT3D -> {
-                when(hostOs) {
-                    OS.JS,
-                    OS.Ios,
-                    OS.Android,
-                    OS.Linux,
-                    OS.MacOS -> throw Exception("$hostOs does not support DirectX rendering API.")
-                }
-            }
-            GraphicsApi.METAL -> {
-                when(hostOs) {
-                    OS.JS,
-                    OS.Android,
-                    OS.Linux,
-                    OS.Windows -> throw Exception("$hostOs does not support Metal rendering API.")
-                }
-            }
-        }
-
         var fallbackApis = when (hostOs) {
             OS.Linux -> listOf(GraphicsApi.OPENGL, GraphicsApi.SOFTWARE_FAST, GraphicsApi.SOFTWARE_COMPAT)
             OS.MacOS -> listOf(GraphicsApi.METAL, GraphicsApi.SOFTWARE_COMPAT)
@@ -91,9 +71,10 @@ internal object SkikoProperties {
         }
 
         val indexOfInitialApi = fallbackApis.indexOf(initialApi)
-        if (indexOfInitialApi >= 0) {
-            fallbackApis = fallbackApis.drop(indexOfInitialApi + 1)
+        require(indexOfInitialApi >= 0) {
+            "$hostOs does not support $initialApi rendering API."
         }
+        fallbackApis = fallbackApis.drop(indexOfInitialApi + 1)
 
         return listOf(initialApi) + fallbackApis
     }


### PR DESCRIPTION

see: https://github.com/JetBrains/skiko/issues/493