### PR TITLE
Add binding for SkSurface::draw() that takes sampling parameter

### DIFF
--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Surface.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Surface.kt
@@ -780,9 +780,27 @@ class Surface : RefCnt {
      * @see [https://fiddle.skia.org/c/@Surface_draw](https://fiddle.skia.org/c/@Surface_draw)
      */
     fun draw(canvas: Canvas?, x: Int, y: Int, paint: Paint?) {
+        draw(canvas, x, y, SamplingMode.DEFAULT, paint)
+    }
+
+    /**
+     *
+     * Draws Surface contents to canvas, with its top-left corner at (x, y).
+     *
+     *
+     * If Paint paint is not null, apply ColorFilter, alpha, ImageFilter, and BlendMode.
+     *
+     * @param canvas Canvas drawn into
+     * @param x      horizontal offset in Canvas
+     * @param y      vertical offset in Canvas
+     * @param sampling	what technique to use when sampling the surface pixels
+     * @param paint  Paint containing BlendMode, ColorFilter, ImageFilter, and so on; or null
+     * @see [https://fiddle.skia.org/c/@Surface_draw](https://fiddle.skia.org/c/@Surface_draw)
+     */
+    fun draw(canvas: Canvas?, x: Int, y: Int, samplingMode: SamplingMode, paint: Paint?) {
         try {
             Stats.onNativeCall()
-            _nDraw(_ptr, getPtr(canvas), x.toFloat(), y.toFloat(), getPtr(paint))
+            _nDraw(_ptr, getPtr(canvas), x.toFloat(), y.toFloat(), samplingMode._packedInt1(), samplingMode._packedInt2(), getPtr(paint))
         } finally {
             reachabilityBarrier(this)
             reachabilityBarrier(canvas)
@@ -1116,7 +1134,7 @@ private external fun _nMakeImageSnapshot(ptr: NativePointer): NativePointer
 private external fun _nMakeImageSnapshotR(ptr: NativePointer, left: Int, top: Int, right: Int, bottom: Int): NativePointer
 
 @ExternalSymbolName("org_jetbrains_skia_Surface__1nDraw")
-private external fun _nDraw(ptr: NativePointer, canvasPtr: NativePointer, x: Float, y: Float, paintPtr: NativePointer)
+private external fun _nDraw(ptr: NativePointer, canvasPtr: NativePointer, x: Float, y: Float, samplingModeValue1: Int, samplingModeValue2: Int, paintPtr: NativePointer)
 
 @ExternalSymbolName("org_jetbrains_skia_Surface__1nPeekPixels")
 private external fun _nPeekPixels(ptr: NativePointer, pixmapPtr: NativePointer): Boolean

--- a/skiko/src/jvmMain/cpp/common/Surface.cc
+++ b/skiko/src/jvmMain/cpp/common/Surface.cc
@@ -255,11 +255,11 @@ extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_SurfaceKt__1nMakeSurf
 }
 
 extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_SurfaceKt__1nDraw
-  (JNIEnv* env, jclass jclass, jlong ptr, jlong canvasPtr, jfloat x, jfloat y, jlong paintPtr) {
+  (JNIEnv* env, jclass jclass, jlong ptr, jlong canvasPtr, jfloat x, jfloat y, jint samplingModeVal1, jint samplingModeVal2, jlong paintPtr) {
     SkSurface* surface = reinterpret_cast<SkSurface*>(static_cast<uintptr_t>(ptr));
     SkCanvas* canvas = reinterpret_cast<SkCanvas*>(static_cast<uintptr_t>(canvasPtr));
     SkPaint* paint = reinterpret_cast<SkPaint*>(static_cast<uintptr_t>(paintPtr));
-    surface->draw(canvas, x, y, paint);
+    surface->draw(canvas, x, y, skija::SamplingMode::unpackFrom2Ints(env, samplingModeVal1, samplingModeVal2), paint);
 }
 
 extern "C" JNIEXPORT jboolean JNICALL Java_org_jetbrains_skia_SurfaceKt__1nPeekPixels

--- a/skiko/src/nativeJsMain/cpp/Surface.cc
+++ b/skiko/src/nativeJsMain/cpp/Surface.cc
@@ -266,11 +266,11 @@ SKIKO_EXPORT KNativePointer org_jetbrains_skia_Surface__1nMakeSurfaceI
 }
 
 SKIKO_EXPORT void org_jetbrains_skia_Surface__1nDraw
-  (KNativePointer ptr, KNativePointer canvasPtr, KFloat x, KFloat y, KNativePointer paintPtr) {
+  (KNativePointer ptr, KNativePointer canvasPtr, KFloat x, KFloat y, KInt samplingModeValue1, KInt samplingModeValue2, KNativePointer paintPtr) {
     SkSurface* surface = reinterpret_cast<SkSurface*>((ptr));
     SkCanvas* canvas = reinterpret_cast<SkCanvas*>((canvasPtr));
     SkPaint* paint = reinterpret_cast<SkPaint*>((paintPtr));
-    surface->draw(canvas, x, y, paint);
+    surface->draw(canvas, x, y, skija::SamplingMode::unpackFrom2Ints(samplingModeValue1, samplingModeValue2), paint);
 }
 
 SKIKO_EXPORT KBoolean org_jetbrains_skia_Surface__1nPeekPixels


### PR DESCRIPTION
Question: why is SamplingMode mode being packed as two ints instead of one long?