### PR TITLE
Throw exception instead of force unwrapping Metal handles when initialising MetalRedrawer.

### DIFF
--- a/skiko/src/iosMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.ios.kt
+++ b/skiko/src/iosMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.ios.kt
@@ -12,7 +12,6 @@ import platform.CoreGraphics.CGContextRef
 import platform.CoreGraphics.CGSizeMake
 import platform.Foundation.NSRunLoop
 import platform.Foundation.NSSelectorFromString
-import platform.Metal.MTLCommandQueueProtocol
 import platform.Metal.MTLCreateSystemDefaultDevice
 import platform.Metal.MTLDeviceProtocol
 import platform.Metal.MTLPixelFormatBGRA8Unorm

--- a/skiko/src/iosMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.ios.kt
+++ b/skiko/src/iosMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.ios.kt
@@ -45,7 +45,7 @@ internal class MetalRedrawer(
     )
 
     init {
-        metalLayer.init(this.layer, contextHandler, this.device)
+        metalLayer.init(this.layer, contextHandler, device)
         caDisplayLink.setPaused(true)
         caDisplayLink.addToRunLoop(NSRunLoop.mainRunLoop, NSRunLoop.mainRunLoop.currentMode)
     }

--- a/skiko/src/iosMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.ios.kt
+++ b/skiko/src/iosMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.ios.kt
@@ -29,8 +29,8 @@ internal class MetalRedrawer(
     override val renderInfo: String get() = contextHandler.rendererInfo()
 
     private var isDisposed = false
-    internal val device: MTLDeviceProtocol
-    private val queue: MTLCommandQueueProtocol
+    internal val device = MTLCreateSystemDefaultDevice() ?: throw IllegalStateException("Metal is not supported on this system")
+    private val queue = device.newCommandQueue() ?: throw IllegalStateException("Couldn't create Metal command queue")
     private var currentDrawable: CAMetalDrawableProtocol? = null
     private val metalLayer = MetalLayer()
     private val frameListener: NSObject = FrameTickListener {
@@ -45,15 +45,6 @@ internal class MetalRedrawer(
     )
 
     init {
-        val device =
-            MTLCreateSystemDefaultDevice() ?: throw IllegalStateException("Metal is not supported on this system")
-
-        val queue =
-            device.newCommandQueue() ?: throw IllegalStateException("Couldn't create Metal command queue")
-
-        this.device = device
-        this.queue = queue
-
         metalLayer.init(this.layer, contextHandler, this.device)
         caDisplayLink.setPaused(true)
         caDisplayLink.addToRunLoop(NSRunLoop.mainRunLoop, NSRunLoop.mainRunLoop.currentMode)

--- a/skiko/src/macosMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.macos.kt
+++ b/skiko/src/macosMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.macos.kt
@@ -26,6 +26,7 @@ import platform.QuartzCore.kCALayerHeightSizable
 import platform.QuartzCore.kCALayerWidthSizable
 import kotlin.system.getTimeNanos
 import platform.CoreGraphics.CGSizeMake
+import platform.Metal.MTLCommandQueueProtocol
 
 /**
  * Metal [Redrawer] implementation for MacOs.
@@ -39,12 +40,21 @@ internal class MacOsMetalRedrawer(
     override val renderInfo: String get() = contextHandler.rendererInfo()
 
     private var isDisposed = false
-    internal val device = MTLCreateSystemDefaultDevice()!!
-    private val queue = device.newCommandQueue()!!
+    internal val device: MTLDeviceProtocol
+    private val queue: MTLCommandQueueProtocol
     private var currentDrawable: CAMetalDrawableProtocol? = null
     private val metalLayer = MetalLayer()
 
     init {
+        val device =
+            MTLCreateSystemDefaultDevice() ?: throw IllegalStateException("Metal is not supported on this system")
+
+        val queue =
+            device.newCommandQueue() ?: throw IllegalStateException("Couldn't create Metal command queue")
+
+        this.device = device
+        this.queue = queue
+
         metalLayer.init(skiaLayer, contextHandler, device)
     }
 

--- a/skiko/src/macosMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.macos.kt
+++ b/skiko/src/macosMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.macos.kt
@@ -26,7 +26,6 @@ import platform.QuartzCore.kCALayerHeightSizable
 import platform.QuartzCore.kCALayerWidthSizable
 import kotlin.system.getTimeNanos
 import platform.CoreGraphics.CGSizeMake
-import platform.Metal.MTLCommandQueueProtocol
 
 /**
  * Metal [Redrawer] implementation for MacOs.

--- a/skiko/src/macosMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.macos.kt
+++ b/skiko/src/macosMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.macos.kt
@@ -46,15 +46,6 @@ internal class MacOsMetalRedrawer(
     private val metalLayer = MetalLayer()
 
     init {
-        val device =
-            MTLCreateSystemDefaultDevice() ?: throw IllegalStateException("Metal is not supported on this system")
-
-        val queue =
-            device.newCommandQueue() ?: throw IllegalStateException("Couldn't create Metal command queue")
-
-        this.device = device
-        this.queue = queue
-
         metalLayer.init(skiaLayer, contextHandler, device)
     }
 

--- a/skiko/src/macosMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.macos.kt
+++ b/skiko/src/macosMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.macos.kt
@@ -40,8 +40,8 @@ internal class MacOsMetalRedrawer(
     override val renderInfo: String get() = contextHandler.rendererInfo()
 
     private var isDisposed = false
-    internal val device: MTLDeviceProtocol
-    private val queue: MTLCommandQueueProtocol
+    internal val device = MTLCreateSystemDefaultDevice() ?: throw IllegalStateException("Metal is not supported on this system")
+    private val queue = device.newCommandQueue() ?: throw IllegalStateException("Couldn't create Metal command queue")
     private var currentDrawable: CAMetalDrawableProtocol? = null
     private val metalLayer = MetalLayer()
 


### PR DESCRIPTION
Sometimes people crash on iOS simulator which glitched. Throwing an explicit exception stating the problem instead of force-unwrapping and wondering where NullPointerException in crash stacktrace came from should help us to discard unjustified issue reports.