### PR TITLE
Fix clipboard

### DIFF
--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/Actuals.awt.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/Actuals.awt.kt
@@ -61,6 +61,8 @@ internal actual fun ClipboardManager_getText(): String? {
         systemClipboard?.getData(DataFlavor.stringFlavor) as String?
     } catch (_: UnsupportedFlavorException) {
         null
+    } catch (_: IllegalStateException) {
+        null
     } catch (_: IOException) {
         null
     }


### PR DESCRIPTION
We need to also catch IllegalStateException. It is said in the JavaDoc and mentioned here:

https://github.com/JetBrains/compose-jb/issues/2098#issuecomment-1234693644