### PR TITLE
feat: add makeShader binding to RuntimeShaderBuilder

### DIFF
--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/RuntimeShaderBuilder.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/RuntimeShaderBuilder.kt
@@ -124,6 +124,17 @@ class RuntimeShaderBuilder internal constructor(ptr: NativePointer) : Managed(pt
             reachabilityBarrier(colorFilter)
         }
     }
+
+    fun makeShader(localMatrix: Matrix33? = null): Shader {
+        Stats.onNativeCall()
+        return try {
+            interopScope {
+                Shader(_nMakeShader(_ptr, toInterop(localMatrix?.mat)))
+            }
+        } finally {
+            reachabilityBarrier(this)
+        }
+    }
 }
 
 @ExternalSymbolName("org_jetbrains_skia_RuntimeShaderBuilder__1nMakeFromRuntimeEffect")
@@ -170,3 +181,6 @@ private external fun _nChildShader(builderPtr: NativePointer, uniformName: Inter
 
 @ExternalSymbolName("org_jetbrains_skia_RuntimeShaderBuilder__1nChildColorFilter")
 private external fun _nChildColorFilter(builderPtr: NativePointer, uniformName: InteropPointer, colorFilterPtr: NativePointer)
+
+@ExternalSymbolName("org_jetbrains_skia_RuntimeShaderBuilder__1nMakeShader")
+private external fun _nMakeShader(builderPtr: NativePointer, localMatrix: InteropPointer): NativePointer

--- a/skiko/src/commonTest/kotlin/org/jetbrains/skia/RuntimeShaderBuilderTest.kt
+++ b/skiko/src/commonTest/kotlin/org/jetbrains/skia/RuntimeShaderBuilderTest.kt
@@ -1,0 +1,74 @@
+package org.jetbrains.skia
+
+import org.jetbrains.skia.impl.use
+import org.jetbrains.skiko.tests.runTest
+import kotlin.test.Test
+
+class RuntimeShaderBuilderTest {
+
+    private fun renderAndReturnBytes(shader: Shader? = null): ByteArray {
+        return Surface.makeRasterN32Premul(20, 20).use {
+            val paint = Paint().apply {
+                setStroke(true)
+                strokeWidth = 2f
+            }
+
+            val region = Region().apply {
+                op(IRect(3, 3, 18, 18), Region.Op.UNION)
+            }
+
+            paint.shader = shader
+            it.canvas.drawRegion(region, paint)
+
+            val image = it.makeImageSnapshot()
+            Bitmap.makeFromImage(image).readPixels()!!
+        }
+    }
+
+    private fun shaderTest(shader: () -> Shader) = runTest {
+        // We just test that rendering with the given shader is successful.
+        renderAndReturnBytes(shader = shader())
+    }
+
+    @Test
+    fun customShader() = shaderTest {
+        val shaderSksl = """
+            uniform shader content;
+            uniform float greenAmount;
+            vec4 main(vec2 coord) {
+                vec4 c = content.eval(coord);
+                c.r += 0.5;
+                c.g = greenAmount;
+                c.b -= 0.5;
+                return c;
+            }
+        """
+
+        val runtimeEffect = RuntimeEffect.makeForShader(shaderSksl)
+        val runtimeShaderBuilder = RuntimeShaderBuilder(runtimeEffect)
+        runtimeShaderBuilder.child("content", Shader.makeColor(Color.BLUE))
+        runtimeShaderBuilder.uniform("greenAmount", 0.7f)
+        runtimeShaderBuilder.makeShader()
+    }
+
+    @Test
+    fun customShaderWithMatrix() = shaderTest {
+        val shaderSksl = """
+            uniform shader content;
+            uniform vec2 baValue;
+            vec4 main(vec2 coord) {
+                vec4 c = content.eval(coord);
+                c.rg += coord;
+                c.ba = baValue;
+                return c;
+            }
+        """
+
+        val runtimeEffect = RuntimeEffect.makeForShader(shaderSksl)
+        val runtimeShaderBuilder = RuntimeShaderBuilder(runtimeEffect)
+        runtimeShaderBuilder.child("content", Shader.makeColor(Color.MAGENTA))
+        runtimeShaderBuilder.uniform("baValue", 0.6f, 0.2f)
+        runtimeShaderBuilder.makeShader(Matrix33.makeRotate(45f))
+    }
+
+}

--- a/skiko/src/jvmMain/cpp/common/RuntimeShaderBuilder.cc
+++ b/skiko/src/jvmMain/cpp/common/RuntimeShaderBuilder.cc
@@ -123,3 +123,12 @@ Java_org_jetbrains_skia_RuntimeShaderBuilderKt__1nChildColorFilter
     sk_sp<SkColorFilter> colorFilter = sk_ref_sp<SkColorFilter>(reinterpret_cast<SkColorFilter*>(static_cast<uintptr_t>(childColorFilterPtr)));
     runtimeShaderBuilder->child(skString(env, childName).c_str()) = colorFilter;
 }
+
+extern "C" JNIEXPORT jlong JNICALL
+Java_org_jetbrains_skia_RuntimeShaderBuilderKt__1nMakeShader
+  (JNIEnv* env, jclass jclass, jlong builderPtr, jfloatArray localMatrixArr) {
+    SkRuntimeShaderBuilder* runtimeShaderBuilder = jlongToPtr<SkRuntimeShaderBuilder*>(builderPtr);
+    std::unique_ptr<SkMatrix> localMatrix = skMatrix(env, localMatrixArr);
+    sk_sp<SkShader> shader = runtimeShaderBuilder->makeShader(localMatrix.get());
+    return reinterpret_cast<jlong>(shader.release());
+}

--- a/skiko/src/nativeJsMain/cpp/RuntimeShaderBuilder.cc
+++ b/skiko/src/nativeJsMain/cpp/RuntimeShaderBuilder.cc
@@ -103,3 +103,11 @@ SKIKO_EXPORT void org_jetbrains_skia_RuntimeShaderBuilder__1nChildColorFilter
     sk_sp<SkColorFilter> colorFilter = sk_ref_sp<SkColorFilter>(reinterpret_cast<SkColorFilter*>(childColorFilterPtr));
     runtimeShaderBuilder->child(skString(childName).c_str()) = colorFilter;
 }
+
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_RuntimeShaderBuilder__1nMakeShader
+  (KNativePointer builderPtr, KFloat* localMatrixArr) {
+    SkRuntimeShaderBuilder* runtimeShaderBuilder = reinterpret_cast<SkRuntimeShaderBuilder*>(builderPtr);
+    std::unique_ptr<SkMatrix> localMatrix = skMatrix(localMatrixArr);
+    sk_sp<SkShader> shader = runtimeShaderBuilder->makeShader(localMatrix.get());
+    return reinterpret_cast<KNativePointer>(shader.release());
+}


### PR DESCRIPTION
Porting of [`RuntimeShaderBuilder.makeShader`](https://github.com/google/skia/blob/17ec2b96242ddb4ac63c92e1701d2d5fc11855e2/include/effects/SkRuntimeEffect.h#L488) binding. 
Trying to follow the rest of the codebase. 
I need this binding in my project to concatenate RuntimeEffects in a single Shader. 