### PR TITLE
Refactor Skiko properties

### DIFF
--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt
@@ -624,7 +624,8 @@ internal fun defaultFPSCounter(
     FPSCounter(
         periodSeconds = fpsPeriodSeconds,
         showLongFrames = fpsLongFramesShow,
-        getLongFrameMillis = { fpsLongFramesMillis ?: 1.5 * 1000 / refreshRate }
+        getLongFrameMillis = { fpsLongFramesMillis ?: (1.5 * 1000 / refreshRate) },
+        logOnTick = true
     )
 }
 

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/Direct3DRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/Direct3DRedrawer.kt
@@ -17,7 +17,9 @@ internal class Direct3DRedrawer(
     private var isDisposed = false
     private var drawLock = Any()
 
-    private val device = createDirectXDevice(getAdapterPriority(), layer.contentHandle, layer.transparency).also {
+    private val device = createDirectXDevice(
+        properties.adapterPriority.ordinal, layer.contentHandle, layer.transparency
+    ).also {
         if (it == 0L || !isVideoCardSupported(layer.renderApi)) {
             throw RenderException("Failed to create DirectX12 device.")
         }
@@ -76,16 +78,6 @@ internal class Direct3DRedrawer(
     fun makeSurface(context: Long, width: Int, height: Int, index: Int) = Surface(
         makeDirectXSurface(device, context, width, height, index)
     )
-
-    private fun getAdapterPriority(): Int {
-        val adapterPriority = GpuPriority.parse(System.getProperty("skiko.directx.gpu.priority"))
-        return when (adapterPriority) {
-            GpuPriority.Auto -> 0
-            GpuPriority.Integrated -> 1
-            GpuPriority.Discrete -> 2
-            else -> 0
-        }
-    }
 
     fun resizeBuffers(width: Int, height: Int) = resizeBuffers(device, width, height)
 

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
@@ -25,7 +25,7 @@ internal class MetalRedrawer(
     private var isDisposed = false
     private var drawLock = Any()
     private val device = layer.backedLayer.useDrawingSurfacePlatformInfo {
-        createMetalDevice(layer.windowHandle, layer.transparency, getAdapterPriority(), it)
+        createMetalDevice(layer.windowHandle, layer.transparency, properties.adapterPriority.ordinal, it)
     }
     private val windowHandle = layer.windowHandle
 
@@ -126,16 +126,6 @@ internal class MetalRedrawer(
     )
 
     fun finishFrame() = finishFrame(device)
-
-    fun getAdapterPriority(): Int {
-        val adapterPriority = GpuPriority.parse(System.getProperty("skiko.metal.gpu.priority"))
-        return when (adapterPriority) {
-            GpuPriority.Auto -> 0
-            GpuPriority.Integrated -> 1
-            GpuPriority.Discrete -> 2
-            else -> 0
-        }
-    }
 
     fun getAdapterName(): String = getAdapterName(device)
     fun getAdapterMemorySize(): Long = getAdapterMemorySize(device)

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skiko/FPSCounter.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skiko/FPSCounter.kt
@@ -7,14 +7,18 @@ class FPSCounter(
     private val showLongFrames: Boolean = false,
     private val getLongFrameMillis: () -> Double = {
         1.5 * 1000 / 60
-    }
+    },
+    private val logOnTick: Boolean = false
 ) {
     private val times = mutableListOf<Long>()
     private var lastLogTime = currentNanoTime()
     private var lastTime = currentNanoTime()
-    private var _average = 0
-    private var _min = 0
-    private var _max = 0
+    var average = 0
+        private set
+    var min = 0
+        private set
+    var max = 0
+        private set
 
     fun tick() {
         val time = currentNanoTime()
@@ -24,28 +28,21 @@ class FPSCounter(
 
         times.add(frameTime)
 
-        if (showLongFrames && frameTime > getLongFrameMillis().millisToNanos()) {
+        if (logOnTick && showLongFrames && frameTime > getLongFrameMillis().millisToNanos()) {
             println("$timestamp Long frame ${frameTime.nanosToMillis()} ms")
         }
 
         if ((time - lastLogTime) > periodSeconds.secondsToNanos() && times.isNotEmpty()) {
-            _average = (nanosPerSecond / times.average()).roundToInt()
-            _min = (nanosPerSecond / times.maxOrNull()!!).roundToInt()
-            _max = (nanosPerSecond / times.minOrNull()!!).roundToInt()
+            average = (nanosPerSecond / times.average()).roundToInt()
+            min = (nanosPerSecond / times.maxOrNull()!!).roundToInt()
+            max = (nanosPerSecond / times.minOrNull()!!).roundToInt()
             times.clear()
             lastLogTime = time
+            if (logOnTick) {
+                println("[$timestamp] FPS $average ($min-$max)")
+            }
         }
     }
-
-    val average: Int
-        get() = _average
-
-    val min: Int
-        get() = _min
-
-    val max: Int
-        get() = _max
-
 
     private val nanosPerMillis = 1_000_000.0
     private val nanosPerSecond = 1_000_000_000.0

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skiko/GraphicsApi.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skiko/GraphicsApi.kt
@@ -26,6 +26,6 @@ enum class GpuPriority(val value: String) {
     Auto("auto"), Integrated("integrated"), Discrete("discrete");
 
     companion object {
-        fun parse(value: String?): GpuPriority? = GpuPriority.values().find { it.value == value }
+        fun parseOrNull(value: String): GpuPriority? = GpuPriority.values().find { it.value == value }
     }
 }

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/SkiaLayerProperties.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/SkiaLayerProperties.kt
@@ -4,4 +4,5 @@ internal data class SkiaLayerProperties(
     val isVsyncEnabled: Boolean = SkikoProperties.vsyncEnabled,
     val isVsyncFramelimitFallbackEnabled: Boolean = SkikoProperties.vsyncFramelimitFallbackEnabled,
     val renderApi: GraphicsApi = SkikoProperties.renderApi,
+    val adapterPriority: GpuPriority = SkikoProperties.gpuPriority,
 )


### PR DESCRIPTION
- Make SkikoProperties public, and don't cache the values, so users can change properties in runtime

- Deprecate skiko.directx.gpu.priority and skiko.directx.gpu.priority, introduce skiko.gpu.priority. There is no need in separate priority for macOs/DirectX

- Fix skiko.fps.enabled property