### PR TITLE
SkiaLayerAnalytics - send events for different steps of rendering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
           java-version: '11'
       - shell: bash
         run: |
-          ./gradlew --stacktrace --info -Pskiko.native.enabled=true -skiko.test.onci=true :skiko:awtTest
-          ./gradlew --stacktrace --info -Pskiko.native.enabled=true -skiko.test.onci=true :skiko:macosX64Test
+          ./gradlew --stacktrace --info -Pskiko.native.enabled=true -Pskiko.test.onci=true :skiko:awtTest
+          ./gradlew --stacktrace --info -Pskiko.native.enabled=true -Pskiko.test.onci=true :skiko:macosX64Test
           ./gradlew --stacktrace --info -Pskiko.native.enabled=true :skiko:publishToMavenLocal
           ./gradlew --stacktrace --info :SkiaAwtSample:installDist # check AWT sample works
       - uses: actions/upload-artifact@v2
@@ -51,7 +51,7 @@ jobs:
           java-version: '11'
       - shell: bash
         run: |
-          ./gradlew --stacktrace --info -Pskiko.native.enabled=true -skiko.test.onci=true :skiko:iosX64Test
+          ./gradlew --stacktrace --info -Pskiko.native.enabled=true -Pskiko.test.onci=true :skiko:iosX64Test
           ./gradlew --stacktrace --info -Pskiko.native.enabled=true :skiko:publishToMavenLocal
           # TODO run iOS specific tests on iPhone simulator
       - uses: actions/upload-artifact@v2
@@ -93,7 +93,7 @@ jobs:
           sudo apt-get install ninja-build fontconfig libfontconfig1-dev libglu1-mesa-dev libxrandr-dev libdbus-1-dev zip xvfb -y
           sudo Xvfb :0 -screen 0 1280x720x24 &
           export DISPLAY=:0
-          ./gradlew --stacktrace --info -Pskiko.native.enabled=true -Pkotlin.native.cacheKind.linuxX64=none -skiko.test.onci=true :skiko:linuxX64Test :skiko:awtTest
+          ./gradlew --stacktrace --info -Pskiko.native.enabled=true -Pkotlin.native.cacheKind.linuxX64=none -Pskiko.test.onci=true :skiko:linuxX64Test :skiko:awtTest
           ./gradlew --stacktrace --info -Pkotlin.native.cacheKind.linuxX64=none :skiko:publishToMavenLocal
           ./gradlew --stacktrace --info :SkiaAwtSample:installDist # check jvm sample works
           ./gradlew -Pskiko.android.enabled=true :skiko:publishSkikoJvmRuntimeAndroidX64PublicationToMavenLocal :skiko:publishSkikoJvmRuntimeAndroidArm64PublicationToMavenLocal :skiko:publishAndroidPublicationToMavenLocal
@@ -132,7 +132,7 @@ jobs:
            ./emsdk activate 2.0.29
            source ./emsdk_env.sh
            cd ..
-           ./gradlew --stacktrace --info -Pskiko.wasm.enabled=true -skiko.test.onci=true jsTest
+           ./gradlew --stacktrace --info -Pskiko.wasm.enabled=true -Pskiko.test.onci=true jsTest
            ./gradlew --stacktrace --info -Pskiko.wasm.enabled=true publishSkikoWasmRuntimePublicationToMavenLocal
        - uses: actions/upload-artifact@v2
          with:
@@ -152,7 +152,7 @@ jobs:
           java-version: '11'
       - shell: bash
         run: |
-          ./gradlew --stacktrace --info -skiko.test.onci=true :skiko:awtTest
+          ./gradlew --stacktrace --info -Pskiko.test.onci=true :skiko:awtTest
           ./gradlew --stacktrace --info :skiko:publishToMavenLocal
           ./gradlew --stacktrace --info :SkiaAwtSample:installDist # check jvm sample works
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
           java-version: '11'
       - shell: bash
         run: |
-          ./gradlew --stacktrace --info -Pskiko.native.enabled=true :skiko:awtTest
-          ./gradlew --stacktrace --info -Pskiko.native.enabled=true :skiko:macosX64Test
+          ./gradlew --stacktrace --info -Pskiko.native.enabled=true -skiko.test.onci=true :skiko:awtTest
+          ./gradlew --stacktrace --info -Pskiko.native.enabled=true -skiko.test.onci=true :skiko:macosX64Test
           ./gradlew --stacktrace --info -Pskiko.native.enabled=true :skiko:publishToMavenLocal
           ./gradlew --stacktrace --info :SkiaAwtSample:installDist # check AWT sample works
       - uses: actions/upload-artifact@v2
@@ -51,7 +51,7 @@ jobs:
           java-version: '11'
       - shell: bash
         run: |
-          ./gradlew --stacktrace --info -Pskiko.native.enabled=true :skiko:iosX64Test
+          ./gradlew --stacktrace --info -Pskiko.native.enabled=true -skiko.test.onci=true :skiko:iosX64Test
           ./gradlew --stacktrace --info -Pskiko.native.enabled=true :skiko:publishToMavenLocal
           # TODO run iOS specific tests on iPhone simulator
       - uses: actions/upload-artifact@v2
