### PR TITLE
add dxgi.lib only for DEBUG build

### DIFF
--- a/skiko/build.gradle.kts
+++ b/skiko/build.gradle.kts
@@ -933,18 +933,20 @@ fun createLinkJvmBindings(
             OS.Windows -> {
                 linker.set(windowsSdkPaths.linker.absolutePath)
                 libDirs.set(windowsSdkPaths.libDirs)
-                osFlags = arrayOf(
-                    *buildType.msvcLinkerFlags,
-                    "/NOLOGO",
-                    "/DLL",
-                    "Advapi32.lib",
-                    "gdi32.lib",
-                    "Dwmapi.lib",
-                    "opengl32.lib",
-                    "shcore.lib",
-                    "user32.lib",
-                    "dxgi.lib",
-                )
+                osFlags = mutableListOf<String>().apply {
+                    addAll(buildType.msvcLinkerFlags)
+                    addAll(arrayOf(
+                        "/NOLOGO",
+                        "/DLL",
+                        "Advapi32.lib",
+                        "gdi32.lib",
+                        "Dwmapi.lib",
+                        "opengl32.lib",
+                        "shcore.lib",
+                        "user32.lib",
+                    ))
+                    if (buildType == SkiaBuildType.DEBUG) add("dxgi.lib")
+                }.toTypedArray()
             }
             OS.Android -> {
                 osFlags = arrayOf(


### PR DESCRIPTION
From skia sources:
DXGIGetDebugInterface1 is defined in dxgi.lib.
But this API is tagged as a development-only capability which implies that linking to this function will cause the application to fail Windows store certification