### PR TITLE
Add test in jvm for SVGCanvas and fix SVGCanvas JNI issue

### DIFF
--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/svg/SVGCanvas.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/svg/SVGCanvas.kt
@@ -42,7 +42,7 @@ object SVGCanvas {
     fun make(bounds: Rect, out: WStream, convertTextToPaths: Boolean, prettyXML: Boolean): Canvas {
         Stats.onNativeCall()
         val ptr = try {
-            SVGCanvas_nMake(
+            _nMake(
                 bounds.left,
                 bounds.top,
                 bounds.right,
@@ -61,5 +61,6 @@ object SVGCanvas {
     }
 }
 
-@ExternalSymbolName("org_jetbrains_skia_svg_SVGCanvas__1nMake")
-private external fun SVGCanvas_nMake(left: Float, top: Float, right: Float, bottom: Float, wstreamPtr: NativePointer, flags: Int): NativePointer
+@ExternalSymbolName("org_jetbrains_skia_svg_SVGCanvasKt__1nMake")
+private external fun _nMake(left: Float, top: Float, right: Float, bottom: Float, wstreamPtr: NativePointer, flags: Int): NativePointer
+

--- a/skiko/src/jvmTest/kotlin/org/jetbrains/skia/svg/SVGCanvasTest.kt
+++ b/skiko/src/jvmTest/kotlin/org/jetbrains/skia/svg/SVGCanvasTest.kt
@@ -1,0 +1,62 @@
+package org.jetbrains.skiko.tests.org.jetbrains.skia.svg
+
+import org.jetbrains.skia.Data
+import org.jetbrains.skia.OutputWStream
+import org.jetbrains.skia.Point
+import org.jetbrains.skia.Rect
+import org.jetbrains.skia.svg.*
+import java.io.ByteArrayOutputStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SVGCanvasTest {
+
+    val svgText = """
+            <svg version="1.1"
+                 width="300" height="200"
+                 xmlns="http://www.w3.org/2000/svg">
+
+              <rect width="100%" height="100%" fill="red" />
+
+              <circle cx="150" cy="100" r="80" fill="green" />
+
+              <text x="150" y="125" font-size="60" text-anchor="middle" fill="white">SVG</text>
+
+            </svg>
+        """.trimIndent()
+
+    @Test
+    fun svgCanvasSmoke() {
+        val data = Data.makeFromBytes(svgText.encodeToByteArray())
+        val inputDom = SVGDOM(data)
+
+        val baos = ByteArrayOutputStream()
+        val svgCanvas = SVGCanvas.make(Rect.Companion.makeWH(300f, 200f), OutputWStream(baos))
+        inputDom.render(svgCanvas)
+        svgCanvas.close()
+
+        val svgCanvasData = Data.makeFromBytes(baos.toByteArray())
+        val dom = SVGDOM(svgCanvasData)
+
+        require(!dom.isClosed)
+        dom.setContainerSize(Point(100f, 100f))
+        dom.setContainerSize(101f, 101f)
+        require(dom.root != null)
+        val e = dom.root!!
+        require(e.x.unit == SVGLengthUnit.NUMBER)
+        require(e.y.unit == SVGLengthUnit.NUMBER)
+        require(e.width.unit == SVGLengthUnit.NUMBER)
+        require(e.height.unit == SVGLengthUnit.NUMBER)
+        require(e.viewBox == null)
+        require(e.tag == SVGTag.SVG)
+        e.viewBox = Rect(0f, 1f, 100f, 200f)
+
+        val aspectRatio =
+            SVGPreserveAspectRatio(SVGPreserveAspectRatioAlign.XMIN_YMIN, SVGPreserveAspectRatioScale.MEET)
+        e.preserveAspectRatio = aspectRatio
+        assertEquals(aspectRatio, e.preserveAspectRatio)
+        require(e.getIntrinsicSize(SVGLengthContext(100f, 100f)).x == 300f)
+        e.viewBox = Rect.makeXYWH(0f, 1f, 2f, 3f)
+        require(e.viewBox == Rect.makeXYWH(0f, 1f, 2f, 3f))
+    }
+}


### PR DESCRIPTION
Hi there 

I tried to use the SVGCanvas in some of our projects, but noticed that there was an `UnsatisfiedLinkError` when trying to use it.
```
'long org.jetbrains.skia.svg.SVGCanvasKt.SVGCanvas_nMake(float, float, float, float, long, int)'
java.lang.UnsatisfiedLinkError: 'long org.jetbrains.skia.svg.SVGCanvasKt.SVGCanvas_nMake(float, float, float, float, long, int)'
	at org.jetbrains.skia.svg.SVGCanvasKt.SVGCanvas_nMake(Native Method)
	at org.jetbrains.skia.svg.SVGCanvasKt.access$SVGCanvas_nMake(SVGCanvas.kt:1)
	at org.jetbrains.skia.svg.SVGCanvas.make(SVGCanvas.kt:45)
	at org.jetbrains.skia.svg.SVGCanvas.make(SVGCanvas.kt:25)
```

Upon further inspection I figured out that the `ExternalSymbolName` name was wrong and did not match up to the compiled symbol in the C++ JNI wrapper code. 

In this PR I fixed the issue and added a test, borrowing a bit from the SVGDom's test. I added the test under the `jvmTest` module just for the simple fact that I could not figure out how to make a `OutputWStream` for the common module.

Please let me know if you require anything else to merge this PR.