### PR TITLE
Fix ClipboardManager unable to setText on macOS

### DIFF
--- a/skiko/src/macosMain/kotlin/org/jetbrains/skiko/Actuals.macos.kt
+++ b/skiko/src/macosMain/kotlin/org/jetbrains/skiko/Actuals.macos.kt
@@ -8,6 +8,7 @@ internal actual fun URIHandler_openUri(uri: String) {
 }
 
 internal actual fun ClipboardManager_setText(text: String) {
+    NSPasteboard.generalPasteboard.clearContents()
     NSPasteboard.generalPasteboard.setString(string = text, forType = NSPasteboardTypeString)
 }
 


### PR DESCRIPTION
https://developer.apple.com/documentation/appkit/nspasteboard/1533599-clearcontents
Current `ClipboardManager` for macOS target is unable to write to the clipboard. It seems `clearContents`  is required to run first or `setString` function will fail otherwise.