### PR TITLE
Throw a java exception on native crash by default (Windows, Linux)

### DIFF
--- a/skiko/src/awtMain/cpp/include/exceptions_handler.h
+++ b/skiko/src/awtMain/cpp/include/exceptions_handler.h
@@ -4,6 +4,6 @@
 #include <windows.h>
 #include <stdio.h>
 
-void logJavaException(JNIEnv *env, const char * function, DWORD sehCode);
+void throwJavaException(JNIEnv *env, const char * function, DWORD sehCode);
 
 #endif

--- a/skiko/src/awtMain/cpp/windows/SoftwareRedrawer.cc
+++ b/skiko/src/awtMain/cpp/windows/SoftwareRedrawer.cc
@@ -61,7 +61,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            logJavaException(env, __FUNCTION__, code);
+            throwJavaException(env, __FUNCTION__, code);
         }
     }
 
@@ -88,7 +88,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            logJavaException(env, __FUNCTION__, code);
+            throwJavaException(env, __FUNCTION__, code);
         }
     }
 

--- a/skiko/src/awtMain/cpp/windows/direct3DContext.cc
+++ b/skiko/src/awtMain/cpp/windows/direct3DContext.cc
@@ -25,7 +25,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            logJavaException(env, __FUNCTION__, code);
+            throwJavaException(env, __FUNCTION__, code);
         }
     }
 }

--- a/skiko/src/awtMain/cpp/windows/directXRedrawer.cc
+++ b/skiko/src/awtMain/cpp/windows/directXRedrawer.cc
@@ -321,7 +321,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            logJavaException(env, __FUNCTION__, code);
+            throwJavaException(env, __FUNCTION__, code);
         }
     }
 
@@ -341,7 +341,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            logJavaException(env, __FUNCTION__, code);
+            throwJavaException(env, __FUNCTION__, code);
         }
     }
 
@@ -396,7 +396,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            logJavaException(env, __FUNCTION__, code);
+            throwJavaException(env, __FUNCTION__, code);
         }
     }
 
@@ -413,7 +413,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            logJavaException(env, __FUNCTION__, code);
+            throwJavaException(env, __FUNCTION__, code);
         }
     }
 
@@ -441,7 +441,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            logJavaException(env, __FUNCTION__, code);
+            throwJavaException(env, __FUNCTION__, code);
         }
     }
 

--- a/skiko/src/awtMain/cpp/windows/openGLRedrawer.cc
+++ b/skiko/src/awtMain/cpp/windows/openGLRedrawer.cc
@@ -34,7 +34,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            logJavaException(env, __FUNCTION__, code);
+            throwJavaException(env, __FUNCTION__, code);
         }
         return (jlong) 0;
     }
@@ -54,7 +54,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            logJavaException(env, __FUNCTION__, code);
+            throwJavaException(env, __FUNCTION__, code);
         }
     }
 
@@ -67,7 +67,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            logJavaException(env, __FUNCTION__, code);
+            throwJavaException(env, __FUNCTION__, code);
         }
     }
 
@@ -93,7 +93,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            logJavaException(env, __FUNCTION__, code);
+            throwJavaException(env, __FUNCTION__, code);
         }
         return (jlong) 0;
     }


### PR DESCRIPTION
This was enabled in Toolbox, and it seems work without issues.

When we throw RenderException, we fallback to the next render API.