### PR TITLE
set moduleName for kjs target

### DIFF
--- a/skiko/build.gradle.kts
+++ b/skiko/build.gradle.kts
@@ -228,6 +228,7 @@ kotlin {
 
     if (supportWasm) {
         js(IR) {
+            moduleName = "skiko-kjs" // override the name to avoid name collision with a different skiko.js file
             browser {
                 testTask {
                     dependsOn("linkWasm")


### PR DESCRIPTION
Kotlin 1.7.0 introduced some changes related to kjs module names (affecting modules consuming skiko).

Therefore, we need to override the moduleName to avoid name collision with a different skiko.js file