### PR TITLE
Java 8 compatible

### DIFF
--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/context/Direct3DContextHandler.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/context/Direct3DContextHandler.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.skiko.context
 
 import org.jetbrains.skia.Surface
+import org.jetbrains.skia.impl.reachabilityBarrier
 import org.jetbrains.skia.impl.getPtr
 import org.jetbrains.skiko.SkiaLayer
 import org.jetbrains.skiko.redrawer.Direct3DRedrawer
@@ -61,7 +62,7 @@ internal class Direct3DContextHandler(layer: SkiaLayer) : JvmContextHandler(laye
                     surfaces[bufferIndex] = directXRedrawer.makeSurface(getPtr(context!!), w, h, bufferIndex)
                 }
             } finally {
-                Reference.reachabilityFence(context!!)
+                reachabilityBarrier(context!!)
             }
 
             if (!isD3DInited) {
@@ -80,8 +81,8 @@ internal class Direct3DContextHandler(layer: SkiaLayer) : JvmContextHandler(laye
                 getPtr(surface!!)
             )
         } finally {
-            Reference.reachabilityFence(context!!)
-            Reference.reachabilityFence(surface!!)
+            reachabilityBarrier(context!!)
+            reachabilityBarrier(surface!!)
         }
     }
 

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/context/DirectSoftwareContextHandler.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/context/DirectSoftwareContextHandler.kt
@@ -2,6 +2,7 @@ package org.jetbrains.skiko.context
 
 import org.jetbrains.skia.impl.getPtr
 import org.jetbrains.skiko.SkiaLayer
+import org.jetbrains.skia.impl.reachabilityBarrier
 import org.jetbrains.skiko.redrawer.AbstractDirectSoftwareRedrawer
 import java.lang.ref.Reference
 
@@ -55,7 +56,7 @@ internal class DirectSoftwareContextHandler(layer: SkiaLayer) : JvmContextHandle
             try {
                 softwareRedrawer.finishFrame(getPtr(surface))
             } finally {
-                Reference.reachabilityFence(surface)
+                reachabilityBarrier(surface)
             }
         }
     }

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skia/impl/Native.jvm.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skia/impl/Native.jvm.kt
@@ -22,8 +22,8 @@ actual abstract class Native actual constructor(ptr: NativePointer) {
             val nOther = other as Native
             if (_ptr == nOther._ptr) true else nativeEquals(nOther)
         } finally {
-            Reference.reachabilityFence(this)
-            Reference.reachabilityFence(other)
+            reachabilityBarrier(this)
+            reachabilityBarrier(other)
         }
     }
 
@@ -42,8 +42,12 @@ actual abstract class Native actual constructor(ptr: NativePointer) {
     }
 }
 
+private val isJava8 = System.getProperty("java.version").startsWith("1.8")
+
 internal actual fun reachabilityBarrier(obj: Any?) {
-    Reference.reachabilityFence(obj)
+    if (!isJava8) {
+        Reference.reachabilityFence(obj)
+    }
 }
 
 actual typealias NativePointer = Long

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skia/impl/RefCnt.jvm.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skia/impl/RefCnt.jvm.kt
@@ -11,7 +11,7 @@ actual abstract class RefCnt : Managed {
             Stats.onNativeCall()
             _nGetRefCount(_ptr)
         } finally {
-            Reference.reachabilityFence(this)
+            reachabilityBarrier(this)
         }
 
     override fun toString(): String {


### PR DESCRIPTION
Only call `Reference.reachabilityFence` on java above 1.8 to prevent `NoSuchMethodError` on java 8