### PR TITLE
Another method to parse font features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,8 +93,8 @@ jobs:
           sudo apt-get install ninja-build fontconfig libfontconfig1-dev libglu1-mesa-dev libxrandr-dev libdbus-1-dev zip xvfb -y
           sudo Xvfb :0 -screen 0 1280x720x24 &
           export DISPLAY=:0
-          ./gradlew --stacktrace --info -Pskiko.native.enabled=true :skiko:linuxX64Test :skiko:awtTest
-          ./gradlew --stacktrace --info :skiko:publishToMavenLocal
+          ./gradlew --stacktrace --info -Pskiko.native.enabled=true -Pkotlin.native.cacheKind.linuxX64=none :skiko:linuxX64Test :skiko:awtTest
+          ./gradlew --stacktrace --info -Pkotlin.native.cacheKind.linuxX64=none :skiko:publishToMavenLocal
           ./gradlew --stacktrace --info :SkiaAwtSample:installDist # check jvm sample works
           ./gradlew -Pskiko.android.enabled=true :skiko:publishSkikoJvmRuntimeAndroidX64PublicationToMavenLocal :skiko:publishSkikoJvmRuntimeAndroidArm64PublicationToMavenLocal :skiko:publishAndroidPublicationToMavenLocal
       - uses: actions/upload-artifact@v2

--- a/skiko/src/commonTest/kotlin/org/jetbrains/skia/PatternMatcherTests.kt
+++ b/skiko/src/commonTest/kotlin/org/jetbrains/skia/PatternMatcherTests.kt
@@ -84,6 +84,47 @@ class PatternMatcherTests {
     }
 
     @Test
+    fun fontFeatureCanBeParsedAsW3() = runTest {
+        FontFeature.parseW3("abcd").apply {
+            assertEquals(1, size)
+            assertEquals("abcd", get(0).tag)
+            assertEquals(1, get(0).value)
+        }
+
+        FontFeature.parseW3("abcd 0").apply {
+            assertEquals(1, size)
+            assertEquals("abcd", get(0).tag)
+            assertEquals(0, get(0).value)
+        }
+
+        FontFeature.parseW3("abcd 0, vfgb").apply {
+            assertEquals(2, size)
+            assertEquals("abcd", get(0).tag)
+            assertEquals(0, get(0).value)
+            assertEquals("vfgb", get(1).tag)
+            assertEquals(1, get(1).value)
+        }
+
+        FontFeature.parseW3("abcd 0, abc, vfgb").apply {
+            assertEquals(2, size)
+            assertEquals("abcd", get(0).tag)
+            assertEquals(0, get(0).value)
+            assertEquals("vfgb", get(1).tag)
+            assertEquals(1, get(1).value)
+        }
+
+        FontFeature.parseW3("abcd vfgb").apply {
+            assertEquals(1, size)
+            assertEquals("abcd", get(0).tag)
+            assertEquals(1, get(0).value)
+        }
+
+        FontFeature.parseW3("").apply {
+            assertEquals(0, size)
+        }
+    }
+
+    @Test
     fun fontVariationCanBeParsed() = runTest {
         val f1 = FontVariation.parseOne("abcd=111")
 


### PR DESCRIPTION
Needed for Compose. I compared it with Android, and Android/Compose by documentation uses this format without quotes: ttps://www.w3.org/TR/css-fonts-3/#font-feature-settings-prop

[Compose PR](https://github.com/JetBrains/androidx/pull/251)