### PR TITLE
Remove internal from org.jetbrains.skiko.currentNanoTime

### DIFF
--- a/skiko/src/commonMain/kotlin/org/jetbrains/skiko/Expects.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skiko/Expects.kt
@@ -2,4 +2,4 @@ package org.jetbrains.skiko
 
 internal expect inline fun <R> maybeSynchronized(lock: Any, block: () -> R): R
 
-internal expect fun currentNanoTime(): Long
+expect fun currentNanoTime(): Long


### PR DESCRIPTION
It is already public in the targets