@@ -93,7 +93,7 @@ jobs:
           sudo apt-get install ninja-build fontconfig libfontconfig1-dev libglu1-mesa-dev libxrandr-dev libdbus-1-dev zip xvfb -y
           sudo Xvfb :0 -screen 0 1280x720x24 &
           export DISPLAY=:0
-          ./gradlew --stacktrace --info -Pskiko.native.enabled=true -Pkotlin.native.cacheKind.linuxX64=none :skiko:linuxX64Test :skiko:awtTest
+          ./gradlew --stacktrace --info -Pskiko.native.enabled=true -Pkotlin.native.cacheKind.linuxX64=none -skiko.test.onci=true :skiko:linuxX64Test :skiko:awtTest
           ./gradlew --stacktrace --info -Pkotlin.native.cacheKind.linuxX64=none :skiko:publishToMavenLocal
           ./gradlew --stacktrace --info :SkiaAwtSample:installDist # check jvm sample works
           ./gradlew -Pskiko.android.enabled=true :skiko:publishSkikoJvmRuntimeAndroidX64PublicationToMavenLocal :skiko:publishSkikoJvmRuntimeAndroidArm64PublicationToMavenLocal :skiko:publishAndroidPublicationToMavenLocal
@@ -132,7 +132,7 @@ jobs:
            ./emsdk activate 2.0.29
            source ./emsdk_env.sh
            cd ..
-           ./gradlew --stacktrace --info -Pskiko.wasm.enabled=true jsTest
+           ./gradlew --stacktrace --info -Pskiko.wasm.enabled=true -skiko.test.onci=true jsTest
            ./gradlew --stacktrace --info -Pskiko.wasm.enabled=true publishSkikoWasmRuntimePublicationToMavenLocal
        - uses: actions/upload-artifact@v2
          with:
@@ -152,7 +152,7 @@ jobs:
           java-version: '11'
       - shell: bash
         run: |
-          ./gradlew --stacktrace --info :skiko:awtTest
+          ./gradlew --stacktrace --info -skiko.test.onci=true :skiko:awtTest
           ./gradlew --stacktrace --info :skiko:publishToMavenLocal
           ./gradlew --stacktrace --info :SkiaAwtSample:installDist # check jvm sample works
       - uses: actions/upload-artifact@v2

