### PR TITLE
Fix skiko declaration bridges

### DIFF
--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/BackendRenderTarget.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/BackendRenderTarget.kt
@@ -77,7 +77,7 @@ private external fun _nMakeGL(width: Int, height: Int, sampleCnt: Int, stencilBi
 @ExternalSymbolName("BackendRenderTarget_nMakeMetal")
 private external fun _nMakeMetal(width: Int, height: Int, texturePtr: NativePointer): NativePointer
 
-@ExternalSymbolName("BackendRenderTarget_nMakeDirect3D")
+@ExternalSymbolName("BackendRenderTarget_MakeDirect3D")
 private external fun _nMakeDirect3D(
     width: Int,
     height: Int,

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Bitmap.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Bitmap.kt
@@ -647,8 +647,9 @@ class Bitmap internal constructor(ptr: NativePointer) : Managed(ptr, _FinalizerH
     val pixelRefOrigin: IPoint
         get() = try {
             Stats.onNativeCall()
-            val res = _nGetPixelRefOrigin(_ptr)
-            toIPoint(res)
+            val resX = _nGetPixelRefOriginX(_ptr)
+            val resY = _nGetPixelRefOriginY(_ptr)
+            IPoint(resX, resY)
         } finally {
             reachabilityBarrier(this)
         }
@@ -1154,8 +1155,11 @@ private external fun _nAllocPixels(ptr: NativePointer): Boolean
 @ExternalSymbolName("org_jetbrains_skia_Bitmap__1nGetPixelRef")
 private external fun _nGetPixelRef(ptr: NativePointer): NativePointer
 
-@ExternalSymbolName("org_jetbrains_skia_Bitmap__1nGetPixelRefOrigin")
-private external fun _nGetPixelRefOrigin(ptr: NativePointer): Long
+@ExternalSymbolName("org_jetbrains_skia_Bitmap__1nGetPixelRefOriginX")
+private external fun _nGetPixelRefOriginX(ptr: NativePointer): Int
+
+@ExternalSymbolName("org_jetbrains_skia_Bitmap__1nGetPixelRefOriginY")
+private external fun _nGetPixelRefOriginY(ptr: NativePointer): Int
 
 @ExternalSymbolName("org_jetbrains_skia_Bitmap__1nSetPixelRef")
 private external fun _nSetPixelRef(ptr: NativePointer, pixelRefPtr: NativePointer, dx: Int, dy: Int)

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Canvas.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Canvas.kt
@@ -469,7 +469,9 @@ open class Canvas internal constructor(ptr: NativePointer, managed: Boolean, int
 
     fun drawString(s: String, x: Float, y: Float, font: Font?, paint: Paint): Canvas {
         Stats.onNativeCall()
-        _nDrawString(_ptr, s, x, y, getPtr(font), getPtr(paint))
+        interopScope {
+            _nDrawString(_ptr, toInterop(s), x, y, getPtr(font), getPtr(paint))
+        }
         reachabilityBarrier(font)
         reachabilityBarrier(paint)
         return this
@@ -1345,14 +1347,13 @@ private external fun _nDrawImageNine(
 private external fun _nDrawRegion(ptr: NativePointer, nativeRegion: NativePointer, paintPtr: NativePointer)
 
 @ExternalSymbolName("org_jetbrains_skia_Canvas__1nDrawString")
-private external fun _nDrawString(ptr: NativePointer, string: String?, x: Float, y: Float, font: NativePointer, paint: NativePointer)
+private external fun _nDrawString(ptr: NativePointer, string: InteropPointer, x: Float, y: Float, font: NativePointer, paint: NativePointer)
 
 @ExternalSymbolName("org_jetbrains_skia_Canvas__1nDrawTextBlob")
 private external fun _nDrawTextBlob(ptr: NativePointer, blob: NativePointer, x: Float, y: Float, paint: NativePointer)
 
 @ExternalSymbolName("org_jetbrains_skia_Canvas__1nDrawPicture")
 private external fun _nDrawPicture(ptr: NativePointer, picturePtr: NativePointer, matrix: InteropPointer, paintPtr: NativePointer)
-
 
 @ExternalSymbolName("org_jetbrains_skia_Canvas__1nDrawVertices")
 private external fun _nDrawVertices(
@@ -1408,7 +1409,6 @@ private external fun _nClipRect(
     mode: Int,
     antiAlias: Boolean
 )
-
 
 @ExternalSymbolName("org_jetbrains_skia_Canvas__1nClipRRect")
 private external fun _nClipRRect(

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/ColorSpace.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/ColorSpace.kt
@@ -94,8 +94,7 @@ class ColorSpace : Managed {
 private external fun ColorSpace_nGetFinalizer(): NativePointer
 
 @ExternalSymbolName("org_jetbrains_skia_ColorSpace__nConvert")
-private external fun _nConvert(
-    fromPtr: NativePointer, toPtr: NativePointer, r: Float, g: Float, b: Float, a: Float, result: InteropPointer)
+private external fun _nConvert(fromPtr: NativePointer, toPtr: NativePointer, r: Float, g: Float, b: Float, a: Float, result: InteropPointer)
 
 @ExternalSymbolName("org_jetbrains_skia_ColorSpace__1nMakeSRGB")
 private external fun _nMakeSRGB(): NativePointer

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/DirectContext.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/DirectContext.kt
@@ -102,7 +102,7 @@ class DirectContext internal constructor(ptr: NativePointer) : RefCnt(ptr) {
     fun abandon() {
         try {
             Stats.onNativeCall()
-            _nAbandon(_ptr)
+            _nAbandon(_ptr, 0)
         } finally {
             reachabilityBarrier(this)
         }
@@ -114,7 +114,7 @@ fun <R> DirectContext.useContext(block: (ctx: DirectContext) -> R): R = use {
 }
 
 @ExternalSymbolName("org_jetbrains_skia_DirectContext__1nFlush")
-private external fun DirectContext_nFlush(ptr: NativePointer): NativePointer
+private external fun DirectContext_nFlush(ptr: NativePointer)
 
 @ExternalSymbolName("org_jetbrains_skia_DirectContext__1nMakeGL")
 private external fun _nMakeGL(): NativePointer
@@ -126,10 +126,10 @@ private external fun _nMakeMetal(devicePtr: NativePointer, queuePtr: NativePoint
 private external fun _nMakeDirect3D(adapterPtr: NativePointer, devicePtr: NativePointer, queuePtr: NativePointer): NativePointer
 
 @ExternalSymbolName("org_jetbrains_skia_DirectContext__1nSubmit")
-private external fun _nSubmit(ptr: NativePointer, syncCpu: Boolean): NativePointer
+private external fun _nSubmit(ptr: NativePointer, syncCpu: Boolean)
 
 @ExternalSymbolName("org_jetbrains_skia_DirectContext__1nReset")
 private external fun _nReset(ptr: NativePointer, flags: Int)
 
 @ExternalSymbolName("org_jetbrains_skia_DirectContext__1nAbandon")
-private external fun _nAbandon(ptr: NativePointer)
+private external fun _nAbandon(ptr: NativePointer, flags: Int)

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Font.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Font.kt
@@ -572,7 +572,7 @@ class Font : Managed {
     val spacing: Float
         get() = try {
             Stats.onNativeCall()
-            _nGetSpacing(_ptr)
+            _nGetSpacing(_ptr, NullPointer)
         } finally {
             reachabilityBarrier(this)
         }
@@ -716,4 +716,4 @@ private external fun _nGetPaths(ptr: NativePointer, glyphs: InteropPointer, coun
 private external fun _nGetMetrics(ptr: NativePointer, metrics: InteropPointer)
 
 @ExternalSymbolName("org_jetbrains_skia_Font__1nGetSpacing")
-private external fun _nGetSpacing(ptr: NativePointer): Float
+private external fun _nGetSpacing(ptr: NativePointer, glyphsArr: NativePointer): Float

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/FontMgr.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/FontMgr.kt
@@ -83,7 +83,7 @@ open class FontMgr : RefCnt {
     fun matchFamilyStyle(familyName: String?, style: FontStyle): Typeface? {
         return try {
             Stats.onNativeCall()
-            val ptr = _nMatchFamilyStyle(_ptr, familyName, style._value)
+            val ptr = interopScope { _nMatchFamilyStyle(_ptr, toInterop(familyName), style._value) }
             if (ptr == NullPointer) null else Typeface(ptr)
         } finally {
             reachabilityBarrier(this)
@@ -116,12 +116,21 @@ open class FontMgr : RefCnt {
     fun matchFamilyStyleCharacter(
         familyName: String?,
         style: FontStyle,
-        bcp47: Array<String?>?,
+        bcp47: Array<String>?,
         character: Int
     ): Typeface? {
         return try {
             Stats.onNativeCall()
-            val ptr = _nMatchFamilyStyleCharacter(_ptr, familyName, style._value, bcp47, bcp47?.size ?: 0, character)
+            val ptr = interopScope {
+                _nMatchFamilyStyleCharacter(
+                    _ptr,
+                    toInterop(familyName),
+                    style._value,
+                    toInterop(bcp47 ?: emptyArray()),
+                    bcp47?.size ?: 0,
+                    character
+                )
+            }
             if (ptr == NullPointer) null else Typeface(ptr)
         } finally {
             reachabilityBarrier(this)
@@ -131,7 +140,7 @@ open class FontMgr : RefCnt {
     fun matchFamiliesStyleCharacter(
         families: Array<String?>,
         style: FontStyle,
-        bcp47: Array<String?>?,
+        bcp47: Array<String>?,
         character: Int
     ): Typeface? {
         for (family in families) {
@@ -177,14 +186,14 @@ private external fun _nMakeStyleSet(ptr: NativePointer, index: Int): NativePoint
 private external fun _nMatchFamily(ptr: NativePointer, familyName: InteropPointer): NativePointer
 
 @ExternalSymbolName("org_jetbrains_skia_FontMgr__1nMatchFamilyStyle")
-private external fun _nMatchFamilyStyle(ptr: NativePointer, familyName: String?, fontStyle: Int): NativePointer
+private external fun _nMatchFamilyStyle(ptr: NativePointer, familyName: InteropPointer, fontStyle: Int): NativePointer
 
 @ExternalSymbolName("org_jetbrains_skia_FontMgr__1nMatchFamilyStyleCharacter")
 private external fun _nMatchFamilyStyleCharacter(
     ptr: NativePointer,
-    familyName: String?,
+    familyName: InteropPointer,
     fontStyle: Int,
-    bcp47: Array<String?>?,
+    bcp47: InteropPointer,
     bcp47size: Int,
     character: Int
 ): NativePointer

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/ImageFilter.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/ImageFilter.kt
@@ -786,18 +786,25 @@ private external fun _nMakeMatrixConvolution(
 
 @ExternalSymbolName("org_jetbrains_skia_ImageFilter__1nMakeMatrixTransform")
 private external fun _nMakeMatrixTransform(matrix: InteropPointer, samplingModeVal1: Int, samplingModeVal2: Int, input: NativePointer): NativePointer
+
 @ExternalSymbolName("org_jetbrains_skia_ImageFilter__1nMakeMerge")
 private external fun _nMakeMerge(filters: InteropPointer, filtersLength: Int, crop: InteropPointer): NativePointer
+
 @ExternalSymbolName("org_jetbrains_skia_ImageFilter__1nMakeOffset")
 private external fun _nMakeOffset(dx: Float, dy: Float, input: NativePointer, crop: InteropPointer): NativePointer
+
 @ExternalSymbolName("org_jetbrains_skia_ImageFilter__1nMakePaint")
 private external fun _nMakePaint(paint: NativePointer, crop: InteropPointer): NativePointer
+
 @ExternalSymbolName("org_jetbrains_skia_ImageFilter__1nMakePicture")
 private external fun _nMakePicture(picture: NativePointer, l: Float, t: Float, r: Float, b: Float): NativePointer
+
 @ExternalSymbolName("org_jetbrains_skia_ImageFilter__1nMakeRuntimeShader")
 private external fun _nMakeRuntimeShader(runtimeShaderBuilderPtr: NativePointer, childShaderName: InteropPointer, input: NativePointer): NativePointer
+
 @ExternalSymbolName("org_jetbrains_skia_ImageFilter__1nMakeRuntimeShaderFromArray")
 private external fun _nMakeRuntimeShaderFromArray(runtimeShaderBuilderPtr: NativePointer, childShaderNames: InteropPointer, inputs: InteropPointer, inputLength: Int): NativePointer
+
 @ExternalSymbolName("org_jetbrains_skia_ImageFilter__1nMakeTile")
 private external fun _nMakeTile(
     l0: Float,
@@ -813,8 +820,10 @@ private external fun _nMakeTile(
 
 @ExternalSymbolName("org_jetbrains_skia_ImageFilter__1nMakeDilate")
 private external fun _nMakeDilate(rx: Float, ry: Float, input: NativePointer, crop: InteropPointer): NativePointer
+
 @ExternalSymbolName("org_jetbrains_skia_ImageFilter__1nMakeErode")
 private external fun _nMakeErode(rx: Float, ry: Float, input: NativePointer, crop: InteropPointer): NativePointer
+
 @ExternalSymbolName("org_jetbrains_skia_ImageFilter__1nMakeDistantLitDiffuse")
 private external fun _nMakeDistantLitDiffuse(
     x: Float,

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/RuntimeEffect.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/RuntimeEffect.kt
@@ -40,7 +40,6 @@ class RuntimeEffect internal constructor(ptr: NativePointer) : RefCnt(ptr) {
 
 internal expect fun RuntimeEffect.Companion.makeFromResultPtr(ptr: NativePointer): RuntimeEffect
 
-
 @ExternalSymbolName("org_jetbrains_skia_RuntimeEffect__1nMakeShader")
 private external fun _nMakeShader(
     runtimeEffectPtr: NativePointer, uniformPtr: NativePointer, childrenPtrs: InteropPointer,

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Surface.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Surface.kt
@@ -277,14 +277,16 @@ class Surface : RefCnt {
         ): Surface? {
             return try {
                 Stats.onNativeCall()
-                val ptr = _nMakeFromBackendRenderTarget(
-                    getPtr(context),
-                    getPtr(rt),
-                    origin.ordinal,
-                    colorFormat.ordinal,
-                    getPtr(colorSpace),
-                    surfaceProps
-                )
+                val ptr = interopScope {
+                    _nMakeFromBackendRenderTarget(
+                        getPtr(context),
+                        getPtr(rt),
+                        origin.ordinal,
+                        colorFormat.ordinal,
+                        getPtr(colorSpace),
+                        toInterop(surfaceProps?.packToIntArray())
+                    )
+                }
                 if (ptr == NullPointer)
                     null
                 else
@@ -307,15 +309,17 @@ class Surface : RefCnt {
         ): Surface {
             return try {
                 Stats.onNativeCall()
-                val ptr = _nMakeFromMTKView(
-                    getPtr(context),
-                    mtkViewPtr,
-                    origin.ordinal,
-                    sampleCount,
-                    colorFormat.ordinal,
-                    getPtr(colorSpace),
-                    surfaceProps
-                )
+                val ptr = interopScope {
+                    _nMakeFromMTKView(
+                        getPtr(context),
+                        mtkViewPtr,
+                        origin.ordinal,
+                        sampleCount,
+                        colorFormat.ordinal,
+                        getPtr(colorSpace),
+                        toInterop(surfaceProps?.packToIntArray())
+                    )
+                }
                 require(ptr != NullPointer) {
                     "Failed Surface.makeFromMTKView($context, $mtkViewPtr $origin, $colorFormat, $surfaceProps)"
                 }
@@ -489,19 +493,21 @@ class Surface : RefCnt {
         ): Surface {
             return try {
                 Stats.onNativeCall()
-                val ptr = _nMakeRenderTarget(
-                    getPtr(context),
-                    budgeted,
-                    imageInfo.width,
-                    imageInfo.height,
-                    imageInfo.colorInfo.colorType.ordinal,
-                    imageInfo.colorInfo.alphaType.ordinal,
-                    getPtr(imageInfo.colorInfo.colorSpace),
-                    sampleCount,
-                    origin.ordinal,
-                    surfaceProps,
-                    shouldCreateWithMips
-                )
+                val ptr = interopScope {
+                    _nMakeRenderTarget(
+                        getPtr(context),
+                        budgeted,
+                        imageInfo.width,
+                        imageInfo.height,
+                        imageInfo.colorInfo.colorType.ordinal,
+                        imageInfo.colorInfo.alphaType.ordinal,
+                        getPtr(imageInfo.colorInfo.colorSpace),
+                        sampleCount,
+                        origin.ordinal,
+                        toInterop(surfaceProps?.packToIntArray()),
+                        shouldCreateWithMips
+                    )
+                }
                 require(ptr != NullPointer) {
                     "Failed Surface.makeRenderTarget($context, $budgeted, $imageInfo, $sampleCount, $origin, $surfaceProps, $shouldCreateWithMips)"
                 }
@@ -1066,9 +1072,8 @@ private external fun _nMakeFromBackendRenderTarget(
     surfaceOrigin: Int,
     colorType: Int,
     colorSpacePtr: NativePointer,
-    surfaceProps: SurfaceProps?
+    surfaceProps: InteropPointer
 ): NativePointer
-
 
 @ExternalSymbolName("org_jetbrains_skia_Surface__1nMakeFromMTKView")
 private external fun _nMakeFromMTKView(
@@ -1078,9 +1083,8 @@ private external fun _nMakeFromMTKView(
     sampleCount: Int,
     colorType: Int,
     colorSpacePtr: NativePointer,
-    surfaceProps: SurfaceProps?
+    surfaceProps: InteropPointer
 ): NativePointer
-
 
 @ExternalSymbolName("org_jetbrains_skia_Surface__1nMakeRenderTarget")
 private external fun _nMakeRenderTarget(
@@ -1093,7 +1097,7 @@ private external fun _nMakeRenderTarget(
     colorSpacePtr: NativePointer,
     sampleCount: Int,
     surfaceOrigin: Int,
-    surfaceProps: SurfaceProps?,
+    surfaceProps: InteropPointer,
     shouldCreateWithMips: Boolean
 ): NativePointer
 

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Typeface.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Typeface.kt
@@ -342,7 +342,7 @@ class Typeface internal constructor(ptr: NativePointer) : RefCnt(ptr) {
             if (glyphs != null) {
                 if (glyphs.size > 0) {
                     withNullableResult(IntArray(glyphs.size)) {
-                        _nGetKerningPairAdjustments(_ptr, glyphs, glyphs.size, it)
+                        _nGetKerningPairAdjustments(_ptr, toInterop(glyphs), glyphs.size, it)
                     }
                 } else null
             } else null
@@ -485,7 +485,7 @@ private external fun _nGetUnitsPerEm(ptr: NativePointer): Int
 @ExternalSymbolName("org_jetbrains_skia_Typeface__1nGetKerningPairAdjustments")
 private external fun _nGetKerningPairAdjustments(
     ptr: NativePointer,
-    glyphs: ShortArray,
+    glyphs: InteropPointer,
     count: Int,
     adjustments: InteropPointer
 ): Boolean

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/paragraph/FontCollection.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/paragraph/FontCollection.kt
@@ -27,7 +27,7 @@ class FontCollection internal constructor(ptr: NativePointer) : RefCnt(ptr) {
     fun setAssetFontManager(fontMgr: FontMgr?): FontCollection {
         return try {
             Stats.onNativeCall()
-            _nSetAssetFontManager(_ptr, getPtr(fontMgr))
+            _nSetAssetFontManager(_ptr, getPtr(fontMgr), NullPointer)
             this
         } finally {
             reachabilityBarrier(fontMgr)
@@ -39,7 +39,8 @@ class FontCollection internal constructor(ptr: NativePointer) : RefCnt(ptr) {
             Stats.onNativeCall()
             _nSetDynamicFontManager(
                 _ptr,
-                getPtr(fontMgr)
+                getPtr(fontMgr),
+                NullPointer
             )
             this
         } finally {
@@ -50,7 +51,7 @@ class FontCollection internal constructor(ptr: NativePointer) : RefCnt(ptr) {
     fun setTestFontManager(fontMgr: FontMgr?): FontCollection {
         return try {
             Stats.onNativeCall()
-            _nSetTestFontManager(_ptr, getPtr(fontMgr))
+            _nSetTestFontManager(_ptr, getPtr(fontMgr), NullPointer)
             this
         } finally {
             reachabilityBarrier(fontMgr)
@@ -143,16 +144,16 @@ private external fun _nMake(): NativePointer
 private external fun _nGetFontManagersCount(ptr: NativePointer): Int
 
 @ExternalSymbolName("org_jetbrains_skia_paragraph_FontCollection__1nSetAssetFontManager")
-private external fun _nSetAssetFontManager(ptr: NativePointer, fontManagerPtr: NativePointer): NativePointer
+private external fun _nSetAssetFontManager(ptr: NativePointer, fontManagerPtr: NativePointer, defaultFamilyNameStr: NativePointer)
 
 @ExternalSymbolName("org_jetbrains_skia_paragraph_FontCollection__1nSetDynamicFontManager")
-private external fun _nSetDynamicFontManager(ptr: NativePointer, fontManagerPtr: NativePointer): NativePointer
+private external fun _nSetDynamicFontManager(ptr: NativePointer, fontManagerPtr: NativePointer, defaultFamilyNameStr: NativePointer)
 
 @ExternalSymbolName("org_jetbrains_skia_paragraph_FontCollection__1nSetTestFontManager")
-private external fun _nSetTestFontManager(ptr: NativePointer, fontManagerPtr: NativePointer): NativePointer
+private external fun _nSetTestFontManager(ptr: NativePointer, fontManagerPtr: NativePointer, defaultFamilyNameStr: NativePointer)
 
 @ExternalSymbolName("org_jetbrains_skia_paragraph_FontCollection__1nSetDefaultFontManager")
-private external fun _nSetDefaultFontManager(ptr: NativePointer, fontManagerPtr: NativePointer, defaultFamilyName: InteropPointer): NativePointer
+private external fun _nSetDefaultFontManager(ptr: NativePointer, fontManagerPtr: NativePointer, defaultFamilyName: InteropPointer)
 
 @ExternalSymbolName("org_jetbrains_skia_paragraph_FontCollection__1nGetFallbackManager")
 private external fun _nGetFallbackManager(ptr: NativePointer): NativePointer
@@ -167,7 +168,7 @@ private external fun _nDefaultFallbackChar(ptr: NativePointer, unicode: Int, fon
 private external fun _nDefaultFallback(ptr: NativePointer): NativePointer
 
 @ExternalSymbolName("org_jetbrains_skia_paragraph_FontCollection__1nSetEnableFallback")
-private external fun _nSetEnableFallback(ptr: NativePointer, value: Boolean): NativePointer
+private external fun _nSetEnableFallback(ptr: NativePointer, value: Boolean)
 
 @ExternalSymbolName("org_jetbrains_skia_paragraph_FontCollection__1nGetParagraphCache")
 private external fun _nGetParagraphCache(ptr: NativePointer): NativePointer

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/paragraph/Paragraph.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/paragraph/Paragraph.kt
@@ -306,7 +306,7 @@ private external fun _nDidExceedMaxLines(ptr: NativePointer): Boolean
 private external fun _nLayout(ptr: NativePointer, width: Float)
 
 @ExternalSymbolName("org_jetbrains_skia_paragraph_Paragraph__1nPaint")
-private external fun _nPaint(ptr: NativePointer, canvasPtr: NativePointer, x: Float, y: Float): NativePointer
+private external fun _nPaint(ptr: NativePointer, canvasPtr: NativePointer, x: Float, y: Float)
 
 @ExternalSymbolName("org_jetbrains_skia_paragraph_Paragraph__1nGetRectsForRange")
 private external fun _nGetRectsForRange(

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/paragraph/ParagraphBuilder.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/paragraph/ParagraphBuilder.kt
@@ -26,7 +26,7 @@ class ParagraphBuilder(style: ParagraphStyle?, fc: FontCollection?) :
 
     fun popStyle(): ParagraphBuilder {
         Stats.onNativeCall()
-        _nPopStyle(_ptr)
+        _nPopStyle(_ptr, NullPointer)
         return this
     }
 
@@ -84,7 +84,7 @@ private external fun _nMake(paragraphStylePtr: NativePointer, fontCollectionPtr:
 private external fun _nPushStyle(ptr: NativePointer, textStylePtr: NativePointer)
 
 @ExternalSymbolName("org_jetbrains_skia_paragraph_ParagraphBuilder__1nPopStyle")
-private external fun _nPopStyle(ptr: NativePointer)
+private external fun _nPopStyle(ptr: NativePointer, textStylePtr: NativePointer)
 
 @ExternalSymbolName("org_jetbrains_skia_paragraph_ParagraphBuilder__1nAddText")
 private external fun _nAddText(ptr: NativePointer, text: InteropPointer)

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/paragraph/ParagraphCache.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/paragraph/ParagraphCache.kt
@@ -61,7 +61,7 @@ class ParagraphCache internal constructor(owner: FontCollection, ptr: NativePoin
         try {
             _validate()
             Stats.onNativeCall()
-            _nPrintStatistics(_ptr)
+            _nPrintStatistics(_ptr, NullPointer)
         } finally {
             reachabilityBarrier(this)
         }
@@ -113,7 +113,7 @@ private external fun _nUpdateParagraph(ptr: NativePointer, paragraphPtr: NativeP
 private external fun _nFindParagraph(ptr: NativePointer, paragraphPtr: NativePointer): Boolean
 
 @ExternalSymbolName("org_jetbrains_skia_paragraph_ParagraphCache__1nPrintStatistics")
-private external fun _nPrintStatistics(ptr: NativePointer)
+private external fun _nPrintStatistics(ptr: NativePointer, paragraphPtr: NativePointer)
 
 @ExternalSymbolName("org_jetbrains_skia_paragraph_ParagraphCache__1nSetEnabled")
 private external fun _nSetEnabled(ptr: NativePointer, value: Boolean)

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/paragraph/StrutStyle.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/paragraph/StrutStyle.kt
@@ -223,7 +223,7 @@ private external fun _nGetFontFamilies(ptr: NativePointer): NativePointer
 private external fun StrutStyle_nSetFontFamilies(ptr: NativePointer, families: InteropPointer, familiesCount: Int)
 
 @ExternalSymbolName("org_jetbrains_skia_paragraph_StrutStyle__1nGetFontStyle")
-private external fun _nGetFontStyle(ptr: NativePointer, fontStyleData: InteropPointer): Int
+private external fun _nGetFontStyle(ptr: NativePointer, fontStyleData: InteropPointer)
 
 @ExternalSymbolName("org_jetbrains_skia_paragraph_StrutStyle__1nSetFontStyle")
 private external fun _nSetFontStyle(ptr: NativePointer, value: Int)

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/paragraph/TextStyle.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/paragraph/TextStyle.kt
@@ -277,7 +277,7 @@ class TextStyle internal constructor(ptr: NativePointer) : Managed(ptr, _Finaliz
     var isHalfLeading: Boolean
         get() = try {
             Stats.onNativeCall()
-            TextStyle_nIsHalfLeading(_ptr)
+            TextStyle_nGetHalfLeading(_ptr)
         } finally {
             reachabilityBarrier(this)
         }
@@ -465,8 +465,8 @@ private external fun TextStyle_nGetHeight(ptr: NativePointer): Float
 @ExternalSymbolName("org_jetbrains_skia_paragraph_TextStyle__1nSetHeight")
 private external fun TextStyle_nSetHeight(ptr: NativePointer, override: Boolean, height: Float)
 
-@ExternalSymbolName("org_jetbrains_skia_paragraph_TextStyle__1nIsHalfLeading")
-private external fun TextStyle_nIsHalfLeading(ptr: NativePointer): Boolean
+@ExternalSymbolName("org_jetbrains_skia_paragraph_TextStyle__1nGetHalfLeading")
+private external fun TextStyle_nGetHalfLeading(ptr: NativePointer): Boolean
 
 @ExternalSymbolName("org_jetbrains_skia_paragraph_TextStyle__1nSetHalfLeading")
 private external fun TextStyle_nSetHalfLeading(ptr: NativePointer, value: Boolean)

--- a/skiko/src/commonTest/kotlin/org/jetbrains/skia/BitmapTest.kt
+++ b/skiko/src/commonTest/kotlin/org/jetbrains/skia/BitmapTest.kt
@@ -70,6 +70,7 @@ class BitmapTest {
         assertTrue(bitmap.rowBytes > 0)
         assertEquals(5 * bitmap.rowBytes, result.size)
     }
+
     @Test
     fun canPeekPixels() = runTest {
         val bitmap = Bitmap()
@@ -129,5 +130,20 @@ class BitmapTest {
         setArray.forEachIndexed { ix, value ->
             assertEquals(value, dataBytes[ix])
         }
+    }
+
+    @Test
+    fun canSetOrGetPixelRefOrigin() = runTest {
+        val source = Bitmap()
+        source.allocPixels(ImageInfo.makeS32(15, 15, ColorAlphaType.OPAQUE))
+        val subset = Bitmap()
+        source.extractSubset(subset, IRect.makeXYWH(5, 5, 10, 10))
+        val sourceOrigin = source.pixelRefOrigin
+        val subsetOrigin = subset.pixelRefOrigin
+
+        assertEquals(sourceOrigin.x, 0)
+        assertEquals(sourceOrigin.y, 0)
+        assertEquals(subsetOrigin.x, 5)
+        assertEquals(subsetOrigin.y, 5)
     }
 }

--- a/skiko/src/commonTest/kotlin/org/jetbrains/skia/CanvasTest.kt
+++ b/skiko/src/commonTest/kotlin/org/jetbrains/skia/CanvasTest.kt
@@ -93,9 +93,7 @@ class CanvasTest {
     private suspend fun fontInter36() =
         Font(Typeface.makeFromResource("./fonts/Inter-Hinted-Regular.ttf"), 36f)
 
-    // TODO(karpovich): enable for all platforms
-    // native and js don't work: resulting image has no changed pixels (typeface implementations required)
-    @Test @SkipNativeTarget @SkipJsTarget
+    @Test
     fun drawString() = runTest {
         val surface = Surface.makeRasterN32Premul(100, 100)
 

--- a/skiko/src/jvmMain/cpp/common/Bitmap.cc
+++ b/skiko/src/jvmMain/cpp/common/Bitmap.cc
@@ -161,11 +161,18 @@ extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_BitmapKt__1nGetPixelR
     return reinterpret_cast<jlong>(pixelRef);
 }
 
-extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_BitmapKt__1nGetPixelRefOrigin
+extern "C" JNIEXPORT jint JNICALL Java_org_jetbrains_skia_BitmapKt__1nGetPixelRefOriginX
   (JNIEnv* env, jclass jclass, jlong ptr) {
     SkBitmap* instance = reinterpret_cast<SkBitmap*>(static_cast<uintptr_t>(ptr));
     SkIPoint origin = instance->pixelRefOrigin();
-    return packIPoint(origin);
+    return origin.x();
+}
+
+extern "C" JNIEXPORT jint JNICALL Java_org_jetbrains_skia_BitmapKt__1nGetPixelRefOriginY
+  (JNIEnv* env, jclass jclass, jlong ptr) {
+    SkBitmap* instance = reinterpret_cast<SkBitmap*>(static_cast<uintptr_t>(ptr));
+    SkIPoint origin = instance->pixelRefOrigin();
+    return origin.y();
 }
 
 extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_BitmapKt__1nSetPixelRef

--- a/skiko/src/jvmMain/cpp/common/paragraph/TextStyle.cc
+++ b/skiko/src/jvmMain/cpp/common/paragraph/TextStyle.cc
@@ -245,7 +245,7 @@ extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_paragraph_TextStyleKt_
     instance->setHeight(height);
 }
 
-extern "C" JNIEXPORT jboolean JNICALL Java_org_jetbrains_skia_paragraph_TextStyleKt_TextStyle_1nIsHalfLeading
+extern "C" JNIEXPORT jboolean JNICALL Java_org_jetbrains_skia_paragraph_TextStyleKt_TextStyle_1nGetHalfLeading
   (JNIEnv* env, jclass jclass, jlong ptr) {
     TextStyle* instance = reinterpret_cast<TextStyle*>(static_cast<uintptr_t>(ptr));
     return instance->getHalfLeading();

--- a/skiko/src/nativeJsMain/cpp/Bitmap.cc
+++ b/skiko/src/nativeJsMain/cpp/Bitmap.cc
@@ -173,11 +173,18 @@ SKIKO_EXPORT KNativePointer org_jetbrains_skia_Bitmap__1nGetPixelRef
     return reinterpret_cast<KNativePointer>(pixelRef);
 }
 
-SKIKO_EXPORT KLong org_jetbrains_skia_Bitmap__1nGetPixelRefOrigin
+SKIKO_EXPORT KInt org_jetbrains_skia_Bitmap__1nGetPixelRefOriginX
   (KNativePointer ptr) {
     SkBitmap* instance = reinterpret_cast<SkBitmap*>((ptr));
     SkIPoint origin = instance->pixelRefOrigin();
-    return packIPoint(origin);
+    return origin.x();
+}
+
+SKIKO_EXPORT KInt org_jetbrains_skia_Bitmap__1nGetPixelRefOriginY
+  (KNativePointer ptr) {
+    SkBitmap* instance = reinterpret_cast<SkBitmap*>((ptr));
+    SkIPoint origin = instance->pixelRefOrigin();
+    return origin.y();
 }
 
 SKIKO_EXPORT void org_jetbrains_skia_Bitmap__1nSetPixelRef

--- a/skiko/src/nativeJsMain/cpp/Picture.cc
+++ b/skiko/src/nativeJsMain/cpp/Picture.cc
@@ -70,10 +70,10 @@ SKIKO_EXPORT KInt org_jetbrains_skia_Picture__1nGetApproximateOpCount
     return instance->approximateOpCount();
 }
 
-SKIKO_EXPORT KLong org_jetbrains_skia_Picture__1nGetApproximateBytesUsed
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_Picture__1nGetApproximateBytesUsed
   (KNativePointer ptr) {
     SkPicture* instance = reinterpret_cast<SkPicture*>((ptr));
-    return instance->approximateBytesUsed();
+    return reinterpret_cast<KNativePointer>(instance->approximateBytesUsed());
 }
 
 

--- a/skiko/src/nativeJsMain/cpp/Typeface.cc
+++ b/skiko/src/nativeJsMain/cpp/Typeface.cc
@@ -177,7 +177,7 @@ SKIKO_EXPORT KInt org_jetbrains_skia_Typeface__1nGetUnitsPerEm
 
 
 SKIKO_EXPORT bool org_jetbrains_skia_Typeface__1nGetKerningPairAdjustments
-  (KNativePointer ptr, KShort* glyphs, KInt count, KInt* res) {
+  (KNativePointer ptr, KInteropPointer glyphs, KInt count, KInt* res) {
   SkTypeface* instance = reinterpret_cast<SkTypeface*>(ptr);
   if (count > 0) {
       std::vector<int> adjustments(count);

--- a/skiko/src/nativeJsMain/cpp/paragraph/TextStyle.cc
+++ b/skiko/src/nativeJsMain/cpp/paragraph/TextStyle.cc
@@ -243,7 +243,7 @@ SKIKO_EXPORT void org_jetbrains_skia_paragraph_TextStyle__1nSetHeight
     instance->setHeight(height);
 }
 
-SKIKO_EXPORT KFloat org_jetbrains_skia_paragraph_TextStyle__1nGetHalfLeading
+SKIKO_EXPORT KBoolean org_jetbrains_skia_paragraph_TextStyle__1nGetHalfLeading
   (KNativePointer ptr) {
     TextStyle* instance = reinterpret_cast<TextStyle*>(ptr);
     return instance->getHalfLeading();

--- a/skiko/src/nativeMain/kotlin/org/jetbrains/skia/impl/RefCnt.native.kt
+++ b/skiko/src/nativeMain/kotlin/org/jetbrains/skia/impl/RefCnt.native.kt
@@ -26,5 +26,6 @@ actual abstract class RefCnt : Managed {
 
 @ExternalSymbolName("org_jetbrains_skia_impl_RefCnt__getFinalizer")
 internal actual external fun RefCnt_nGetFinalizer(): NativePointer
+
 @ExternalSymbolName("org_jetbrains_skia_impl_RefCnt__getRefCount")
 private external fun _nGetRefCount(ptr: NativePointer): Int


### PR DESCRIPTION
Kotlin/C bridges synchronisation:

Removed Kotlin parameters (like kotlin.String) from skia bridges (would not work for js)
Fixed invalid int_64t result return from bridge (would not work for emscripten)
Added/removed missing arguments from bridges
Fixed invalid named bridge