### PR TITLE
Expose SkiaLayer.redrawImmediately

### DIFF
--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt
@@ -484,6 +484,17 @@ actual open class SkiaLayer internal constructor(
         redrawer?.needRedraw()
     }
 
+    /**
+     * Redraw content immediately and synchronously, without waiting for the next vsync.
+     *
+     * After we exit this method, the display graphical buffer contain the new drawn content.
+     */
+    fun redrawImmediately() {
+        check(isEventDispatchThread()) { "Method should be called from AWT event dispatch thread" }
+        check(!isDisposed) { "SkiaLayer is disposed" }
+        redrawer?.redrawImmediately()
+    }
+
     @Suppress("LeakingThis")
     private val fpsCounter = defaultFPSCounter(this)
 

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/Direct3DRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/Direct3DRedrawer.kt
@@ -57,8 +57,8 @@ internal class Direct3DRedrawer(
 
     override fun redrawImmediately() {
         check(!isDisposed) { "Direct3DRedrawer is disposed" }
+        update(System.nanoTime())
         inDrawScope {
-            update(System.nanoTime())
             drawAndSwap(withVsync = false)
         }
     }

--- a/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
+++ b/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
@@ -655,7 +655,9 @@ class SkiaLayerTest {
             repeat(10) {
                 val renderCountOld = renderCount
                 window.layer.redrawImmediately()
-                assertEquals(renderCountOld + 1, renderCount)
+                // onRender can be called multiple times during redrawImmediately
+                // (when we fallback to another render api)
+                assertTrue(renderCount > renderCountOld)
             }
         } finally {
             window.close()

--- a/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
+++ b/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
@@ -636,6 +636,32 @@ class SkiaLayerTest {
         }
     }
 
+    @Test
+    fun `render immediately`() = uiTest {
+        val window = UiTestWindow()
+        try {
+            var renderCount = 0
+            window.setLocation(200, 200)
+            window.setSize(400, 200)
+            window.defaultCloseOperation = WindowConstants.DISPOSE_ON_CLOSE
+            window.layer.skikoView = object : SkikoView {
+                override fun onRender(canvas: Canvas, width: Int, height: Int, nanoTime: Long) {
+                    renderCount++
+                }
+            }
+            window.isUndecorated = true
+            window.isVisible = true
+
+            repeat(10) {
+                val renderCountOld = renderCount
+                window.layer.redrawImmediately()
+                assertEquals(renderCountOld + 1, renderCount)
+            }
+        } finally {
+            window.close()
+        }
+    }
+
     private fun testRenderText(os: OS) = uiTest {
         assumeTrue(hostOs == os)
 


### PR DESCRIPTION
Sometimes we need to update the current frame as fast as we can to avoid input lag.

For example, when we typed a character, or scrolled a list. If we render the new state only on the next frame, the user will experience input lag:
```
event -> change state -> needRedraw -> vsync -> draw -> vsync
```
If we would call this:
```
event -> change state -> redrawImmediately -> vsync
```
then there is no input lag.

We can't know in what condition we need to call it. The caller of SkiaLayer should decide it by itself. Usually it should be called when we change some state in response to an input event.