### PR TITLE
fix `SwingSkia` example

### DIFF
--- a/samples/SkiaAwtSample/src/main/kotlin/SkiaAwtSample/SkiaPanel.kt
+++ b/samples/SkiaAwtSample/src/main/kotlin/SkiaAwtSample/SkiaPanel.kt
@@ -4,8 +4,6 @@ import org.jetbrains.skiko.ClipComponent
 import org.jetbrains.skiko.SkiaLayer
 import java.awt.Color
 import java.awt.Component
-import java.awt.event.ComponentAdapter
-import java.awt.event.ComponentEvent
 import javax.swing.JLayeredPane
 
 open class SkiaPanel: JLayeredPane {
@@ -21,15 +19,13 @@ open class SkiaPanel: JLayeredPane {
         return super.add(component, Integer.valueOf(0))
     }
 
+    override fun doLayout() {
+        layer.setBounds(0, 0, width, height)
+    }
+
     override fun addNotify() {
         super.addNotify()
         super.add(layer, Integer.valueOf(10))
-
-        addComponentListener(object : ComponentAdapter() {
-            override fun componentResized(e: ComponentEvent) {
-                layer.setSize(width, height)
-            }
-        })
     }
 
      override fun removeNotify() {


### PR DESCRIPTION
component listeners are performed to late so for absolute positioning we need to stick with `doLayout`