### PR TITLE
Exclude bytecode from skiko-awt-runtime-*.jar files

### DIFF
--- a/skiko/buildSrc/src/main/kotlin/properties.kt
+++ b/skiko/buildSrc/src/main/kotlin/properties.kt
@@ -177,6 +177,7 @@ class SkikoProperties(private val myProject: Project) {
 }
 
 object SkikoArtifacts {
+    val groupId = "org.jetbrains.skiko"
     // names are also used in samples, e.g. samples/SkijaInjectSample/build.gradle
     val commonArtifactId = "skiko"
     val jvmArtifactId = "skiko-awt"


### PR DESCRIPTION
Previously, `skiko-awt.jar` and all of `skiko-awt-runtime-*.jar` files contained the same bytecode. However, this led to duplication of bytecode in Compose projects:
* `skiko-awt.jar` is a necessary API dependency of Compose/Desktop, which means it is a runtime dependency as well;
* `skiko-awt-runtime-*.jar` is a necessary RUNTIME dependency of any Compose/Desktop project.

Thus, both `skiko-awt.jar` and `skiko-awt-runtime-*.jar` ended up in a runtime classpath of any Compose/Desktop project, so the same classes were present in the runtime classpath twice. This increased a final application image by approximately 1.1 Mb. Also, it led to excessive ProGuard warnings, e.g. https://github.com/JetBrains/compose-jb/issues/2393

This change excludes bytecode from `skiko-awt-runtime-*.jar` artifacts, and adds Maven dependency `skiko-awt-runtime-*.jar` -> `skiko-awt.jar`, so many existing Maven/Gradle usages of `skiko-awt-runtime-*.jar` will continue to work.