### PR TITLE
UIKit Clipboard, simplify permission

### DIFF
--- a/skiko/src/androidMain/kotlin/org/jetbrains/skiko/Actuals.android.kt
+++ b/skiko/src/androidMain/kotlin/org/jetbrains/skiko/Actuals.android.kt
@@ -68,6 +68,8 @@ internal actual fun ClipboardManager_getText(): String? {
     return clip.getItemAt(0)?.text?.toString()
 }
 
+internal actual fun ClipboardManager_hasText(): Boolean = !ClipboardManager_getText().isNullOrEmpty()
+
 actual typealias Cursor = android.view.PointerIcon
 
 // TODO: not sure if correct.

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/Actuals.awt.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/Actuals.awt.kt
@@ -68,6 +68,8 @@ internal actual fun ClipboardManager_getText(): String? {
     }
 }
 
+internal actual fun ClipboardManager_hasText(): Boolean = !ClipboardManager_getText().isNullOrEmpty()
+
 actual typealias Cursor = java.awt.Cursor
 
 internal actual fun CursorManager_setCursor(component: Any, cursor: Cursor) {

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skiko/Platform.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skiko/Platform.kt
@@ -26,10 +26,16 @@ open class ClipboardManager {
      * Get current system clipboard content as text.
      */
     open fun getText(): String? = ClipboardManager_getText()
+
+    /**
+     * Returns true, if clipboard contains text
+     */
+    open fun hasText(): Boolean = ClipboardManager_hasText()
 }
 
 internal expect fun ClipboardManager_setText(text: String)
 internal expect fun ClipboardManager_getText(): String?
+internal expect fun ClipboardManager_hasText(): Boolean
 
 /**
  * Manager to control cursor per native component.

--- a/skiko/src/iosMain/kotlin/org/jetbrains/skiko/Actuals.ios.kt
+++ b/skiko/src/iosMain/kotlin/org/jetbrains/skiko/Actuals.ios.kt
@@ -15,6 +15,8 @@ internal actual fun ClipboardManager_getText(): String? {
     return UIPasteboard.generalPasteboard.string
 }
 
+internal actual fun ClipboardManager_hasText(): Boolean = UIPasteboard.generalPasteboard.hasStrings()
+
 // TODO: not sure if correct.
 actual typealias Cursor = Any
 

--- a/skiko/src/jsMain/kotlin/org/jetbrains/skiko/Actuals.js.kt
+++ b/skiko/src/jsMain/kotlin/org/jetbrains/skiko/Actuals.js.kt
@@ -21,6 +21,8 @@ internal actual fun ClipboardManager_getText(): String? {
     return null
 }
 
+internal actual fun ClipboardManager_hasText(): Boolean = !ClipboardManager_getText().isNullOrEmpty()
+
 actual typealias Cursor = String
 
 internal actual fun CursorManager_setCursor(component: Any, cursor: Cursor) {

--- a/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/Actuals.linux.kt
+++ b/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/Actuals.linux.kt
@@ -12,6 +12,8 @@ internal actual fun ClipboardManager_getText(): String? {
     TODO("Implement ClipboardManager_getText() on Linux")
 }
 
+internal actual fun ClipboardManager_hasText(): Boolean = !ClipboardManager_getText().isNullOrEmpty()
+
 actual typealias Cursor = Any
 
 internal actual fun CursorManager_setCursor(component: Any, cursor: Cursor) {

--- a/skiko/src/macosMain/kotlin/org/jetbrains/skiko/Actuals.macos.kt
+++ b/skiko/src/macosMain/kotlin/org/jetbrains/skiko/Actuals.macos.kt
@@ -16,6 +16,8 @@ internal actual fun ClipboardManager_getText(): String? {
     return NSPasteboard.generalPasteboard.stringForType(dataType = NSPasteboardTypeString)
 }
 
+internal actual fun ClipboardManager_hasText(): Boolean = !ClipboardManager_getText().isNullOrEmpty()
+
 actual typealias Cursor = NSCursor
 
 // TODO: not sure if it is correct.


### PR DESCRIPTION
UIKit require permission to get clipboard content.
But, we can access method `generalPasteboard.hasStrings()` to get clipboard content. without permission.
It will help in this PR: https://github.com/JetBrains/androidx/pull/393