### PR TITLE
Dynamically load GetDpiForWindow/Monitor to support Windows before 10

### DIFF
--- a/skiko/src/jvmMain/cpp/windows/drawlayer.cc
+++ b/skiko/src/jvmMain/cpp/windows/drawlayer.cc
@@ -68,14 +68,14 @@ extern "C"
 
         // Try to dynamically load GetDpiForWindow and GetDpiForMonitor - they are only supported from Windows 10 and 8.1 respectively
         static bool dynamicFunctionsLoaded = false;
-        if(!dynamicFunctionsLoaded) {
+        if (!dynamicFunctionsLoaded) {
             HINSTANCE shcoreDll = LoadLibrary("Shcore.dll");
-            if(shcoreDll) {
+            if (shcoreDll) {
                 getDpiForMonitor = reinterpret_cast<GDFM>(GetProcAddress(shcoreDll, "GetDpiForMonitor"));
             }
             
             HINSTANCE user32Dll = LoadLibrary("User32");
-            if(user32Dll) {
+            if (user32Dll) {
                 getDpiForWindow = reinterpret_cast<GDFW>(GetProcAddress(user32Dll, "GetDpiForWindow"));
             }
             
@@ -84,22 +84,22 @@ extern "C"
 
         HWND hwnd = (HWND)Java_org_jetbrains_skiko_HardwareLayer_getWindowHandle(env, canvas, platformInfoPtr);
         int dpi = 0;
-        if(getDpiForMonitor) {
+        if (getDpiForMonitor) {
             HMONITOR display = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
             UINT xDpi = 0, yDpi = 0;
             getDpiForMonitor(display, MDT_RAW_DPI, &xDpi, &yDpi);
-            dpi = (int)xDpi;
+            dpi = (int) xDpi;
         }
         
         // We can get dpi:0 if we set up multiple displays for content duplication (mirror). 
         if (dpi == 0) {            
-            if(getDpiForWindow) {
+            if (getDpiForWindow) {
                 // get default system dpi
                 dpi = getDpiForWindow(hwnd);
             }
         }
         
-        if(dpi == 0) {
+        if (dpi == 0) {
             // If failed to get DPI, assume standard 96
             dpi = 96;
         }


### PR DESCRIPTION
Closes #540

Converting `GetDpiForMonitor` gives compatibility with Windows 8.1/2012R2 and `GetDpiForWindow` theoretically goes back to Windows 7, as supported by skia.

Tested on Windows: 10, Server 2012R2, Server 2012R1.

(I don't beg for an official support for those older versions, but since this little is required to make it work I think it's nice to have, especially since it is an requirement for me and I'd like to avoid keeping my own fork of skiko).