### PR TITLE
Make device scaling reactivity more reliable and fix layout glitch

### DIFF
--- a/samples/SkiaAwtSample/src/main/kotlin/SkiaAwtSample/App.kt
+++ b/samples/SkiaAwtSample/src/main/kotlin/SkiaAwtSample/App.kt
@@ -38,9 +38,8 @@ fun createWindow(title: String, exitOnClose: Boolean) = SwingUtilities.invokeLat
     val window = JFrame(title)
     window.defaultCloseOperation =
         if (exitOnClose) WindowConstants.EXIT_ON_CLOSE else WindowConstants.DISPOSE_ON_CLOSE
-    window.title = title
-
-    skiaLayer.attachTo(window.contentPane)
+    window.background = Color.GREEN
+    window.contentPane = skiaLayer
 
     // Create menu.
     val menuBar = JMenuBar()
@@ -126,15 +125,12 @@ fun createWindow(title: String, exitOnClose: Boolean) = SwingUtilities.invokeLat
         }
         skiaLayer.transparency = true
     } else {
-        skiaLayer.background = Color.WHITE
+        skiaLayer.background = Color.RED
     }
 
     // MANDATORY: set window preferred size before calling pack()
     window.preferredSize = Dimension(800, 600)
     window.pack()
-    skiaLayer.disableTitleBar(64f)
-    window.pack()
-    skiaLayer.paint(window.graphics)
     window.isVisible = true
 }
 

--- a/skiko/src/awtMain/cpp/linux/drawlayer.cc
+++ b/skiko/src/awtMain/cpp/linux/drawlayer.cc
@@ -82,12 +82,6 @@ extern "C"
         }
     }
 
-    JNIEXPORT jfloat JNICALL Java_org_jetbrains_skiko_PlatformOperationsKt_linuxGetDpiScaleNative(JNIEnv *env, jobject properties, jlong platformInfoPtr)
-    {
-        JAWT_X11DrawingSurfaceInfo *dsi_x11 = fromJavaPointer<JAWT_X11DrawingSurfaceInfo *>(platformInfoPtr);
-        return (float) getDpiScaleByDisplay(dsi_x11->display);
-    }
-
     JNIEXPORT jfloat JNICALL Java_org_jetbrains_skiko_SetupKt_linuxGetSystemDpiScale(JNIEnv *env, jobject layer)
     {
         return (float) getDpiScale();

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/HardwareLayer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/HardwareLayer.kt
@@ -18,13 +18,6 @@ internal open class HardwareLayer(
         }
     }
 
