### PR TITLE
Update gradle to 7.6 and repositories

### DIFF
--- a/skiko/buildSrc/settings.gradle.kts
+++ b/skiko/buildSrc/settings.gradle.kts
@@ -1,0 +1,6 @@
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}

--- a/skiko/gradle/wrapper/gradle-wrapper.properties
+++ b/skiko/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/skiko/settings.gradle.kts
+++ b/skiko/settings.gradle.kts
@@ -1,5 +1,6 @@
 pluginManagement {
     repositories {
+        mavenCentral()
         gradlePluginPortal()
     }
     buildscript {


### PR DESCRIPTION
Add mavenCentral to make it not redirect to jcenter to download the dependencies (fails when running in teamcity with MacOs X86_64 agents, but ok with all other agents). 