### PR TITLE
Fix getting text from clipboard

### DIFF
--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/Actuals.awt.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/Actuals.awt.kt
@@ -7,6 +7,7 @@ import java.awt.Toolkit
 import java.awt.datatransfer.DataFlavor
 import java.awt.datatransfer.StringSelection
 import java.awt.datatransfer.UnsupportedFlavorException
+import java.io.IOException
 import java.net.URI
 import javax.swing.UIManager
 
@@ -58,7 +59,9 @@ internal actual fun ClipboardManager_setText(text: String) {
 internal actual fun ClipboardManager_getText(): String? {
     return try {
         systemClipboard?.getData(DataFlavor.stringFlavor) as String?
-    } catch (_: UnsupportedFlavorException) {
+    } catch (_: Exception) {
+        null
+    } catch (_: IOException) {
         null
     }
 }

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/Actuals.awt.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/Actuals.awt.kt
@@ -59,7 +59,7 @@ internal actual fun ClipboardManager_setText(text: String) {
 internal actual fun ClipboardManager_getText(): String? {
     return try {
         systemClipboard?.getData(DataFlavor.stringFlavor) as String?
-    } catch (_: Exception) {
+    } catch (_: UnsupportedFlavorException) {
         null
     } catch (_: IOException) {
         null


### PR DESCRIPTION
Sometimes, internal AWT implementation can't properly parse the clipboard data.

getData's docs say that it can throw IOException

Fixes https://github.com/JetBrains/compose-jb/issues/2098