### PR TITLE
Add bindings for half leading to TextStyle and StrutStyle

### DIFF
--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/paragraph/StrutStyle.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/paragraph/StrutStyle.kt
@@ -175,6 +175,23 @@ class StrutStyle internal constructor(ptr: NativePointer) : Managed(ptr, _Finali
         return this
     }
 
+    var isHalfLeading: Boolean
+        get() = try {
+            Stats.onNativeCall()
+            _nIsHalfLeading(_ptr)
+        } finally {
+            reachabilityBarrier(this)
+        }
+        set(value) {
+            setHalfLeading(value)
+        }
+
+    fun setHalfLeading(value: Boolean): StrutStyle {
+        Stats.onNativeCall()
+        _nSetHalfLeading(_ptr, value)
+        return this
+    }
+
     private object _FinalizerHolder {
         val PTR = StrutStyle_nGetFinalizer()
     }
@@ -237,3 +254,9 @@ private external fun _nIsHeightOverridden(ptr: NativePointer): Boolean
 
 @ExternalSymbolName("org_jetbrains_skia_paragraph_StrutStyle__1nSetHeightOverridden")
 private external fun _nSetHeightOverridden(ptr: NativePointer, value: Boolean)
+
+@ExternalSymbolName("org_jetbrains_skia_paragraph_StrutStyle__1nIsHalfLeading")
+private external fun _nIsHalfLeading(ptr: NativePointer): Boolean
+
+@ExternalSymbolName("org_jetbrains_skia_paragraph_StrutStyle__1nSetHalfLeading")
+private external fun _nSetHalfLeading(ptr: NativePointer, value: Boolean)

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/paragraph/TextStyle.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/paragraph/TextStyle.kt
@@ -274,6 +274,23 @@ class TextStyle internal constructor(ptr: NativePointer) : Managed(ptr, _Finaliz
         return this
     }
 
+    var isHalfLeading: Boolean
+        get() = try {
+            Stats.onNativeCall()
+            TextStyle_nIsHalfLeading(_ptr)
+        } finally {
+            reachabilityBarrier(this)
+        }
+        set(value) {
+            setHalfLeading(value)
+        }
+
+    fun setHalfLeading(value: Boolean): TextStyle {
+        Stats.onNativeCall()
+        TextStyle_nSetHalfLeading(_ptr, value)
+        return this
+    }
+
     var letterSpacing: Float
         get() = try {
             Stats.onNativeCall()
@@ -447,6 +464,12 @@ private external fun TextStyle_nGetHeight(ptr: NativePointer): Float
 
 @ExternalSymbolName("org_jetbrains_skia_paragraph_TextStyle__1nSetHeight")
 private external fun TextStyle_nSetHeight(ptr: NativePointer, override: Boolean, height: Float)
+
+@ExternalSymbolName("org_jetbrains_skia_paragraph_TextStyle__1nIsHalfLeading")
+private external fun TextStyle_nIsHalfLeading(ptr: NativePointer): Boolean
+
+@ExternalSymbolName("org_jetbrains_skia_paragraph_TextStyle__1nSetHalfLeading")
+private external fun TextStyle_nSetHalfLeading(ptr: NativePointer, value: Boolean)
 
 @ExternalSymbolName("org_jetbrains_skia_paragraph_TextStyle__1nGetBaselineShift")
 private external fun TextStyle_nGetBaselineShift(ptr: NativePointer): Float

--- a/skiko/src/jvmMain/cpp/common/paragraph/StrutStyle.cc
+++ b/skiko/src/jvmMain/cpp/common/paragraph/StrutStyle.cc
@@ -133,3 +133,15 @@ extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_paragraph_StrutStyleKt
     StrutStyle* instance = reinterpret_cast<StrutStyle*>(static_cast<uintptr_t>(ptr));
     instance->setHeightOverride(value);
 }
+
+extern "C" JNIEXPORT jboolean JNICALL Java_org_jetbrains_skia_paragraph_StrutStyleKt__1nIsHalfLeading
+  (JNIEnv* env, jclass jclass, jlong ptr) {
+    StrutStyle* instance = reinterpret_cast<StrutStyle*>(static_cast<uintptr_t>(ptr));
+    return instance->getHalfLeading();
+}
+
+extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_paragraph_StrutStyleKt__1nSetHalfLeading
+  (JNIEnv* env, jclass jclass, jlong ptr, jboolean value) {
+    StrutStyle* instance = reinterpret_cast<StrutStyle*>(static_cast<uintptr_t>(ptr));
+    instance->setHalfLeading(value);
+}

