### PR TITLE
prevent usage of dangling pointer to `MetalDevice`

### DIFF
--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
@@ -25,7 +25,11 @@ internal class MetalRedrawer(
     }
     private var drawLock = Any()
 
-    private val device: Long
+    private var device: Long
+        get() {
+            check(field != 0L) { "Device is not initialized" }
+            return field
+        }
     val adapterName: String
     val adapterMemorySize: Long
 
@@ -60,6 +64,7 @@ internal class MetalRedrawer(
         frameDispatcher.cancel()
         contextHandler.dispose()
         disposeDevice(device)
+        device = 0
         super.dispose()
     }
 
@@ -74,7 +79,9 @@ internal class MetalRedrawer(
             setVSyncEnabled(device, enabled = false)
             update(System.nanoTime())
             performDraw()
-            setVSyncEnabled(device, properties.isVsyncEnabled)
+            if (!isDisposed) {
+                setVSyncEnabled(device, properties.isVsyncEnabled)
+            }
         }
     }
 

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
@@ -78,8 +78,8 @@ internal class MetalRedrawer(
         inDrawScope {
             setVSyncEnabled(device, enabled = false)
             update(System.nanoTime())
-            performDraw()
-            if (!isDisposed) {
+            if (!isDisposed) { // Redrawer may be disposed in user code, during `update`
+                performDraw()
                 setVSyncEnabled(device, properties.isVsyncEnabled)
             }
         }


### PR DESCRIPTION
MetalRedrawer may be disposed during update which leads to use after free