### PR TITLE
Linux. Fix deadlock when we close a window

### DIFF
--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/Display.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/Display.kt
@@ -1,10 +1,7 @@
 package org.jetbrains.skiko
 
-import kotlin.time.ExperimentalTime
-
 internal const val MinMainstreamMonitorRefreshRate = 60.0
 
-@OptIn(ExperimentalTime::class)
 internal fun HardwareLayer.getDisplayRefreshRate(): Double {
     // We use different method for Linux, because it.displayMode.refreshRate returns always a wrong value: 50 (probably because of the using the old xrandr API)
     return if (hostOs == OS.Linux) {

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/FrameLimiter.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/FrameLimiter.kt
@@ -14,7 +14,6 @@ private const val NanosecondsPerMillisecond = 1_000_000L
  * (Windows has ~15ms precision by default, Linux/macOs ~2ms).
  * FrameLimiter will try to delay frames as close as possible to [frameMillis], but not greater
  */
-@OptIn(ExperimentalTime::class)
 class FrameLimiter(
     private val coroutineScope: CoroutineScope,
     private val frameMillis: () -> Long,


### PR DESCRIPTION
Deadlock:
[AWTThread] awtLock -> SkiaLayer.dispose -> LinuxOpenGLRedrawer.dispose -> we are here -> lockLinuxDrawingSurface -> awtLock [refreshRate updater thread] -> lockLinuxDrawingSurface -> we are here -> awtLock

We moved refreshRate to another thread, and check it only once a second, because it is not fast. I mistakenly thought in the past, that it is very slow on Linux (2ms), but it appears it was because of the awtLock itself. In the AWT thread it take 0.2ms, that is also slow for just one functions, but bearable, if it called only once every second.

Alternative is to subscribe to the native XRRScreenChangeNotifyEvent: https://www.x.org/releases/current/doc/man/man3/Xrandr.3.xhtml. But it seems X window system can have only one event queue associated with the window, and we already have one inside AWT, and we don't have access to it.