--- a/skiko/build.gradle.kts
+++ b/skiko/build.gradle.kts
@@ -1082,7 +1082,10 @@ tasks.withType<Test>().configureEach {
         systemProperty("skiko.test.screenshots.dir", File(project.projectDir, "src/jvmTest/screenshots").absolutePath)
         systemProperty("skiko.test.font.dir", File(project.projectDir, "src/commonTest/resources/fonts").absolutePath)
 
-        val canRunUiTests = System.getProperty("os.name") != "Mac OS X"
+        val testingOnCI = System.getProperty("skiko.test.onci", "false").toBoolean()
+        val canRunPerformanceTests = testingOnCI
+        val canRunUiTests = testingOnCI || System.getProperty("os.name") != "Mac OS X"
+        systemProperty("skiko.test.performance.enabled", System.getProperty("skiko.test.performance.enabled", canRunPerformanceTests.toString()))
         systemProperty("skiko.test.ui.enabled", System.getProperty("skiko.test.ui.enabled", canRunUiTests.toString()))
         systemProperty("skiko.test.ui.renderApi", System.getProperty("skiko.test.ui.renderApi", "all"))
 

--- a/skiko/src/androidMain/kotlin/org/jetbrains/skiko/Actuals.android.kt
+++ b/skiko/src/androidMain/kotlin/org/jetbrains/skiko/Actuals.android.kt
@@ -26,6 +26,7 @@ internal actual fun makeDefaultRenderFactory(): RenderFactory {
         override fun createRedrawer(
             layer: SkiaLayer,
             renderApi: GraphicsApi,
+            analytics: SkiaLayerAnalytics,
             properties: SkiaLayerProperties
         ): Redrawer = when (hostOs) {
             OS.Android -> AndroidOpenGLRedrawer(layer, properties)

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/Actuals.awt.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/Actuals.awt.kt
@@ -17,27 +17,25 @@ internal actual fun makeDefaultRenderFactory(): RenderFactory {
         override fun createRedrawer(
             layer: SkiaLayer,
             renderApi: GraphicsApi,
+            analytics: SkiaLayerAnalytics,
             properties: SkiaLayerProperties
         ): Redrawer = when (hostOs) {
             OS.MacOS -> when (renderApi) {
-                GraphicsApi.SOFTWARE_COMPAT, GraphicsApi.SOFTWARE_FAST -> SoftwareRedrawer(layer, properties)
-                else -> MetalRedrawer(layer, properties)
+                GraphicsApi.SOFTWARE_COMPAT, GraphicsApi.SOFTWARE_FAST -> SoftwareRedrawer(layer, analytics, properties)
+                else -> MetalRedrawer(layer, analytics, properties)
             }
             OS.Windows -> when (renderApi) {
-                GraphicsApi.SOFTWARE_COMPAT -> SoftwareRedrawer(layer, properties)
-                GraphicsApi.SOFTWARE_FAST -> WindowsSoftwareRedrawer(layer, properties)
-                GraphicsApi.OPENGL -> WindowsOpenGLRedrawer(layer, properties)
-                else -> Direct3DRedrawer(layer, properties)
+                GraphicsApi.SOFTWARE_COMPAT -> SoftwareRedrawer(layer, analytics, properties)
+                GraphicsApi.SOFTWARE_FAST -> WindowsSoftwareRedrawer(layer, analytics, properties)
+                GraphicsApi.OPENGL -> WindowsOpenGLRedrawer(layer, analytics, properties)
+                else -> Direct3DRedrawer(layer, analytics, properties)
             }
             OS.Linux -> when (renderApi) {
-                GraphicsApi.SOFTWARE_COMPAT -> SoftwareRedrawer(layer, properties)
-                GraphicsApi.SOFTWARE_FAST -> LinuxSoftwareRedrawer(layer, properties)
-                else -> LinuxOpenGLRedrawer(layer, properties)
+                GraphicsApi.SOFTWARE_COMPAT -> SoftwareRedrawer(layer, analytics, properties)
+                GraphicsApi.SOFTWARE_FAST -> LinuxSoftwareRedrawer(layer, analytics, properties)
+                else -> LinuxOpenGLRedrawer(layer, analytics, properties)
             }
-            OS.Android -> TODO()
-            OS.JS, OS.Ios -> {
-                TODO("Commonize me")
-            }
+            OS.Android, OS.JS, OS.Ios -> throw UnsupportedOperationException("The awt target doesn't support $hostOs")
         }
     }
 }

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt
@@ -19,7 +19,8 @@ import javax.swing.UIManager
 actual open class SkiaLayer internal constructor(
     externalAccessibleFactory: ((Component) -> Accessible)? = null,
     private val properties: SkiaLayerProperties,
-    private val renderFactory: RenderFactory = RenderFactory.Default
+    private val renderFactory: RenderFactory = RenderFactory.Default,
+    private val analytics: SkiaLayerAnalytics = SkiaLayerAnalytics.Empty,
 ) : JPanel() {
 
     internal companion object {
@@ -52,6 +53,7 @@ actual open class SkiaLayer internal constructor(
         isVsyncEnabled: Boolean = SkikoProperties.vsyncEnabled,
         isVsyncFramelimitFallbackEnabled: Boolean = SkikoProperties.vsyncFramelimitFallbackEnabled,
         renderApi: GraphicsApi = SkikoProperties.renderApi,
+        analytics: SkiaLayerAnalytics = SkiaLayerAnalytics.Empty
     ) : this(
         externalAccessibleFactory,
         SkiaLayerProperties(
@@ -59,7 +61,8 @@ actual open class SkiaLayer internal constructor(
             isVsyncFramelimitFallbackEnabled,
             renderApi
         ),
-        RenderFactory.Default
+        RenderFactory.Default,
+        analytics,
     )
 
     val canvas: java.awt.Canvas
@@ -279,7 +282,7 @@ actual open class SkiaLayer internal constructor(
             try {
                 renderApi = fallbackRenderApiQueue.removeAt(0)
                 redrawer?.dispose()
-                redrawer = renderFactory.createRedrawer(this, renderApi, properties)
+                redrawer = renderFactory.createRedrawer(this, renderApi, analytics, properties)
                 redrawer?.syncSize()
             } catch (e: RenderException) {
                 println(e.message)

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/context/MetalContextHandler.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/context/MetalContextHandler.kt
@@ -61,7 +61,7 @@ internal class MetalContextHandler(layer: SkiaLayer) : JvmContextHandler(layer) 
 
     override fun rendererInfo(): String {
         return super.rendererInfo() +
-            "Video card: ${metalRedrawer.getAdapterName()}\n" +
-            "Total VRAM: ${metalRedrawer.getAdapterMemorySize() / 1024 / 1024} MB\n"
+            "Video card: ${metalRedrawer.adapterName}\n" +
+            "Total VRAM: ${metalRedrawer.adapterMemorySize / 1024 / 1024} MB\n"
     }
 }

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/AWTRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/AWTRedrawer.kt
@@ -1,0 +1,53 @@
+package org.jetbrains.skiko.redrawer
+
+import org.jetbrains.skiko.*
+import org.jetbrains.skiko.SkiaLayerAnalytics.DeviceAnalytics
+
+/**
+ * Common class for all AWT redrawers.
+ * Don't forget to call [onDeviceChosen] and [onContextInit] to send necessary analytics.
+ */
+@OptIn(ExperimentalSkikoApi::class)
+internal abstract class AWTRedrawer(
+    private val layer: SkiaLayer,
+    private val analytics: SkiaLayerAnalytics,
+    private val graphicsApi: GraphicsApi,
+) : Redrawer {
+    private var isFirstFrameRendered = false
+
+    private val rendererAnalytics = analytics.renderer(Version.skiko, hostOs, graphicsApi)
+    private var deviceAnalytics: DeviceAnalytics? = null
+
+    init {
+        rendererAnalytics.init()
+    }
+
+    /**
+     * Should be called when the device name is known as early, as possible.
+     */
+    protected fun onDeviceChosen(deviceName: String?) {
+        rendererAnalytics.deviceChosen()
+        deviceAnalytics = analytics.device(Version.skiko, hostOs, graphicsApi, deviceName)
+        deviceAnalytics?.init()
+    }
+
+    /**
+     * Should be called when initialization of graphic context is ended. Only call it after [onDeviceChosen]
+     */
+    protected fun onContextInit() {
+        deviceAnalytics?.contextInit()
+    }
+
+    protected fun update(nanoTime: Long) = layer.update(nanoTime)
+
+    protected inline fun inDrawScope(body: () -> Unit) {
+        if (!isFirstFrameRendered) {
+            deviceAnalytics?.beforeFirstFrameRender()
+        }
+        layer.inDrawScope(body)
+        if (!isFirstFrameRendered) {
+            deviceAnalytics?.afterFirstFrameRender()
+        }
+        isFirstFrameRendered = true
+    }
+}

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/AbstractDirectSoftwareRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/AbstractDirectSoftwareRedrawer.kt
@@ -55,7 +55,8 @@ internal abstract class AbstractDirectSoftwareRedrawer(
         disposeDevice(device)
         runBlocking {
             frameJob.cancelAndJoin()
-        }  
+        }
+        super.dispose()
     }
 
     private external fun resize(devicePtr: Long, width: Int, height: Int)

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/AbstractDirectSoftwareRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/AbstractDirectSoftwareRedrawer.kt
@@ -2,18 +2,15 @@ package org.jetbrains.skiko.redrawer
 
 import org.jetbrains.skia.Surface
 import kotlinx.coroutines.*
-import org.jetbrains.skiko.FrameDispatcher
+import org.jetbrains.skiko.*
 import org.jetbrains.skiko.FrameLimiter
-import org.jetbrains.skiko.RenderException
-import org.jetbrains.skiko.MainUIDispatcher
-import org.jetbrains.skiko.SkiaLayer
-import org.jetbrains.skiko.SkiaLayerProperties
 import org.jetbrains.skiko.context.DirectSoftwareContextHandler
 
 internal abstract class AbstractDirectSoftwareRedrawer(
     private val layer: SkiaLayer,
+    analytics: SkiaLayerAnalytics,
     private val properties: SkiaLayerProperties
-) : Redrawer {
+) : AWTRedrawer(layer, analytics, GraphicsApi.SOFTWARE_FAST) {
     private val contextHandler = DirectSoftwareContextHandler(layer)
     override val renderInfo: String get() = contextHandler.rendererInfo()
 
@@ -25,7 +22,7 @@ internal abstract class AbstractDirectSoftwareRedrawer(
         }
 
         if (layer.isShowing) {
-            layer.update(System.nanoTime())
+            update(System.nanoTime())
             draw()
         }
     }
@@ -36,11 +33,11 @@ internal abstract class AbstractDirectSoftwareRedrawer(
         frameDispatcher.scheduleFrame()
     }
 
-    protected open fun draw() = layer.inDrawScope(contextHandler::draw)
+    protected open fun draw() = inDrawScope(contextHandler::draw)
 
     override fun redrawImmediately() {
-        layer.update(System.nanoTime())
-        layer.inDrawScope(contextHandler::draw)
+        update(System.nanoTime())
+        draw()
     }
 
     open fun resize(width: Int, height: Int) = resize(device, width, height)

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/Direct3DRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/Direct3DRedrawer.kt
@@ -9,18 +9,26 @@ import org.jetbrains.skiko.context.Direct3DContextHandler
 
 internal class Direct3DRedrawer(
     private val layer: SkiaLayer,
+    analytics: SkiaLayerAnalytics,
     private val properties: SkiaLayerProperties
-) : Redrawer {
+) : AWTRedrawer(layer, analytics, GraphicsApi.DIRECT3D) {
     private val contextHandler = Direct3DContextHandler(layer)
     override val renderInfo: String get() = contextHandler.rendererInfo()
 
     private var isDisposed = false
     private var drawLock = Any()
 
-    private val device = createDirectXDevice(
-        properties.adapterPriority.ordinal, layer.contentHandle, layer.transparency
-    ).also {
-        if (it == 0L || !isVideoCardSupported(layer.renderApi)) {
+    private val device: Long
+    val adapterName: String
+    val adapterMemorySize: Long
+
+    init {
+        val adapter = chooseAdapter(properties.adapterPriority.ordinal)
+        adapterName = getAdapterName(adapter)
+        adapterMemorySize = getAdapterMemorySize(adapter)
+        onDeviceChosen(getAdapterName(adapter))
+        device = createDirectXDevice(adapter, layer.contentHandle, layer.transparency)
+        if (device == 0L) {
             throw RenderException("Failed to create DirectX12 device.")
         }
     }
@@ -30,6 +38,10 @@ internal class Direct3DRedrawer(
             update(System.nanoTime())
             draw()
         }
+    }
+
+    init {
+        onContextInit()
     }
 
     override fun dispose() = synchronized(drawLock) {
@@ -46,18 +58,14 @@ internal class Direct3DRedrawer(
 
     override fun redrawImmediately() {
         check(!isDisposed) { "Direct3DRedrawer is disposed" }
-        layer.inDrawScope {
-        layer.update(System.nanoTime())
+        inDrawScope {
+            update(System.nanoTime())
             drawAndSwap(withVsync = false)
         }
     }
 
-    private fun update(nanoTime: Long) {
-        layer.update(nanoTime)
-    }
-
     private suspend fun draw() {
-        layer.inDrawScope {
+        inDrawScope {
             withContext(Dispatchers.IO) {
                 drawAndSwap(withVsync = properties.isVsyncEnabled)
             }
@@ -84,10 +92,12 @@ internal class Direct3DRedrawer(
     fun getBufferIndex() = getBufferIndex(device)
     fun initSwapChain() = initSwapChain(device)
     fun initFence() = initFence(device)
-    val adapterName get() = getAdapterName(device)
-    val adapterMemorySize get() = getAdapterMemorySize(device)
 
-    private external fun createDirectXDevice(adapterPriority: Int, contentHandle: Long, transparency: Boolean): Long
+    // Called from native code
+    private fun isAdapterSupported(name: String) = isVideoCardSupported(GraphicsApi.DIRECT3D, name)
+
+    private external fun chooseAdapter(adapterPriority: Int): Long
+    private external fun createDirectXDevice(adapter: Long, contentHandle: Long, transparency: Boolean): Long
     private external fun makeDirectXContext(device: Long): Long
     private external fun makeDirectXSurface(device: Long, context: Long, width: Int, height: Int, index: Int): Long
     private external fun resizeBuffers(device: Long, width: Int, height: Int)
@@ -96,6 +106,6 @@ internal class Direct3DRedrawer(
     private external fun getBufferIndex(device: Long): Int
     private external fun initSwapChain(device: Long)
     private external fun initFence(device: Long)
-    private external fun getAdapterName(device: Long): String
-    private external fun getAdapterMemorySize(device: Long): Long
+    private external fun getAdapterName(adapter: Long): String
+    private external fun getAdapterMemorySize(adapter: Long): Long
 }

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/Direct3DRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/Direct3DRedrawer.kt
@@ -15,7 +15,6 @@ internal class Direct3DRedrawer(
     private val contextHandler = Direct3DContextHandler(layer)
     override val renderInfo: String get() = contextHandler.rendererInfo()
 
-    private var isDisposed = false
     private var drawLock = Any()
 
     private val device: Long
@@ -48,7 +47,7 @@ internal class Direct3DRedrawer(
         frameDispatcher.cancel()
         contextHandler.dispose()
         disposeDevice(device)
-        isDisposed = true
+        super.dispose()
     }
 
     override fun needRedraw() {

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/LinuxOpenGLRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/LinuxOpenGLRedrawer.kt
@@ -12,7 +12,6 @@ internal class LinuxOpenGLRedrawer(
     private val contextHandler = OpenGLContextHandler(layer)
     override val renderInfo: String get() = contextHandler.rendererInfo()
 
-    private var isDisposed = false
     private var context = 0L
     private val swapInterval = if (properties.isVsyncEnabled) 1 else 0
 
@@ -66,7 +65,7 @@ internal class LinuxOpenGLRedrawer(
         runBlocking {
             frameJob.cancelAndJoin()
         }
-        isDisposed = true
+        super.dispose()
     }
 
     override fun needRedraw() {

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/LinuxSoftwareRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/LinuxSoftwareRedrawer.kt
@@ -4,10 +4,12 @@ import org.jetbrains.skiko.*
 
 internal class LinuxSoftwareRedrawer(
     private val layer: SkiaLayer,
-    private val properties: SkiaLayerProperties
-) : AbstractDirectSoftwareRedrawer(layer, properties) {
+    analytics: SkiaLayerAnalytics,
+    properties: SkiaLayerProperties
+) : AbstractDirectSoftwareRedrawer(layer, analytics, properties) {
 
     init {
+        onDeviceChosen("Software")
         val scale = layer.contentScale
         val w = (layer.width * scale).toInt().coerceAtLeast(0)
         val h = (layer.height * scale).toInt().coerceAtLeast(0)
@@ -18,6 +20,7 @@ internal class LinuxSoftwareRedrawer(
                 }
             }
         }
+        onContextInit()
     }
 
     override fun dispose() = layer.backedLayer.lockLinuxDrawingSurface {

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
@@ -23,7 +23,6 @@ internal class MetalRedrawer(
             Library.load()
         }
     }
-    private var isDisposed = false
     private var drawLock = Any()
 
     private val device: Long
@@ -61,7 +60,7 @@ internal class MetalRedrawer(
         frameDispatcher.cancel()
         contextHandler.dispose()
         disposeDevice(device)
-        isDisposed = true
+        super.dispose()
     }
 
     override fun needRedraw() {

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
@@ -12,8 +12,9 @@ import javax.swing.SwingUtilities.*
 
 internal class MetalRedrawer(
     private val layer: SkiaLayer,
+    analytics: SkiaLayerAnalytics,
     private val properties: SkiaLayerProperties
-) : Redrawer {
+) : AWTRedrawer(layer, analytics, GraphicsApi.METAL) {
     private val contextHandler = MetalContextHandler(layer)
     override val renderInfo: String get() = contextHandler.rendererInfo()
 
@@ -24,9 +25,21 @@ internal class MetalRedrawer(
     }
     private var isDisposed = false
     private var drawLock = Any()
-    private val device = layer.backedLayer.useDrawingSurfacePlatformInfo {
-        createMetalDevice(layer.windowHandle, layer.transparency, properties.adapterPriority.ordinal, it)
+
+    private val device: Long
+    val adapterName: String
+    val adapterMemorySize: Long
+
+    init {
+        val adapter = chooseAdapter(properties.adapterPriority.ordinal)
+        adapterName = getAdapterName(adapter)
+        adapterMemorySize = getAdapterMemorySize(adapter)
+        onDeviceChosen(adapterName)
+        device = layer.backedLayer.useDrawingSurfacePlatformInfo {
+            createMetalDevice(layer.windowHandle, layer.transparency, adapter, it)
+        }
     }
+
     private val windowHandle = layer.windowHandle
 
     init {
@@ -38,6 +51,10 @@ internal class MetalRedrawer(
             update(System.nanoTime())
             draw()
         }
+    }
+
+    init {
+        onContextInit()
     }
 
     override fun dispose() = synchronized(drawLock) {
@@ -54,16 +71,12 @@ internal class MetalRedrawer(
 
     override fun redrawImmediately() {
         check(!isDisposed) { "MetalRedrawer is disposed" }
-        layer.inDrawScope {
+        inDrawScope {
             setVSyncEnabled(device, enabled = false)
             update(System.nanoTime())
             performDraw()
             setVSyncEnabled(device, properties.isVsyncEnabled)
         }
-    }
-
-    private fun update(nanoTime: Long) {
-        layer.update(nanoTime)
     }
 
     private suspend fun draw() {
@@ -78,7 +91,7 @@ internal class MetalRedrawer(
         //
         // Executors.newSingleThreadExecutor().asCoroutineDispatcher(): 50 FPS, 150% CPU
         // Dispatchers.IO: 50 FPS, 200% CPU
-        layer.inDrawScope {
+        inDrawScope {
             withContext(Dispatchers.IO) {
                 performDraw()
             }
@@ -127,10 +140,8 @@ internal class MetalRedrawer(
 
     fun finishFrame() = finishFrame(device)
 
-    fun getAdapterName(): String = getAdapterName(device)
-    fun getAdapterMemorySize(): Long = getAdapterMemorySize(device)
-
-    private external fun createMetalDevice(window:Long, transparency: Boolean, adapterPriority: Int, platformInfo: Long): Long
+    private external fun chooseAdapter(adapterPriority: Int): Long
+    private external fun createMetalDevice(window:Long, transparency: Boolean, adapter: Long, platformInfo: Long): Long
     private external fun makeMetalContext(device: Long): Long
     private external fun makeMetalRenderTarget(device: Long, width: Int, height: Int): Long
     private external fun disposeDevice(device: Long)
@@ -139,8 +150,8 @@ internal class MetalRedrawer(
     private external fun setContentScale(device: Long, contentScale: Float)
     private external fun setVSyncEnabled(device: Long, enabled: Boolean)
     private external fun isOccluded(window: Long): Boolean
-    private external fun getAdapterName(device: Long): String
-    private external fun getAdapterMemorySize(device: Long): Long
+    private external fun getAdapterName(adapter: Long): String
+    private external fun getAdapterMemorySize(adapter: Long): Long
     private external fun startRendering(): Long
     private external fun endRendering(handle: Long)
 }

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/SoftwareRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/SoftwareRedrawer.kt
@@ -41,6 +41,7 @@ internal class SoftwareRedrawer(
         runBlocking {
             frameJob.cancelAndJoin()
         }
+        super.dispose()
     }
 
     override fun needRedraw() {

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/SoftwareRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/SoftwareRedrawer.kt
@@ -1,17 +1,19 @@
 package org.jetbrains.skiko.redrawer
 
 import kotlinx.coroutines.*
-import org.jetbrains.skiko.FrameDispatcher
+import org.jetbrains.skiko.*
 import org.jetbrains.skiko.FrameLimiter
-import org.jetbrains.skiko.MainUIDispatcher
-import org.jetbrains.skiko.SkiaLayer
-import org.jetbrains.skiko.SkiaLayerProperties
 import org.jetbrains.skiko.context.SoftwareContextHandler
 
 internal class SoftwareRedrawer(
     private val layer: SkiaLayer,
+    analytics: SkiaLayerAnalytics,
     private val properties: SkiaLayerProperties
-) : Redrawer {
+) : AWTRedrawer(layer, analytics, GraphicsApi.SOFTWARE_FAST) {
+    init {
+        onDeviceChosen("Software")
+    }
+
     private val contextHandler = SoftwareContextHandler(layer)
     override val renderInfo: String get() = contextHandler.rendererInfo()
 
@@ -24,9 +26,13 @@ internal class SoftwareRedrawer(
         }
 
         if (layer.isShowing) {
-            layer.update(System.nanoTime())
-            layer.inDrawScope(contextHandler::draw)
+            update(System.nanoTime())
+            inDrawScope(contextHandler::draw)
         }
+    }
+
+    init {
+        onContextInit()
     }
 
     override fun dispose() {
@@ -42,7 +48,7 @@ internal class SoftwareRedrawer(
     }
 
     override fun redrawImmediately() {
-        layer.update(System.nanoTime())
-        layer.inDrawScope(contextHandler::draw)
+        update(System.nanoTime())
+        inDrawScope(contextHandler::draw)
     }
 }

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/WindowsOpenGLRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/WindowsOpenGLRedrawer.kt
@@ -25,7 +25,6 @@ internal class WindowsOpenGLRedrawer(
         }
         onDeviceChosen(adapterName)
     }
-    private var isDisposed = false
 
     private val adapterName get() = OpenGLApi.instance.glGetString(OpenGLApi.instance.GL_RENDERER)
 
@@ -44,7 +43,7 @@ internal class WindowsOpenGLRedrawer(
         makeCurrent()
         contextHandler.dispose()
         deleteContext(context)
-        isDisposed = true
+        super.dispose()
     }
 
     override fun needRedraw() {

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/WindowsSoftwareRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/WindowsSoftwareRedrawer.kt
@@ -3,18 +3,22 @@ package org.jetbrains.skiko.redrawer
 import org.jetbrains.skiko.SkiaLayer
 import org.jetbrains.skiko.SkiaLayerProperties
 import org.jetbrains.skiko.RenderException
+import org.jetbrains.skiko.SkiaLayerAnalytics
 
 internal class WindowsSoftwareRedrawer(
     layer: SkiaLayer,
+    analytics: SkiaLayerAnalytics,
     properties: SkiaLayerProperties
-) : AbstractDirectSoftwareRedrawer(layer, properties) {
+) : AbstractDirectSoftwareRedrawer(layer, analytics, properties) {
 
     init {
+        onDeviceChosen("Software")
         device = createDevice(layer.contentHandle, layer.transparency).also {
             if (it == 0L) {
                 throw RenderException("Failed to create Software device")
             }
         }
+        onContextInit()
     }
 
     private external fun createDevice(contentHandle: Long, transparency: Boolean): Long

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skiko/Annotations.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skiko/Annotations.kt
@@ -15,3 +15,15 @@ package org.jetbrains.skiko
             " Make sure you fully read and understand documentation of the declaration that is marked as a delicate API."
 )
 annotation class DelicateSkikoApi
+
+/**
+ * Marks declarations that are experimental and don't have stable API yet.
+ */
+@MustBeDocumented
+@Retention(value = AnnotationRetention.BINARY)
+@RequiresOptIn(
+    level = RequiresOptIn.Level.WARNING,
+    message = "This is an experimental API and can be changed in the near future. The behaviour isn't properly tested" +
+            "and can have bugs."
+)
+annotation class ExperimentalSkikoApi

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skiko/SkiaLayerAnalytics.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skiko/SkiaLayerAnalytics.kt
@@ -1,0 +1,54 @@
+package org.jetbrains.skiko
+
+/**
+ * Analytics that helps to know more about SkiaLayer behaviour.
+ * Implementation usually uses third-party solution to send info to some centralized analytics gatherer.
+ */
+interface SkiaLayerAnalytics {
+    /**
+     * Create analytics for a renderer with specific API. Can be called multiple times because of API fallbacks.
+     */
+    @ExperimentalSkikoApi
+    fun renderer(
+        skikoVersion: String,
+        os: OS,
+        api: GraphicsApi
+    ): RendererAnalytics = RendererAnalytics.Empty
+
+    /**
+     * Create analytics for a device with specific API and name. Can be called multiple times because of API fallbacks.
+     */
+    @ExperimentalSkikoApi
+    fun device(
+        skikoVersion: String,
+        os: OS,
+        api: GraphicsApi,
+        deviceName: String?
+    ): DeviceAnalytics = DeviceAnalytics.Empty
+
+    @ExperimentalSkikoApi
+    interface RendererAnalytics {
+        fun init() = Unit
+        fun deviceChosen() = Unit
+
+        companion object {
+            val Empty = object : RendererAnalytics {}
+        }
+    }
+
+    @ExperimentalSkikoApi
+    interface DeviceAnalytics {
+        fun init() = Unit
+        fun contextInit() = Unit
+        fun beforeFirstFrameRender() = Unit
+        fun afterFirstFrameRender() = Unit
+
+        companion object {
+            val Empty = object : DeviceAnalytics {}
+        }
+    }
+
+    companion object {
+        val Empty = object : SkiaLayerAnalytics {}
+    }
+}

--- a/skiko/src/jvmMain/cpp/windows/exceptions_handler.cc
+++ b/skiko/src/jvmMain/cpp/windows/exceptions_handler.cc
@@ -73,8 +73,8 @@ void logJavaException(JNIEnv *env, const char *function, DWORD sehCode)
         char buffer[200];
         int result = snprintf(
             buffer, sizeof(buffer) - 1, "Native exception in [%s]:\nSEH description: %s\n", function, getDescription(sehCode));
-        jclass logClass = env->FindClass("org/jetbrains/skiko/RenderExceptionsHandler");
-        jmethodID logMethod = env->GetStaticMethodID(logClass, "logAndThrow", "(Ljava/lang/String;)V");
+        static jclass logClass = (jclass) env->NewGlobalRef(env->FindClass("org/jetbrains/skiko/RenderExceptionsHandler"));
+        static jmethodID logMethod = env->GetStaticMethodID(logClass, "throwException", "(Ljava/lang/String;)V");
         env->CallStaticVoidMethod(logClass, logMethod, env->NewStringUTF(buffer));
     }
 }

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/GraphicsApi.jvm.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/GraphicsApi.jvm.kt
@@ -1,32 +1,25 @@
 package org.jetbrains.skiko
 
-private val notSupportedAdapters by lazy {
-    val resource = SkiaLayer::class.java.getResource("/not-supported-adapter.list").readText()
-    resource.split(";").map { it.trim() }
-}
-
-internal fun isVideoCardSupported(renderApi: GraphicsApi): Boolean {
-    return when (renderApi) {
-        GraphicsApi.DIRECT3D -> {
-            true
+private val notSupportedAdapters: Set<NotSupportedAdapter> by lazy {
+    val resource = SkiaLayer::class.java.getResource("/not-supported-adapter.list")?.readText().orEmpty()
+    resource.splitToSequence(";").map { it.trim() }.mapNotNullTo(mutableSetOf()) {
+        val splits = it.split(":")
+        val api = when (splits.getOrNull(0)) {
+            "directx" -> GraphicsApi.DIRECT3D
+            "opengl" -> GraphicsApi.OPENGL
+            else -> return@mapNotNullTo null
         }
-        GraphicsApi.OPENGL -> {
-            val gl = OpenGLApi.instance
-            val adaptersList = notSupportedAdapters.filter { it.startsWith("opengl:") }.map {
-                it.replace("opengl:", "")
-            }
-            var adapter = gl.glGetString(gl.GL_RENDERER).also {
-                if (it == null) { return false }
-            }
-            adaptersList.forEach {
-                if (adapter?.startsWith(it) == true) {
-                    return false
-                }
-            }
-            true
-        }
-        else -> true
+        val name = splits.getOrNull(1) ?: return@mapNotNullTo null
+        NotSupportedAdapter(api, name)
     }
 }
 
-private external fun getNextDirectXAdapter(index: Int = 0): String?
+internal fun isVideoCardSupported(
+    api: GraphicsApi,
+    name: String?
+): Boolean = name == null || !notSupportedAdapters.contains(NotSupportedAdapter(api, name))
+
+private data class NotSupportedAdapter(
+    val api: GraphicsApi,
+    val name: String
+)

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/RenderFactory.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/RenderFactory.kt
@@ -3,7 +3,12 @@ package org.jetbrains.skiko
 import org.jetbrains.skiko.redrawer.*
 
 internal interface RenderFactory {
-    fun createRedrawer(layer: SkiaLayer, renderApi: GraphicsApi, properties: SkiaLayerProperties): Redrawer
+    fun createRedrawer(
+        layer: SkiaLayer,
+        renderApi: GraphicsApi,
+        analytics: SkiaLayerAnalytics,
+        properties: SkiaLayerProperties
+    ): Redrawer
 
     companion object {
         val Default = makeDefaultRenderFactory()

--- a/skiko/src/jvmTest/kotlin/org/jetbrains/skiko/SkiaLayerPerformanceTest.kt
+++ b/skiko/src/jvmTest/kotlin/org/jetbrains/skiko/SkiaLayerPerformanceTest.kt
@@ -5,6 +5,7 @@ import org.jetbrains.skia.*
 import org.jetbrains.skiko.util.UiTestScope
 import org.jetbrains.skiko.util.UiTestWindow
 import org.jetbrains.skiko.util.uiTest
+import org.junit.Assume.assumeTrue
 import org.junit.Test
 import java.awt.Point
 import javax.swing.WindowConstants
@@ -128,6 +129,8 @@ class SkiaLayerPerformanceTest {
 
     @Test
     fun `FPS is near display refresh rate (multiple windows)`() = uiTest {
+        assumeTrue(System.getProperty("skiko.test.performance.enabled", "true") == "true")
+
         val helpers = (1..3).map { index ->
             performanceHelper(width = 40, height = 20, frameCount = 300, deviatedTerminalCount = 20).apply {
                 window.toFront()

--- a/skiko/src/jvmTest/kotlin/org/jetbrains/skiko/util/UiTest.kt
+++ b/skiko/src/jvmTest/kotlin/org/jetbrains/skiko/util/UiTest.kt
@@ -33,10 +33,12 @@ internal class UiTestScope(
 ) : CoroutineScope by scope {
     fun UiTestWindow(
         properties: SkiaLayerProperties = SkiaLayerProperties(),
+        analytics: SkiaLayerAnalytics = SkiaLayerAnalytics.Empty,
         renderFactory: RenderFactory = RenderFactory.Default
     ) = object : UiTestWindow() {
         override val layer: SkiaLayer = SkiaLayer(
             properties = properties.copy(renderApi = renderApi),
+            analytics = analytics,
             renderFactory = renderFactory
         )
 


### PR DESCRIPTION
It will help us to detect GPU's, on which we have crashes. After we compare two events, and if in the second event we have less hits, it means we have a crash. We can investigate it, and if the issue only in GPU, we will add it to not-supported-adapter.list

The plan to integrate this analytics to Toolbox.