### PR TITLE
`Image.makeFromEncoded()` makes jvm crash

### DIFF
--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Image.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Image.kt
@@ -131,10 +131,10 @@ class Image internal constructor(ptr: NativePointer) : RefCnt(ptr), IHasImageInf
             }
         }
 
-        fun makeFromEncoded(bytes: ByteArray?): Image {
+        fun makeFromEncoded(bytes: ByteArray): Image {
             Stats.onNativeCall()
             val ptr = interopScope {
-                _nMakeFromEncoded(toInterop(bytes), bytes?.size ?: 0)
+                _nMakeFromEncoded(toInterop(bytes), bytes.size)
             }
             require(ptr != NullPointer) { "Failed to Image::makeFromEncoded" }
             return Image(ptr)

--- a/skiko/src/jvmMain/cpp/common/Image.cc
+++ b/skiko/src/jvmMain/cpp/common/Image.cc
@@ -47,8 +47,6 @@ extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_ImageKt__1nMakeFromPi
 
 extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_ImageKt__1nMakeFromEncoded
   (JNIEnv* env, jclass jclass, jbyteArray encodedArray, jint encodedLen) {
-    if (!encodedArray) return 0;
-
     jbyte* encoded = env->GetByteArrayElements(encodedArray, 0);
     sk_sp<SkData> encodedData = SkData::MakeWithCopy(encoded, encodedLen);
     env->ReleaseByteArrayElements(encodedArray, encoded, 0);

--- a/skiko/src/jvmMain/cpp/common/Image.cc
+++ b/skiko/src/jvmMain/cpp/common/Image.cc
@@ -47,6 +47,8 @@ extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_ImageKt__1nMakeFromPi
 
 extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_ImageKt__1nMakeFromEncoded
   (JNIEnv* env, jclass jclass, jbyteArray encodedArray, jint encodedLen) {
+    if (!encodedArray) return 0;
+
     jbyte* encoded = env->GetByteArrayElements(encodedArray, 0);
     sk_sp<SkData> encodedData = SkData::MakeWithCopy(encoded, encodedLen);
     env->ReleaseByteArrayElements(encodedArray, encoded, 0);


### PR DESCRIPTION
this makes jvm crash
```kotlin
Image.makeFromEncoded(null)
```

it should return 0 when input byte array is null
at https://github.com/JetBrains/skiko/blob/master/skiko/src/jvmMain/cpp/common/Image.cc#L48
```cpp
extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_ImageKt__1nMakeFromEncoded
  (JNIEnv* env, jclass jclass, jbyteArray encodedArray, jint encodedLen) {
    jbyte* encoded = env->GetByteArrayElements(encodedArray, 0);
    sk_sp<SkData> encodedData = SkData::MakeWithCopy(encoded, encodedLen);
    env->ReleaseByteArrayElements(encodedArray, encoded, 0);

    sk_sp<SkImage> image = SkImage::MakeFromEncoded(encodedData);

    return reinterpret_cast<jlong>(image.release());
}
```

crash log
```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x00007f5606694621, pid=8030, tid=8031
#
# JRE version: OpenJDK Runtime Environment Corretto-17.0.3.6.1 (17.0.3+6) (build 17.0.3+6-LTS)
# Java VM: OpenJDK 64-Bit Server VM Corretto-17.0.3.6.1 (17.0.3+6-LTS, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, g1 gc, linux-amd64)
# Problematic frame:
# V  [libjvm.so+0x294621]  AccessInternal::PostRuntimeDispatch<G1BarrierSet::AccessBarrier<548964ul, G1BarrierSet>, (AccessInternal::BarrierType)2, 548964ul>::oop_access_barrier(void*)+0x1
#
# Core dump will be written. Default location: Core dumps may be processed with "/usr/share/apport/apport %p %s %c %d %P %E" (or dumping to /home/liu/IdeaProjects/DrawMeme/core.8030)
#
# If you would like to submit a bug report, please visit:
#   https://github.com/corretto/corretto-17/issues/
#

---------------  T H R E A D  ---------------

Current thread (0x00007f5600027430):  JavaThread "main" [_thread_in_vm, id=8031, stack(0x00007f5606300000,0x00007f5606400000)]

Stack: [0x00007f5606300000,0x00007f5606400000],  sp=0x00007f56063fe690,  free space=1017k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
V  [libjvm.so+0x294621]  AccessInternal::PostRuntimeDispatch<G1BarrierSet::AccessBarrier<548964ul, G1BarrierSet>, (AccessInternal::BarrierType)2, 548964ul>::oop_access_barrier(void*)+0x1

Java frames: (J=compiled Java code, j=interpreted, Vv=VM code)
j  org.jetbrains.skia.ImageKt._nMakeFromEncoded(Ljava/lang/Object;I)J+0
j  org.jetbrains.skia.ImageKt.access$_nMakeFromEncoded(Ljava/lang/Object;I)J+2
j  org.jetbrains.skia.Image$Companion.makeFromEncoded([B)Lorg/jetbrains/skia/Image;+41
j  org.laolittle.plugin.draw.TestaKt.main()V+4
j  org.laolittle.plugin.draw.TestaKt.main([Ljava/lang/String;)V+0
v  ~StubRoutines::call_stub
```