### PR TITLE
Add bindings for SkRuntimeShaderBuilder::child

### DIFF
--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/RuntimeShaderBuilder.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/RuntimeShaderBuilder.kt
@@ -3,7 +3,6 @@ package org.jetbrains.skia
 import org.jetbrains.skia.impl.*
 import org.jetbrains.skia.impl.Library.Companion.staticLoad
 import org.jetbrains.skia.impl.Managed
-import org.jetbrains.skia.impl.Native.Companion.NullPointer
 import org.jetbrains.skia.impl.NativePointer
 import org.jetbrains.skia.impl.Stats
 import org.jetbrains.skia.impl.interopScope
@@ -101,6 +100,20 @@ class RuntimeShaderBuilder internal constructor(ptr: NativePointer) : Managed(pt
             _nUniformFloatMatrix44(_ptr, toInterop(name), toInterop(value.mat))
         }
     }
+
+    fun child(name: String, shader: Shader) {
+        Stats.onNativeCall()
+        interopScope {
+            _nChildShader(_ptr, toInterop(name), getPtr(shader))
+        }
+    }
+
+    fun child(name: String, colorFilter: ColorFilter) {
+        Stats.onNativeCall()
+        interopScope {
+            _nChildColorFilter(_ptr, toInterop(name), getPtr(colorFilter))
+        }
+    }
 }
 
 @ExternalSymbolName("org_jetbrains_skia_RuntimeShaderBuilder__1nMakeFromRuntimeEffect")
@@ -141,3 +154,9 @@ private external fun _nUniformFloatMatrix33(builderPtr: NativePointer, uniformNa
 
 @ExternalSymbolName("org_jetbrains_skia_RuntimeShaderBuilder__1nUniformFloatMatrix44")
 private external fun _nUniformFloatMatrix44(builderPtr: NativePointer, uniformName: InteropPointer, uniformMatrix44: InteropPointer)
+
+@ExternalSymbolName("org_jetbrains_skia_RuntimeShaderBuilder__1nChildShader")
+private external fun _nChildShader(builderPtr: NativePointer, uniformName: InteropPointer, shaderPtr: NativePointer)
+
+@ExternalSymbolName("org_jetbrains_skia_RuntimeShaderBuilder__1nChildColorFilter")
+private external fun _nChildColorFilter(builderPtr: NativePointer, uniformName: InteropPointer, colorFilterPtr: NativePointer)

--- a/skiko/src/jvmMain/cpp/common/RuntimeShaderBuilder.cc
+++ b/skiko/src/jvmMain/cpp/common/RuntimeShaderBuilder.cc
@@ -107,3 +107,19 @@ Java_org_jetbrains_skia_RuntimeShaderBuilderKt__1nUniformFloatMatrix44
     std::unique_ptr<SkM44> matrix44 = skM44(env, uniformMatrix44);
     runtimeShaderBuilder->uniform(skString(env, uniformName).c_str()) = matrix44.get();
 }
+
+extern "C" JNIEXPORT void JNICALL
+Java_org_jetbrains_skia_RuntimeShaderBuilderKt__1nChildShader
+  (JNIEnv* env, jclass jclass, jlong builderPtr, jstring childName, jlong childShaderPtr) {
+    SkRuntimeShaderBuilder* runtimeShaderBuilder = jlongToPtr<SkRuntimeShaderBuilder*>(builderPtr);
+    sk_sp<SkShader> shader = sk_ref_sp<SkShader>(reinterpret_cast<SkShader*>(static_cast<uintptr_t>(childShaderPtr)));
+    runtimeShaderBuilder->child(skString(env, childName).c_str()) = shader;
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_org_jetbrains_skia_RuntimeShaderBuilderKt__1nChildColorFilter
+  (JNIEnv* env, jclass jclass, jlong builderPtr, jstring childName, jlong childColorFilterPtr) {
+    SkRuntimeShaderBuilder* runtimeShaderBuilder = jlongToPtr<SkRuntimeShaderBuilder*>(builderPtr);
+    sk_sp<SkColorFilter> colorFilter = sk_ref_sp<SkColorFilter>(reinterpret_cast<SkColorFilter*>(static_cast<uintptr_t>(childColorFilterPtr)));
+    runtimeShaderBuilder->child(skString(env, childName).c_str()) = colorFilter;
+}

--- a/skiko/src/nativeJsMain/cpp/RuntimeShaderBuilder.cc
+++ b/skiko/src/nativeJsMain/cpp/RuntimeShaderBuilder.cc
@@ -89,3 +89,17 @@ SKIKO_EXPORT void org_jetbrains_skia_RuntimeShaderBuilder__1nUniformFloatMatrix4
     SkRuntimeShaderBuilder* runtimeShaderBuilder = reinterpret_cast<SkRuntimeShaderBuilder*>(builderPtr);
     runtimeShaderBuilder->uniform(skString(uniformName).c_str()) = uniformMatrix44;
 }
+
+SKIKO_EXPORT void org_jetbrains_skia_RuntimeShaderBuilder__1nChildShader
+  (KNativePointer builderPtr, KInteropPointer childName, KNativePointer childShaderPtr) {
+    SkRuntimeShaderBuilder* runtimeShaderBuilder = reinterpret_cast<SkRuntimeShaderBuilder*>(builderPtr);
+    sk_sp<SkShader> shader = sk_ref_sp<SkShader>(reinterpret_cast<SkShader*>(childShaderPtr));
+    runtimeShaderBuilder->child(skString(childName).c_str()) = shader;
+}
+
+SKIKO_EXPORT void org_jetbrains_skia_RuntimeShaderBuilder__1nChildColorFilter
+  (KNativePointer builderPtr, KInteropPointer childName, KNativePointer childColorFilterPtr) {
+    SkRuntimeShaderBuilder* runtimeShaderBuilder = reinterpret_cast<SkRuntimeShaderBuilder*>(builderPtr);
+    sk_sp<SkColorFilter> colorFilter = sk_ref_sp<SkColorFilter>(reinterpret_cast<SkColorFilter*>(childColorFilterPtr));
+    runtimeShaderBuilder->child(skString(childName).c_str()) = colorFilter;
+}


### PR DESCRIPTION
For `SkShader` and `SkColorFilter` that can be passed as uniforms into the main SkSL shader