### PR TITLE
Delegate focus methods from SkiaLayer to backedLayer

### DIFF
--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt
@@ -1,13 +1,12 @@
 package org.jetbrains.skiko
 
 import org.jetbrains.skia.*
+import org.jetbrains.skia.Canvas
 import org.jetbrains.skiko.redrawer.Redrawer
+import java.awt.*
 import java.awt.Color
-import java.awt.Component
-import java.awt.Graphics
 import java.awt.event.*
 import java.awt.im.InputMethodRequests
-import java.awt.Window
 import java.util.concurrent.CancellationException
 import javax.accessibility.Accessible
 import javax.swing.JComponent
@@ -83,6 +82,19 @@ actual open class SkiaLayer internal constructor(
             override fun getInputMethodRequests(): InputMethodRequests? {
                 return this@SkiaLayer.inputMethodRequests
             }
+
+            override fun requestFocus(cause: FocusEvent.Cause?) {
+                if (canReceiveFocus(cause)) {
+                    super.requestFocus(cause)
+                }
+            }
+
+            override fun requestFocusInWindow(cause: FocusEvent.Cause?): Boolean {
+                return canReceiveFocus(cause) && super.requestFocusInWindow(cause)
+            }
+
+            private fun canReceiveFocus(cause: FocusEvent.Cause?) = cause != FocusEvent.Cause.MOUSE_EVENT ||
+                    isRequestFocusEnabled
         }
         @Suppress("LeakingThis")
         add(backedLayer)
@@ -366,12 +378,52 @@ actual open class SkiaLayer internal constructor(
         backedLayer.doProcessInputMethodEvent(e)
     }
 
+    override fun addFocusListener(l: FocusListener?) {
+        backedLayer.addFocusListener(l)
+    }
+
+    override fun removeFocusListener(l: FocusListener?) {
+        backedLayer.removeFocusListener(l)
+    }
+
+    override fun setFocusable(focusable: Boolean) {
+        backedLayer.isFocusable = focusable
+    }
+
+    override fun isFocusable(): Boolean {
+        return backedLayer.isFocusable
+    }
+
+    override fun hasFocus(): Boolean {
+        return backedLayer.hasFocus()
+    }
+
+    override fun isFocusOwner(): Boolean {
+        return backedLayer.isFocusOwner
+    }
+
     override fun requestFocus() {
         backedLayer.requestFocus()
     }
 
     override fun requestFocus(cause: FocusEvent.Cause?) {
         backedLayer.requestFocus(cause)
+    }
+
+    override fun requestFocusInWindow(): Boolean {
+        return backedLayer.requestFocusInWindow()
+    }
+
+    override fun requestFocusInWindow(cause: FocusEvent.Cause?): Boolean {
+        return backedLayer.requestFocusInWindow(cause)
+    }
+
+    override fun setFocusTraversalKeysEnabled(focusTraversalKeysEnabled: Boolean) {
+        backedLayer.focusTraversalKeysEnabled = focusTraversalKeysEnabled
+    }
+
+    override fun getFocusTraversalKeysEnabled(): Boolean {
+        return backedLayer.focusTraversalKeysEnabled
     }
 
     override fun addInputMethodListener(l: InputMethodListener) {
@@ -414,10 +466,6 @@ actual open class SkiaLayer internal constructor(
 
     override fun removeKeyListener(l: KeyListener) {
         backedLayer.removeKeyListener(l)
-    }
-
-    override fun setFocusTraversalKeysEnabled(focusTraversalKeysEnabled: Boolean) {
-        backedLayer.focusTraversalKeysEnabled = focusTraversalKeysEnabled
     }
 
     /**


### PR DESCRIPTION
Similar to the other methods

(see the comment "We need to delegate all event listeners..." why we do that)

Also, disable changing focus when click on SkiaLayer if we set `setCanReceiveFocus(false)`, because focus should be changed only when we click on some focusable Swing/Compose component