--- a/skiko/src/jvmMain/cpp/common/paragraph/TextStyle.cc
+++ b/skiko/src/jvmMain/cpp/common/paragraph/TextStyle.cc
@@ -245,6 +245,18 @@ extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_paragraph_TextStyleKt_
     instance->setHeight(height);
 }
 
+extern "C" JNIEXPORT jboolean JNICALL Java_org_jetbrains_skia_paragraph_TextStyleKt_TextStyle_1nIsHalfLeading
+  (JNIEnv* env, jclass jclass, jlong ptr) {
+    TextStyle* instance = reinterpret_cast<TextStyle*>(static_cast<uintptr_t>(ptr));
+    return instance->getHalfLeading();
+}
+
+extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_paragraph_TextStyleKt_TextStyle_1nSetHalfLeading
+  (JNIEnv* env, jclass jclass, jlong ptr, jboolean value) {
+    TextStyle* instance = reinterpret_cast<TextStyle*>(static_cast<uintptr_t>(ptr));
+    instance->setHalfLeading(value);
+}
+
 extern "C" JNIEXPORT jfloat JNICALL Java_org_jetbrains_skia_paragraph_TextStyleKt_TextStyle_1nGetBaselineShift
   (JNIEnv* env, jclass jclass, jlong ptr) {
     TextStyle* instance = reinterpret_cast<TextStyle*>(static_cast<uintptr_t>(ptr));

--- a/skiko/src/nativeJsMain/cpp/paragraph/StrutStyle.cc
+++ b/skiko/src/nativeJsMain/cpp/paragraph/StrutStyle.cc
@@ -133,3 +133,15 @@ SKIKO_EXPORT void org_jetbrains_skia_paragraph_StrutStyle__1nSetHeightOverridden
     StrutStyle* instance = reinterpret_cast<StrutStyle*>(ptr);
     instance->setHeightOverride(value);
 }
+
+SKIKO_EXPORT KBoolean org_jetbrains_skia_paragraph_StrutStyle__1nIsHalfLeading
+  (KNativePointer ptr) {
+    StrutStyle* instance = reinterpret_cast<StrutStyle*>(ptr);
+    return instance->getHalfLeading();
+}
+
+SKIKO_EXPORT void org_jetbrains_skia_paragraph_StrutStyle__1nSetHalfLeading
+  (KNativePointer ptr, KBoolean value) {
+    StrutStyle* instance = reinterpret_cast<StrutStyle*>(ptr);
+    instance->setHalfLeading(value);
+}

--- a/skiko/src/nativeJsMain/cpp/paragraph/TextStyle.cc
+++ b/skiko/src/nativeJsMain/cpp/paragraph/TextStyle.cc
@@ -243,6 +243,18 @@ SKIKO_EXPORT void org_jetbrains_skia_paragraph_TextStyle__1nSetHeight
     instance->setHeight(height);
 }
 
+SKIKO_EXPORT KFloat org_jetbrains_skia_paragraph_TextStyle__1nGetHalfLeading
+  (KNativePointer ptr) {
+    TextStyle* instance = reinterpret_cast<TextStyle*>(ptr);
+    return instance->getHalfLeading();
+}
+
+SKIKO_EXPORT void org_jetbrains_skia_paragraph_TextStyle__1nSetHalfLeading
+  (KNativePointer ptr, KBoolean halfLeading) {
+    TextStyle* instance = reinterpret_cast<TextStyle*>(ptr);
+    instance->setHalfLeading(halfLeading);
+}
+
 SKIKO_EXPORT KFloat org_jetbrains_skia_paragraph_TextStyle__1nGetBaselineShift
   (KNativePointer ptr) {
     TextStyle* instance = reinterpret_cast<TextStyle*>(ptr);


### PR DESCRIPTION
This will allow us to create vertically centered text with custom line height

We need it in Fleet to get rid of our custom leading that we are currently applying around the actual lines of text. We can't leave it up to the Paragraph API right now because without the half leading feature, the additional space will not be evenly distributed above and below the text, but instead proportionally to the ascent and descent in the font. This leaves the text vertically uncentered, which is especially notable when there is a selection or a highlight behind it.

I already tested the new bindings locally with Fleet.

(cherry picked from commit f6f5338c1239625dd3ddf0e3b0e56b393e8a43ae)