### PR TITLE
add dxgi.lib for windows linkJvmBindings

### DIFF
--- a/skiko/build.gradle.kts
+++ b/skiko/build.gradle.kts
@@ -943,6 +943,7 @@ fun createLinkJvmBindings(
                     "opengl32.lib",
                     "shcore.lib",
                     "user32.lib",
+                    "dxgi.lib",
                 )
             }
             OS.Android -> {


### PR DESCRIPTION
Debug build failure for windows in Teamcity:
```
Successfully started process 'command 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\bin\HostX64\x64\link.exe''
     Creating library Z:\\BuildAgent\\work\\a64d3aa477d12f6b\\skiko\\build\\out\\link\\Debug-windows-x64\\skiko-windows-x64.lib and object Z:\\BuildAgent\\work\\a64d3aa477d12f6b\\skiko\\build\\out\\link\\Debug-windows-x64\\skiko-windows-x64.exp
  skia.lib(gpu.GrD3DGpu.obj) : error LNK2019:  ----> unresolved external symbol DXGIGetDebugInterface1 <----     referenced in function "private: __cdecl GrD3DGpu::GrD3DGpu(class GrDirectContext *,struct GrContextOptions const &,struct GrD3DBackendContext const &,class sk_sp<class GrD3DMemoryAllocator>)" (??0GrD3DGpu@@AEAA@PEAVGrDirectContext@@AEBUGrContextOptions@@AEBUGrD3DBackendContext@@V?$sk_sp@VGrD3DMemoryAllocator@@@@@Z)
  Z:\\BuildAgent\\work\\a64d3aa477d12f6b\\skiko\\build\\out\\link\\Debug-windows-x64\\skiko-windows-x64.dll : fatal error LNK1120: 1 unresolved externals
> Task :linkJvmBindingsWindowsX64 FAILED
```

From skia sources:
`# DXGIGetDebugInterface1 is defined in dxgi.lib`