### PR TITLE
Windows ARM support

### DIFF
--- a/samples/SkiaAwtSample/src/main/kotlin/SkiaAwtSample/App.kt
+++ b/samples/SkiaAwtSample/src/main/kotlin/SkiaAwtSample/App.kt
@@ -109,7 +109,7 @@ fun createWindow(title: String, exitOnClose: Boolean) = SwingUtilities.invokeLat
 
     // Window transparency
     if (System.getProperty("skiko.transparency") == "true") {
-        window.setUndecorated(true)
+        window.isUndecorated = true
         // On Windows we don't set transparent background to avoid event input issues (JDK specific)
         if (hostOs != OS.Windows) {
             window.background = Color(0, 0, 0, 0)

--- a/skiko/build.gradle.kts
+++ b/skiko/build.gradle.kts
@@ -623,7 +623,7 @@ val skikoAwtJar by project.tasks.registering(Jar::class) {
     from(kotlin.jvm("awt").compilations["main"].output.allOutputs)
 }
 val skikoAwtRuntimeJar = createSkikoJvmJarTask(targetOs, targetArch, skikoAwtJar)
-val skikoRuntimeDirForTests = skikoRuntimeDirForTestsTask(targetOs, targetArch, skikoAwtRuntimeJar)
+val skikoRuntimeDirForTests = skikoRuntimeDirForTestsTask(targetOs, targetArch, skikoAwtJar, skikoAwtRuntimeJar)
 val skikoJarForTests = skikoJarForTestsTask(skikoRuntimeDirForTests)
 
 if (supportAndroid) {

--- a/skiko/build.gradle.kts
+++ b/skiko/build.gradle.kts
@@ -23,6 +23,8 @@ fun targetSuffix(os: OS, arch: Arch): String {
 
 val skiko = SkikoProperties(rootProject)
 val buildType = skiko.buildType
+val targetOs = hostOs
+val targetArch = skiko.targetArch
 
 allprojects {
     group = SkikoArtifacts.groupId
@@ -34,7 +36,7 @@ repositories {
 }
 
 val windowsSdkPaths: WindowsSdkPaths by lazy {
-    findWindowsSdkPathsForCurrentOS(gradle)
+    findWindowsSdkPaths(gradle, targetArch)
 }
 
 fun KotlinTarget.isIosSimArm64() =
@@ -221,7 +223,7 @@ kotlin {
         compilations.all {
             kotlinOptions.jvmTarget = "1.8"
         }
-        generateVersion(hostOs, hostArch)
+        generateVersion(targetOs, targetArch)
     }
 
     if (supportAndroid) {
@@ -620,8 +622,8 @@ val skikoAwtJar by project.tasks.registering(Jar::class) {
     archiveBaseName.set("skiko-awt")
     from(kotlin.jvm("awt").compilations["main"].output.allOutputs)
 }
-val skikoAwtRuntimeJar = createSkikoJvmJarTask(hostOs, hostArch, skikoAwtJar)
-val skikoRuntimeDirForTests = skikoRuntimeDirForTestsTask(hostOs, hostArch, skikoAwtJar, skikoAwtRuntimeJar)
+val skikoAwtRuntimeJar = createSkikoJvmJarTask(targetOs, targetArch, skikoAwtJar)
+val skikoRuntimeDirForTests = skikoRuntimeDirForTestsTask(targetOs, targetArch, skikoAwtRuntimeJar)
 val skikoJarForTests = skikoJarForTestsTask(skikoRuntimeDirForTests)
 
 if (supportAndroid) {

--- a/skiko/buildSrc/src/main/kotlin/properties.kt
+++ b/skiko/buildSrc/src/main/kotlin/properties.kt
@@ -58,7 +58,11 @@ val OS.dynamicLibExt: String
 enum class Arch(val id: String) {
     X64("x64"),
     Arm64("arm64"),
-    Wasm("wasm")
+    Wasm("wasm");
+
+    companion object {
+        fun byName(name: String) = Arch.values().find { it.id == name }
+    }
 }
 
 enum class SkiaBuildType(
@@ -127,6 +131,9 @@ class SkikoProperties(private val myProject: Project) {
     val buildType: SkiaBuildType
         get() = if (myProject.findProperty("skiko.debug") == "true") SkiaBuildType.DEBUG else SkiaBuildType.RELEASE
 
+    val targetArch: Arch
+        get() = myProject.findProperty("skiko.arch")?.toString()?.let(Arch::byName) ?: hostArch
+
     val includeTestHelpers: Boolean
         get() = !isRelease
 
@@ -148,8 +155,11 @@ class SkikoProperties(private val myProject: Project) {
 
     // todo: make compatible with the configuration cache
     val skiaDir: File?
-        get() = (System.getenv()["SKIA_DIR"] ?: System.getProperty("skia.dir"))?.let { File(it) }
-            ?.takeIf { it.isDirectory }
+        get() = (
+                System.getenv()["SKIA_DIR"]
+                ?: System.getProperty("skia.dir")
+                ?: myProject.findProperty("skia.dir")?.toString()
+            )?.let { File(it) }?.takeIf { it.isDirectory }
 
     val composeRepoUrl: String
         get() = System.getenv("COMPOSE_REPO_URL") ?: "https://maven.pkg.jetbrains.space/public/p/compose/dev"

--- a/skiko/gradle.properties
+++ b/skiko/gradle.properties
@@ -6,6 +6,7 @@ kotlin.native.enableDependencyPropagation=false
 dependencies.skia.windows-x64=m105-305b7c02-1
 dependencies.skia.linux-x64=m105-305b7c02-1
 dependencies.skia.macos-x64=m105-305b7c02-1
+dependencies.skia.windows-arm64=m105-305b7c02-1
 dependencies.skia.linux-arm64=m105-305b7c02-1
 dependencies.skia.macos-arm64=m105-305b7c02-1
 dependencies.skia.wasm-wasm=m105-305b7c02-1

--- a/skiko/gradle/wrapper/gradle-wrapper.properties
+++ b/skiko/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/SkikoProperties.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/SkikoProperties.kt
@@ -48,7 +48,10 @@ object SkikoProperties {
             "SOFTWARE_COMPAT" -> return GraphicsApi.SOFTWARE_COMPAT
             "SOFTWARE_FAST", "DIRECT_SOFTWARE" -> return GraphicsApi.SOFTWARE_FAST
             "SOFTWARE" -> return if (hostOs == OS.MacOS) GraphicsApi.SOFTWARE_COMPAT else GraphicsApi.SOFTWARE_FAST
-            "OPENGL" -> return GraphicsApi.OPENGL
+            "OPENGL" ->
+                // Skia isn't properly tested on OpenGL and Windows ARM (https://groups.google.com/g/skia-discuss/c/McoclAhLpvg?pli=1)
+                return if (hostOs != OS.Windows || hostArch != Arch.Arm64) GraphicsApi.OPENGL
+                    else throw Exception("$hostOs-$hostArch does not support OpenGL rendering API.")
             "DIRECT3D" -> {
                 return if (hostOs == OS.Windows) GraphicsApi.DIRECT3D
                     else throw Exception("$hostOs does not support DirectX rendering API.")
@@ -75,7 +78,11 @@ object SkikoProperties {
         var fallbackApis = when (hostOs) {
             OS.Linux -> listOf(GraphicsApi.OPENGL, GraphicsApi.SOFTWARE_FAST, GraphicsApi.SOFTWARE_COMPAT)
             OS.MacOS -> listOf(GraphicsApi.METAL, GraphicsApi.SOFTWARE_COMPAT)
-            OS.Windows -> listOf(GraphicsApi.DIRECT3D, GraphicsApi.OPENGL, GraphicsApi.SOFTWARE_FAST, GraphicsApi.SOFTWARE_COMPAT)
+            OS.Windows -> when (hostArch) {
+                // Skia isn't properly tested on OpenGL and Windows ARM (https://groups.google.com/g/skia-discuss/c/McoclAhLpvg?pli=1)
+                Arch.Arm64 -> listOf(GraphicsApi.DIRECT3D, GraphicsApi.SOFTWARE_FAST, GraphicsApi.SOFTWARE_COMPAT)
+                else -> listOf(GraphicsApi.DIRECT3D, GraphicsApi.OPENGL, GraphicsApi.SOFTWARE_FAST, GraphicsApi.SOFTWARE_COMPAT)
+            }
             OS.Android -> return listOf(GraphicsApi.OPENGL)
             OS.JS, OS.Ios -> TODO("commonize me")
         }


### PR DESCRIPTION
fixes https://github.com/JetBrains/skiko/issues/607

- add `skia.arch` Gradle property. We set it to `arm64` on CI to build a version for Windows ARM
- change renderAPI fallback strategy (OpenGL doesn't work properly in Skia on Windows ARM)