### PR TITLE
Fix JVM invalid unicode strings interop

### DIFF
--- a/skiko/src/commonTest/kotlin/org/jetbrains/skia/ParagraphTest.kt
+++ b/skiko/src/commonTest/kotlin/org/jetbrains/skia/ParagraphTest.kt
@@ -35,11 +35,15 @@ class ParagraphTest {
         fontCollection().findTypefaces(emptyArray(), FontStyle.NORMAL)
     }
 
-    private suspend fun singleLineMetrics(text: String): LineMetrics {
+    private suspend fun layoutParagraph(text: String): Paragraph {
         return ParagraphBuilder(style, fontCollection()).use {
             it.addText(text)
             it.build()
-        }.layout(Float.POSITIVE_INFINITY).lineMetrics.first()
+        }.layout(Float.POSITIVE_INFINITY)
+    }
+
+    private suspend fun singleLineMetrics(text: String): LineMetrics {
+        return layoutParagraph(text).lineMetrics.first()
     }
 
     @Test
@@ -58,6 +62,14 @@ class ParagraphTest {
             assertEquals(2, lineMetrics.endIncludingNewline)
             assertEquals(2, lineMetrics.endExcludingWhitespaces)
         }
+    }
+    @Test
+    fun invalidUnicode() = runTest {
+        val invalidUnicodeText = "🦊".subSequence(0, 1).toString()
+
+        val paragraph = layoutParagraph(invalidUnicodeText)
+        assertEquals(invalidUnicodeText, paragraph.getText())
+        assertEquals(1, paragraph.lineNumber)
     }
 
     @Test

--- a/skiko/src/commonTest/kotlin/org/jetbrains/skia/ParagraphTest.kt
+++ b/skiko/src/commonTest/kotlin/org/jetbrains/skia/ParagraphTest.kt
@@ -64,11 +64,14 @@ class ParagraphTest {
         }
     }
     @Test
+    @SkipJsTarget // FIXME Emscripten's stringToUTF8 function does not correctly handle invalid unicode symbols.
     fun invalidUnicode() = runTest {
-        val invalidUnicodeText = "🦊".subSequence(0, 1).toString()
+        val invalidUnicodeText = "🦊qwerty".substring(1)
 
         val paragraph = layoutParagraph(invalidUnicodeText)
-        assertEquals(invalidUnicodeText, paragraph.getText())
+
+        // There is an intermediate conversation to UTF-8, so U+FFFD is expected instead of the invalid one.
+        assertEquals("�qwerty", paragraph.getText())
         assertEquals(1, paragraph.lineNumber)
     }
 


### PR DESCRIPTION
### The Problem
`utfToUtf8` function (that converted ["modified UTF-8"](https://docs.oracle.com/javase/1.5.0/docs/guide/jni/spec/types.html#wp16542) to standard UTF-8) accesses out-of-bounds memory in case of invalid unicode and produces invalid UTF-8 output that causes future layouting issues.

### What's changed
`utfToUtf8` was replaced to UTF-16 -> UTF-8 conversion from skia library (patched version).

Fixes https://github.com/JetBrains/compose-multiplatform/issues/2963