-    // getDpiScale is expensive operation on some platforms, so we cache it
-    private var _contentScale: Float? = null
-
-    fun defineContentScale() {
-        _contentScale = getDpiScale()
-    }
-
     override fun paint(g: Graphics) {}
 
     open fun init() {
@@ -43,22 +36,6 @@ internal open class HardwareLayer(
     private external fun nativeInit(platformInfo: Long)
     private external fun nativeDispose()
 
-    // TODO checkContentScale is called before init. it is ok, but when we fix getDpiScale on Linux we should check [isInit]
-    fun checkContentScale(): Boolean {
-        val contentScale = getDpiScale()
-        if (contentScale != _contentScale) {
-            _contentScale = contentScale
-            return true
-        }
-        return false
-    }
-
-    private fun getDpiScale(): Float {
-        val scale = platformOperations.getDpiScale(this)
-        check(scale > 0) { "HardwareLayer.contentScale isn't positive: $contentScale"}
-        return scale
-    }
-
     val contentHandle: Long
         get() = useDrawingSurfacePlatformInfo(::getContentHandle)
 
@@ -67,9 +44,6 @@ internal open class HardwareLayer(
 
     val currentDPI: Int
         get() = useDrawingSurfacePlatformInfo(::getCurrentDPI)
-
-    val contentScale: Float
-        get() = _contentScale!!
 
     var fullscreen: Boolean
         get() = platformOperations.isFullscreen(this)

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/PlatformOperations.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/PlatformOperations.kt
@@ -41,7 +41,6 @@ internal interface PlatformOperations {
     fun setFullscreen(component: Component, value: Boolean)
     fun disableTitleBar(component: Component, headerHeight: Float)
     fun orderEmojiAndSymbolsPopup()
-    fun getDpiScale(component: Component): Float
 }
 
 internal val platformOperations: PlatformOperations by lazy {
@@ -54,10 +53,6 @@ internal val platformOperations: PlatformOperations by lazy {
 
                 override fun setFullscreen(component: Component, value: Boolean) {
                     osxSetFullscreenNative(component, value)
-                }
-
-                override fun getDpiScale(component: Component): Float {
-                    return component.graphicsConfiguration.defaultTransform.scaleX.toFloat()
                 }
 
                 override fun disableTitleBar(component: Component, headerHeight: Float) {
@@ -88,10 +83,6 @@ internal val platformOperations: PlatformOperations by lazy {
 
                 override fun orderEmojiAndSymbolsPopup() {
                 }
-
-                override fun getDpiScale(component: Component): Float {
-                    return component.graphicsConfiguration.defaultTransform.scaleX.toFloat()
-                }
             }
         }
         OS.Linux -> {
@@ -113,10 +104,6 @@ internal val platformOperations: PlatformOperations by lazy {
 
                 override fun orderEmojiAndSymbolsPopup() {
                 }
-
-                override fun getDpiScale(component: Component): Float {
-                    return component.graphicsConfiguration.defaultTransform.scaleX.toFloat()
-                }
             }
         }
         OS.Android -> TODO()
@@ -131,6 +118,3 @@ external private fun osxIsFullscreenNative(component: Component): Boolean
 external private fun osxSetFullscreenNative(component: Component, value: Boolean)
 external private fun osxDisableTitleBar(component: Component, headerHeight: Float)
 external private fun osxOrderEmojiAndSymbolsPopup()
-
-// Linux
-external private fun linuxGetDpiScaleNative(platformInfo: Long): Float

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt
@@ -2,6 +2,8 @@ package org.jetbrains.skiko
 
 import org.jetbrains.skia.*
 import org.jetbrains.skia.Canvas
+import org.jetbrains.skiko.hostOs
+import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.redrawer.Redrawer
 import java.awt.Color
 import java.awt.Component
@@ -83,7 +85,6 @@ actual open class SkiaLayer internal constructor(
                 //    For example, on macOs when we resize window or change DPI
                 //
                 // 3. to avoid double paint in one single frame, use needRedraw instead of redrawImmediately
-                this@SkiaLayer.checkContentScale()
                 redrawer?.needRedraw()
             }
 
@@ -109,9 +110,23 @@ actual open class SkiaLayer internal constructor(
         }
         @Suppress("LeakingThis")
         add(backedLayer)
+
         backedLayer.addHierarchyListener {
             if (it.changeFlags and HierarchyEvent.SHOWING_CHANGED.toLong() != 0L) {
                 checkShowing()
+            }
+        }
+
+        addPropertyChangeListener("graphicsContextScaleTransform") {
+            redrawer?.syncSize()
+            notifyChange(PropertyKind.ContentScale)
+
+            // Workaround for JBR-5259
+            if (hostOs == OS.Windows) {
+                SwingUtilities.invokeLater {
+                    backedLayer.setLocation(1, 0)
+                    backedLayer.setLocation(0, 0)
+                }
             }
         }
     }
@@ -129,8 +144,6 @@ actual open class SkiaLayer internal constructor(
         super.addNotify()
         val window = SwingUtilities.getRoot(this) as Window
         window.addComponentListener(fullscreenAdapter)
-        backedLayer.defineContentScale()
-        checkContentScale()
         checkShowing()
         init(isInited)
     }
@@ -158,7 +171,7 @@ actual open class SkiaLayer internal constructor(
     }
 
     actual val contentScale: Float
-        get() = backedLayer.contentScale
+        get() = graphicsConfiguration.defaultTransform.scaleX.toFloat()
 
     /**
      * Returns the pointer to an OS specific handle (native resource) of the [SkiaLayer].
@@ -340,21 +353,14 @@ actual open class SkiaLayer internal constructor(
         }
     }
 
-    override fun setBounds(x: Int, y: Int, width: Int, height: Int) {
-        var roundedWidth = width
-        var roundedHeight = height
-        if (isInited) {
-            roundedWidth = roundSize(width)
-            roundedHeight = roundSize(height)
-        }
-        super.setBounds(x, y, roundedWidth, roundedHeight)
-        backedLayer.setSize(roundedWidth, roundedHeight)
+    override fun doLayout() {
+        val (roundedWidth, roundedHeight) = if (isInited) roundSize(width) to roundSize(height) else width to height
+        backedLayer.setBounds(0, 0, roundedWidth, roundedHeight)
+        backedLayer.validate()
         redrawer?.syncSize()
     }
 
     override fun paint(g: java.awt.Graphics) {
-        super.paint(g)
-        checkContentScale()
         // `paint` can be called when we already inside `draw` method.
         //
         // For example if we call some AWT function inside renderer.onRender,
@@ -365,17 +371,6 @@ actual open class SkiaLayer internal constructor(
             redrawer?.needRedraw()
         } else {
             redrawer?.redrawImmediately()
-        }
-    }
-
-    /*
-    In AWT there is no a change DPI event; so we should call this function when we expect that DPI maybe changed
-    We hope that call it on AWT/SWING `paint` and our update is enough
-     */
-    private fun checkContentScale() {
-        if (backedLayer.checkContentScale()) {
-            notifyChange(PropertyKind.ContentScale)
-            redrawer?.syncSize()
         }
     }
 
@@ -503,8 +498,6 @@ actual open class SkiaLayer internal constructor(
     internal fun update(nanoTime: Long) {
         check(isEventDispatchThread()) { "Method should be called from AWT event dispatch thread" }
         check(!isDisposed) { "SkiaLayer is disposed" }
-
-        checkContentScale()
 
         FrameWatcher.nextFrame()
         fpsCounter?.tick()

--- a/skiko/src/jvmMain/cpp/common/stubs.cc
+++ b/skiko/src/jvmMain/cpp/common/stubs.cc
@@ -15,12 +15,6 @@ void skikoUnimplemented(const char* message) {
 // we put here stubs for all OS specific native methods.
 
 #ifndef SK_BUILD_FOR_LINUX
-JNIEXPORT jfloat JNICALL Java_org_jetbrains_skiko_PlatformOperationsKt_linuxGetDpiScaleNative(
-    JNIEnv *env, jobject properties, jlong platformInfoPtr) {
-    skikoUnimplemented("Java_org_jetbrains_skiko_PlatformOperationsKt_linuxGetDpiScaleNative");
-    return 0;
-}
-
 JNIEXPORT jfloat JNICALL Java_org_jetbrains_skiko_SetupKt_linuxGetSystemDpiScale(JNIEnv *env, jobject layer) {
     skikoUnimplemented("Java_org_jetbrains_skiko_SetupKt_linuxGetSystemDpiScale");
     return 0;


### PR DESCRIPTION
…on Windows

First off, I don't think there was any need for the repeated checks for device pixel ratio changes via `checkContentScale` because we should be able to rely on the `graphicsContextScaleTransform` property from AWT.

I removed the corresponding code and changed `contentScale` to directly return the platform-specific implementations from the toolkit/device. There's also no need to cache the value because the device and the graphics configuration already does it for us.

Secondly, there was a layout glitch on Windows when moving windows between monitors with different device pixel ratios. A fix has to happen directly in the JBR, but for now I created a semi-cheap workaround. See this issue and the linked ones for details: https://youtrack.jetbrains.com/issue/JBR-5259/Canvas-is-painted-at-the-wrong-position-after-dragging-JFrame-to-a-monitor-with-different-scale