### PR TITLE
Add setBitmapsEmbedded

### DIFF
--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Font.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Font.kt
@@ -119,6 +119,18 @@ class Font : Managed {
     }
 
     /**
+     * If true, requests, but does not require, to use bitmaps in fonts instead of outlines.
+     */
+    fun setBitmapsEmbedded(value: Boolean) {
+        try {
+            Stats.onNativeCall()
+            _nSetBitmapsEmbedded(_ptr, value)
+        } finally {
+            reachabilityBarrier(this)
+        }
+    }
+
+    /**
      * @return  true if glyphs may be drawn at sub-pixel offsets
      */
     var isSubpixel: Boolean


### PR DESCRIPTION
For our project we needed to to use bitmaps in fonts, but this method wasn't bound. We had to use reflection in order to access it. We would like to have this method available as public API.