### PR TITLE
Fix for losing presented drawables on JVM Mac OS

### DIFF
--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
@@ -22,10 +22,6 @@ import javax.swing.SwingUtilities.*
 @JvmInline
 internal value class MetalDevice(val ptr: Long)
 
-internal interface DisplayLinkCallback {
-    fun invoke()
-}
-
 /**
  * Provides a way to request draws on Skia canvas created in [layer] bounds using Metal GPU acceleration.
  *

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
@@ -139,6 +139,9 @@ internal class MetalRedrawer(
             delay(300)
     }
 
+    /**
+     * Avoid calling this method on main thread, it will sleep before next vsync happens if invoked multiple times.
+     */
     private fun performDraw() = synchronized(drawLock) {
         if (!isDisposed) {
             val handle = startRendering()

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
@@ -86,6 +86,11 @@ internal class MetalRedrawer(
         onContextInit()
     }
 
+    fun drawSync() {
+        layer.update(System.nanoTime())
+        performDraw()
+    }
+
     override fun dispose() = synchronized(drawLock) {
         frameDispatcher.cancel()
         contextHandler.dispose()

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
@@ -87,7 +87,8 @@ internal class MetalRedrawer(
     }
 
     fun drawSync() {
-        frameDispatcher.scheduleFrame()
+        layer.update(System.nanoTime())
+        performDraw()
     }
 
     override fun dispose() = synchronized(drawLock) {

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.withContext
 import org.jetbrains.skiko.*
 import org.jetbrains.skiko.context.MetalContextHandler
 import javax.swing.SwingUtilities.*
+import java.util.concurrent.Semaphore
 
 /**
  * Holder for pointer on MetalDevice described in "MetalDevice.h"
@@ -57,6 +58,11 @@ internal class MetalRedrawer(
             return currentDevice
         }
 
+    /**
+     * Semaphore that will allow only one [drawSync] dispatched during VSync
+     */
+    private val drawSyncSemaphore = Semaphore(1)
+
     init {
         val adapter = chooseAdapter(properties.adapterPriority.ordinal)
         val adapterName = getAdapterName(adapter)
@@ -77,6 +83,7 @@ internal class MetalRedrawer(
 
     private val frameDispatcher = FrameDispatcher(MainUIDispatcher) {
         if (layer.isShowing) {
+            println(System.nanoTime())
             update(System.nanoTime())
             draw()
         }
@@ -87,8 +94,7 @@ internal class MetalRedrawer(
     }
 
     fun drawSync() {
-        layer.update(System.nanoTime())
-        performDraw()
+        frameDispatcher.scheduleFrame()
     }
 
     override fun dispose() = synchronized(drawLock) {

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
@@ -55,21 +55,6 @@ internal class MetalRedrawer(
      */
     private var _device: MetalDevice?
 
-    private val displayLinkCallback = object : DisplayLinkCallback {
-        var time = System.nanoTime()
-
-        override fun invoke() {
-            val newTime = System.nanoTime()
-            val delta = newTime - time
-
-            println("Hi from DisplayLink ${delta}")
-
-            time = newTime
-
-            frameDispatcher.handleDisplayLinkFired()
-        }
-    }
-
     private val device: MetalDevice
         get() {
             val currentDevice = _device
@@ -83,7 +68,7 @@ internal class MetalRedrawer(
         val adapterMemorySize = getAdapterMemorySize(adapter)
         onDeviceChosen(adapterName)
         val initDevice = layer.backedLayer.useDrawingSurfacePlatformInfo {
-            MetalDevice(createMetalDevice(layer.windowHandle, layer.transparency, adapter, it, displayLinkCallback))
+            MetalDevice(createMetalDevice(layer.windowHandle, layer.transparency, adapter, it))
         }
         _device = initDevice
         contextHandler =
@@ -93,7 +78,7 @@ internal class MetalRedrawer(
 
     override val renderInfo: String get() = contextHandler.rendererInfo()
 
-    private val frameDispatcher = FrameDispatcher(MainUIDispatcher, true) {
+    private val frameDispatcher = FrameDispatcher(MainUIDispatcher) {
         if (layer.isShowing) {
             update(System.nanoTime())
             draw()
@@ -191,7 +176,7 @@ internal class MetalRedrawer(
     private fun isOccluded() = isOccluded(device.ptr)
 
     private external fun chooseAdapter(adapterPriority: Int): Long
-    private external fun createMetalDevice(window:Long, transparency: Boolean, adapter: Long, platformInfo: Long, displayLinkCallback: DisplayLinkCallback): Long
+    private external fun createMetalDevice(window:Long, transparency: Boolean, adapter: Long, platformInfo: Long): Long
     private external fun disposeDevice(device: Long)
     private external fun resizeLayers(device: Long, x: Int, y: Int, width: Int, height: Int)
     private external fun setLayerVisible(device: Long, isVisible: Boolean)

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
@@ -73,8 +73,6 @@ internal class MetalRedrawer(
 
     override val renderInfo: String get() = contextHandler.rendererInfo()
 
-    private val windowHandle = layer.windowHandle
-
     private val frameDispatcher = FrameDispatcher(MainUIDispatcher) {
         if (layer.isShowing) {
             update(System.nanoTime())
@@ -138,7 +136,7 @@ internal class MetalRedrawer(
         // When window is not visible - it doesn't make sense to redraw fast to avoid battery drain.
         // In theory, we could be more precise, and just suspend rendering in
         // `NSWindowDidChangeOcclusionStateNotification`, but current approach seems to work as well in practise.
-        if (isOccluded(windowHandle))
+        if (isOccluded())
             delay(300)
     }
 
@@ -171,6 +169,8 @@ internal class MetalRedrawer(
         setLayerVisible(device.ptr, isVisible)
     }
 
+    private fun isOccluded() = isOccluded(device.ptr)
+
     private external fun chooseAdapter(adapterPriority: Int): Long
     private external fun createMetalDevice(window:Long, transparency: Boolean, adapter: Long, platformInfo: Long): Long
     private external fun disposeDevice(device: Long)
@@ -178,7 +178,7 @@ internal class MetalRedrawer(
     private external fun setLayerVisible(device: Long, isVisible: Boolean)
     private external fun setContentScale(device: Long, contentScale: Float)
     private external fun setVSyncEnabled(device: Long, enabled: Boolean)
-    private external fun isOccluded(window: Long): Boolean
+    private external fun isOccluded(device: Long): Boolean
     private external fun getAdapterName(adapter: Long): String
     private external fun getAdapterMemorySize(adapter: Long): Long
     private external fun startRendering(): Long

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
@@ -2,7 +2,6 @@ package org.jetbrains.skiko.redrawer
 
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import org.jetbrains.skiko.*

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.withContext
 import org.jetbrains.skiko.*
 import org.jetbrains.skiko.context.MetalContextHandler
 import javax.swing.SwingUtilities.*
-import java.util.concurrent.Semaphore
 
 /**
  * Holder for pointer on MetalDevice described in "MetalDevice.h"
@@ -58,11 +57,6 @@ internal class MetalRedrawer(
             return currentDevice
         }
 
-    /**
-     * Semaphore that will allow only one [drawSync] dispatched during VSync
-     */
-    private val drawSyncSemaphore = Semaphore(1)
-
     init {
         val adapter = chooseAdapter(properties.adapterPriority.ordinal)
         val adapterName = getAdapterName(adapter)
@@ -83,7 +77,6 @@ internal class MetalRedrawer(
 
     private val frameDispatcher = FrameDispatcher(MainUIDispatcher) {
         if (layer.isShowing) {
-            println(System.nanoTime())
             update(System.nanoTime())
             draw()
         }

--- a/skiko/src/awtMain/objectiveC/macos/AWTMetalLayer.h
+++ b/skiko/src/awtMain/objectiveC/macos/AWTMetalLayer.h
@@ -1,3 +1,5 @@
+#ifdef SK_METAL
+
 #ifndef SK_AWT_METAL_LAYER_H
 #define SK_AWT_METAL_LAYER_H
 
@@ -10,4 +12,6 @@
 
 @end
 
-#endif //SK_AWT_METAL_LAYER_H
+#endif // SK_AWT_METAL_LAYER_H
+
+#endif // SK_METAL

--- a/skiko/src/awtMain/objectiveC/macos/AWTMetalLayer.h
+++ b/skiko/src/awtMain/objectiveC/macos/AWTMetalLayer.h
@@ -1,3 +1,6 @@
+#ifndef SK_AWT_METAL_LAYER_H
+#define SK_AWT_METAL_LAYER_H
+
 #import <QuartzCore/CAMetalLayer.h>
 #import <jni.h>
 
@@ -6,3 +9,5 @@
 @property jobject javaRef;
 
 @end
+
+#endif //SK_AWT_METAL_LAYER_H

--- a/skiko/src/awtMain/objectiveC/macos/AWTMetalLayer.h
+++ b/skiko/src/awtMain/objectiveC/macos/AWTMetalLayer.h
@@ -1,0 +1,8 @@
+#import <QuartzCore/CAMetalLayer.h>
+#import <jni.h>
+
+@interface AWTMetalLayer : CAMetalLayer
+
+@property jobject javaRef;
+
+@end

--- a/skiko/src/awtMain/objectiveC/macos/AWTMetalLayer.mm
+++ b/skiko/src/awtMain/objectiveC/macos/AWTMetalLayer.mm
@@ -1,0 +1,18 @@
+#import "AWTMetalLayer.h"
+
+@implementation AWTMetalLayer
+
+- (id)init
+{
+    self = [super init];
+
+    if (self) {
+        [self removeAllAnimations];
+        [self setAutoresizingMask: (kCALayerWidthSizable|kCALayerHeightSizable)];
+        [self setNeedsDisplayOnBoundsChange: YES];
+    }
+
+    return self;
+}
+
+@end

--- a/skiko/src/awtMain/objectiveC/macos/MetalContextHandler.mm
+++ b/skiko/src/awtMain/objectiveC/macos/MetalContextHandler.mm
@@ -29,11 +29,14 @@ JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_context_MetalContextHandler_mak
     @autoreleasepool {
         MetalDevice *device = (__bridge MetalDevice *) (void *) devicePtr;
         [device recreateDisplayLinkIfNeeded];
+        [device waitUntilVsync];
+        [device waitForQueueSlot];
 
         GrBackendRenderTarget* renderTarget = NULL;
 
         id<CAMetalDrawable> currentDrawable = [device.layer nextDrawable];
         if (!currentDrawable) {
+            [device freeQueueSlot];
             return NULL;
         }
         device.drawableHandle = currentDrawable;
@@ -56,6 +59,9 @@ JNIEXPORT void JNICALL Java_org_jetbrains_skiko_context_MetalContextHandler_fini
             id<MTLCommandBuffer> commandBuffer = [device.queue commandBuffer];
             commandBuffer.label = @"Present";
             [commandBuffer presentDrawable:currentDrawable];
+            [commandBuffer addCompletedHandler:^(id<MTLCommandBuffer> buffer) {
+                [device freeQueueSlot];
+            }];
             [commandBuffer commit];
             device.drawableHandle = nil;
         }

--- a/skiko/src/awtMain/objectiveC/macos/MetalContextHandler.mm
+++ b/skiko/src/awtMain/objectiveC/macos/MetalContextHandler.mm
@@ -3,8 +3,6 @@
 #import <jawt.h>
 #import <jawt_md.h>
 
-#import <QuartzCore/CAMetalLayer.h>
-#import <Metal/Metal.h>
 #import <GrDirectContext.h>
 #import <mtl/GrMtlBackendContext.h>
 #import <mtl/GrMtlTypes.h>

--- a/skiko/src/awtMain/objectiveC/macos/MetalContextHandler.mm
+++ b/skiko/src/awtMain/objectiveC/macos/MetalContextHandler.mm
@@ -11,6 +11,7 @@
 
 extern "C"
 {
+
 JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_context_MetalContextHandler_makeMetalContext(
     JNIEnv* env, jobject contextHandler, jlong devicePtr)
 {
@@ -27,6 +28,13 @@ JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_context_MetalContextHandler_mak
     JNIEnv* env, jobject contextHandler, jlong devicePtr, jint width, jint height)
 {
     @autoreleasepool {
+        static double prevTime = CACurrentMediaTime();
+
+        double newTime = CACurrentMediaTime();
+        NSLog(@"Frame time: %f", newTime - prevTime);
+
+        prevTime = newTime;
+
         MetalDevice *device = (__bridge MetalDevice *) (void *) devicePtr;
         [device recreateDisplayLinkIfNeeded];
         [device waitUntilVsync];

--- a/skiko/src/awtMain/objectiveC/macos/MetalContextHandler.mm
+++ b/skiko/src/awtMain/objectiveC/macos/MetalContextHandler.mm
@@ -28,13 +28,6 @@ JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_context_MetalContextHandler_mak
     JNIEnv* env, jobject contextHandler, jlong devicePtr, jint width, jint height)
 {
     @autoreleasepool {
-        static double prevTime = CACurrentMediaTime();
-
-        double newTime = CACurrentMediaTime();
-        NSLog(@"Frame time: %f", newTime - prevTime);
-
-        prevTime = newTime;
-
         MetalDevice *device = (__bridge MetalDevice *) (void *) devicePtr;
         [device recreateDisplayLinkIfNeeded];
         [device waitUntilVsync];

--- a/skiko/src/awtMain/objectiveC/macos/MetalContextHandler.mm
+++ b/skiko/src/awtMain/objectiveC/macos/MetalContextHandler.mm
@@ -28,6 +28,8 @@ JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_context_MetalContextHandler_mak
 {
     @autoreleasepool {
         MetalDevice *device = (__bridge MetalDevice *) (void *) devicePtr;
+        [device recreateDisplayLinkIfNeeded];
+
         GrBackendRenderTarget* renderTarget = NULL;
 
         id<CAMetalDrawable> currentDrawable = [device.layer nextDrawable];

--- a/skiko/src/awtMain/objectiveC/macos/MetalDevice.h
+++ b/skiko/src/awtMain/objectiveC/macos/MetalDevice.h
@@ -15,9 +15,12 @@
 @property (strong) id<MTLCommandQueue> queue;
 @property (strong) id<CAMetalDrawable> drawableHandle;
 
-- (instancetype)initWithContainer:(CALayer *)container adapter:(id<MTLDevice>)adapter window:(NSWindow *)window env:(JNIEnv *)env displayLinkCallback:(jobject)displayLinkCallback;
+- (instancetype)initWithContainer:(CALayer *)container adapter:(id<MTLDevice>)adapter window:(NSWindow *)window;
 - (void)recreateDisplayLinkIfNeeded;
 - (void)handleDisplayLinkFired;
+- (void)waitUntilVsync;
+- (void)waitForQueueSlot;
+- (void)freeQueueSlot;
 
 @end
 

--- a/skiko/src/awtMain/objectiveC/macos/MetalDevice.h
+++ b/skiko/src/awtMain/objectiveC/macos/MetalDevice.h
@@ -1,5 +1,8 @@
 #ifdef SK_METAL
 
+#ifndef SK_METAL_DEVICE_H
+#define SK_METAL_DEVICE_H
+
 #import <QuartzCore/QuartzCore.h>
 #import <AppKit/AppKit.h>
 #import <Metal/Metal.h>
@@ -24,4 +27,6 @@
 
 @end
 
-#endif
+#endif // SK_AWT_METAL_DEVICE_H
+
+#endif // SK_METAL

--- a/skiko/src/awtMain/objectiveC/macos/MetalDevice.h
+++ b/skiko/src/awtMain/objectiveC/macos/MetalDevice.h
@@ -6,9 +6,17 @@
 
 @end
 
+// Forward declarations for dependent implementation files not to depend on non-relevant types header inclusion.
+@class NSWindow;
+@class CALayer;
+@protocol MTLDevice;
+@protocol MTLCommandQueue;
+@protocol CAMetalDrawable;
+
 @interface MetalDevice : NSObject
 
 @property (weak) CALayer *container;
+@property (weak) NSWindow *window;
 @property (retain, strong) AWTMetalLayer *layer;
 @property (retain, strong) id<MTLDevice> adapter;
 @property (retain, strong) id<MTLCommandQueue> queue;

--- a/skiko/src/awtMain/objectiveC/macos/MetalDevice.h
+++ b/skiko/src/awtMain/objectiveC/macos/MetalDevice.h
@@ -1,26 +1,21 @@
 #ifdef SK_METAL
 
-@interface AWTMetalLayer : CAMetalLayer
+#import <QuartzCore/QuartzCore.h>
+#import <AppKit/AppKit.h>
+#import <Metal/Metal.h>
 
-@property jobject javaRef;
-
-@end
-
-// Forward declarations for dependent implementation files not to depend on non-relevant types header inclusion.
-@class NSWindow;
-@class CALayer;
-@protocol MTLDevice;
-@protocol MTLCommandQueue;
-@protocol CAMetalDrawable;
+#import "AWTMetalLayer.h"
 
 @interface MetalDevice : NSObject
 
 @property (weak) CALayer *container;
-@property (weak) NSWindow *window;
-@property (retain, strong) AWTMetalLayer *layer;
-@property (retain, strong) id<MTLDevice> adapter;
-@property (retain, strong) id<MTLCommandQueue> queue;
-@property (retain, strong) id<CAMetalDrawable> drawableHandle;
+@property (strong) NSWindow *window;
+@property (strong) AWTMetalLayer *layer;
+@property (strong) id<MTLDevice> adapter;
+@property (strong) id<MTLCommandQueue> queue;
+@property (strong) id<CAMetalDrawable> drawableHandle;
+
+- (instancetype)initWithContainer:(CALayer *)container adapter:(id<MTLDevice>)adapter window:(NSWindow *)window;
 
 @end
 

--- a/skiko/src/awtMain/objectiveC/macos/MetalDevice.h
+++ b/skiko/src/awtMain/objectiveC/macos/MetalDevice.h
@@ -15,7 +15,9 @@
 @property (strong) id<MTLCommandQueue> queue;
 @property (strong) id<CAMetalDrawable> drawableHandle;
 
-- (instancetype)initWithContainer:(CALayer *)container adapter:(id<MTLDevice>)adapter window:(NSWindow *)window;
+- (instancetype)initWithContainer:(CALayer *)container adapter:(id<MTLDevice>)adapter window:(NSWindow *)window env:(JNIEnv *)env displayLinkCallback:(jobject)displayLinkCallback;
+- (void)recreateDisplayLinkIfNeeded;
+- (void)handleDisplayLinkFired;
 
 @end
 

--- a/skiko/src/awtMain/objectiveC/macos/MetalDevice.mm
+++ b/skiko/src/awtMain/objectiveC/macos/MetalDevice.mm
@@ -1,8 +1,23 @@
 #import "MetalDevice.h"
 
-@implementation MetalDevice
+extern JavaVM* jvm;
 
-- (instancetype)initWithContainer:(CALayer *)container adapter:(id<MTLDevice>)adapter window:(NSWindow *)window;
+static CVReturn MetalDeviceDisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeStamp *now, const CVTimeStamp *outputTime, CVOptionFlags flagsIn, CVOptionFlags *flagsOut, void *displayLinkContext) {
+    MetalDevice *device = (__bridge MetalDevice *)displayLinkContext;
+
+    [device handleDisplayLinkFired];
+
+    return kCVReturnSuccess;
+}
+
+@implementation MetalDevice {
+    NSScreen *_displayLinkScreen;
+    CVDisplayLinkRef _displayLink;
+    jobject _displayLinkCallbackObject;
+    jmethodID _displayLinkCallbackMethod;
+}
+
+- (instancetype)initWithContainer:(CALayer *)container adapter:(id<MTLDevice>)adapter window:(NSWindow *)window env:(JNIEnv *)env displayLinkCallback:(jobject)displayLinkCallback
 {
     self = [super init];
 
@@ -13,6 +28,8 @@
         self.queue = [adapter newCommandQueue];
         self.window = window;
         self.layer = [AWTMetalLayer new];
+
+        _displayLinkScreen = nil;
 
         [container removeAllAnimations];
         [container setAutoresizingMask: (kCALayerWidthSizable|kCALayerHeightSizable)];
@@ -26,9 +43,77 @@
         self.layer.opaque = NO;
 
         [container addSublayer: self.layer];
+
+        // TODO: Release global ref
+
+        /// Make Kotlin callback object global and store handles to call its `invoke` method
+        _displayLinkCallbackObject = env->NewGlobalRef(displayLinkCallback);
+        assert(_displayLinkCallbackObject);
+
+        jclass displayLinkCallbackClass = env->GetObjectClass(_displayLinkCallbackObject);
+        assert(displayLinkCallbackClass);
+
+        _displayLinkCallbackMethod = env->GetMethodID(displayLinkCallbackClass, "invoke", "()V");
+        assert(_displayLinkCallbackMethod);
     }
 
     return self;
+}
+
+- (void)recreateDisplayLinkIfNeeded {
+
+    /// Check if last _displayLinkScreen is the same as current NSWindow one. If not, invalidate current displayLink and create a new one.
+    if (![self.window.screen isEqualTo: _displayLinkScreen]) {
+        [self invalidateDisplayLink];
+
+        _displayLinkScreen = self.window.screen;
+
+        NSDictionary* screenDescription = [_displayLinkScreen deviceDescription];
+        NSNumber* screenID = [screenDescription objectForKey:@"NSScreenNumber"];
+
+        /// TODO: create fallback for any possible failure
+        CVReturn result;
+
+        CVDisplayLinkRef displayLink;
+        result = CVDisplayLinkCreateWithCGDisplay([screenID unsignedIntValue], &displayLink);
+        assert(result == kCVReturnSuccess);
+
+        result = CVDisplayLinkSetOutputCallback(displayLink, &MetalDeviceDisplayLinkCallback, (__bridge void *)(self));
+        assert(result == kCVReturnSuccess);
+
+        _displayLink = displayLink;
+
+        result = CVDisplayLinkStart(displayLink);
+        assert(result == kCVReturnSuccess);
+
+        NSLog(@"DisplayLink launched for screen with ID: %@", screenID);
+    }
+}
+
+- (void)handleDisplayLinkFired {
+    JNIEnv* env = NULL;
+
+    jint result = jvm->GetEnv((void **)&env, JNI_VERSION_1_6);
+
+    if (result == JNI_EDETACHED) {
+        /// If the current thread is not attached to the JVM, attach it
+        /// TODO: do research on whether it can cause issues
+        if (jvm->AttachCurrentThread((void **)&env, NULL) != 0) {
+            env = NULL;
+        }
+    }
+
+    if (env) {
+        env->CallVoidMethod(_displayLinkCallbackObject, _displayLinkCallbackMethod);
+    }
+}
+
+- (void)invalidateDisplayLink {
+    if (_displayLink) {
+        CVDisplayLinkStop(_displayLink);
+        CVDisplayLinkRelease(_displayLink);
+        _displayLink = nil;
+    }
 }
 
 @end

--- a/skiko/src/awtMain/objectiveC/macos/MetalDevice.mm
+++ b/skiko/src/awtMain/objectiveC/macos/MetalDevice.mm
@@ -110,7 +110,7 @@ static CVReturn MetalDeviceDisplayLinkCallback(CVDisplayLinkRef displayLink, con
 
 - (void)waitForQueueSlot {
     /// In case we receive more encoded command buffers, than gpu can handle (GPU bottleneck),
-    /// we need to throttle it down and start a new frame only when the last one is finished
+    /// we need to throttle it down and start a new frame only when one currently run is finished
     ///
     /// see call place of `freeQueueSlot`
     dispatch_semaphore_wait(_presentingBuffersExhaustionSemaphore, DISPATCH_TIME_FOREVER);

--- a/skiko/src/awtMain/objectiveC/macos/MetalDevice.mm
+++ b/skiko/src/awtMain/objectiveC/macos/MetalDevice.mm
@@ -100,6 +100,7 @@ static CVReturn MetalDeviceDisplayLinkCallback(CVDisplayLinkRef displayLink, con
 - (void)waitUntilVsync {
     std::unique_lock<std::mutex> lock(_vsyncMutex);
 
+    /// `while` instead of `if` due to possibility of https://en.wikipedia.org/wiki/Spurious_wakeup
     while (!_vsyncReady) {
         _vsyncConditionVariable.wait(lock);
     }

--- a/skiko/src/awtMain/objectiveC/macos/MetalDevice.mm
+++ b/skiko/src/awtMain/objectiveC/macos/MetalDevice.mm
@@ -109,6 +109,10 @@ static CVReturn MetalDeviceDisplayLinkCallback(CVDisplayLinkRef displayLink, con
 }
 
 - (void)waitForQueueSlot {
+    /// In case we receive more encoded command buffers, than gpu can handle (GPU bottleneck),
+    /// we need to throttle it down and start a new frame only when the last one is finished
+    ///
+    /// see call place of `freeQueueSlot`
     dispatch_semaphore_wait(_presentingBuffersExhaustionSemaphore, DISPATCH_TIME_FOREVER);
 }
 

--- a/skiko/src/awtMain/objectiveC/macos/MetalDevice.mm
+++ b/skiko/src/awtMain/objectiveC/macos/MetalDevice.mm
@@ -1,0 +1,34 @@
+#import "MetalDevice.h"
+
+@implementation MetalDevice
+
+- (instancetype)initWithContainer:(CALayer *)container adapter:(id<MTLDevice>)adapter window:(NSWindow *)window;
+{
+    self = [super init];
+
+    if (self)
+    {
+        self.container = container;
+        self.adapter = adapter;
+        self.queue = [adapter newCommandQueue];
+        self.window = window;
+        self.layer = [AWTMetalLayer new];
+
+        [container removeAllAnimations];
+        [container setAutoresizingMask: (kCALayerWidthSizable|kCALayerHeightSizable)];
+        [container setNeedsDisplayOnBoundsChange: YES];
+
+        self.layer.device = adapter;
+        self.layer.pixelFormat = MTLPixelFormatBGRA8Unorm;
+        self.layer.contentsGravity = kCAGravityTopLeft;
+        CGFloat transparent[] = { 0.0f, 0.0f, 0.0f, 0.0f };
+        self.layer.backgroundColor = CGColorCreate(CGColorSpaceCreateDeviceRGB(), transparent);
+        self.layer.opaque = NO;
+
+        [container addSublayer: self.layer];
+    }
+
+    return self;
+}
+
+@end

--- a/skiko/src/awtMain/objectiveC/macos/MetalDevice.mm
+++ b/skiko/src/awtMain/objectiveC/macos/MetalDevice.mm
@@ -60,33 +60,33 @@ static CVReturn MetalDeviceDisplayLinkCallback(CVDisplayLinkRef displayLink, con
 }
 
 - (void)recreateDisplayLinkIfNeeded {
-
-    /// Check if last _displayLinkScreen is the same as current NSWindow one. If not, invalidate current displayLink and create a new one.
-    if (![self.window.screen isEqualTo: _displayLinkScreen]) {
-        [self invalidateDisplayLink];
-
-        _displayLinkScreen = self.window.screen;
-
-        NSDictionary* screenDescription = [_displayLinkScreen deviceDescription];
-        NSNumber* screenID = [screenDescription objectForKey:@"NSScreenNumber"];
-
-        /// TODO: create fallback for any possible failure
-        CVReturn result;
-
-        CVDisplayLinkRef displayLink;
-        result = CVDisplayLinkCreateWithCGDisplay([screenID unsignedIntValue], &displayLink);
-        assert(result == kCVReturnSuccess);
-
-        result = CVDisplayLinkSetOutputCallback(displayLink, &MetalDeviceDisplayLinkCallback, (__bridge void *)(self));
-        assert(result == kCVReturnSuccess);
-
-        _displayLink = displayLink;
-
-        result = CVDisplayLinkStart(displayLink);
-        assert(result == kCVReturnSuccess);
-
-        NSLog(@"DisplayLink launched for screen with ID: %@", screenID);
+    if ([self.window.screen isEqualTo: _displayLinkScreen]) {
+        return;
     }
+
+    [self invalidateDisplayLink];
+
+    _displayLinkScreen = self.window.screen;
+
+    NSDictionary* screenDescription = [_displayLinkScreen deviceDescription];
+    NSNumber* screenID = [screenDescription objectForKey:@"NSScreenNumber"];
+
+    /// TODO: create fallback for any possible failure
+    CVReturn result;
+
+    CVDisplayLinkRef displayLink;
+    result = CVDisplayLinkCreateWithCGDisplay([screenID unsignedIntValue], &displayLink);
+    assert(result == kCVReturnSuccess);
+
+    result = CVDisplayLinkSetOutputCallback(displayLink, &MetalDeviceDisplayLinkCallback, (__bridge void *)(self));
+    assert(result == kCVReturnSuccess);
+
+    _displayLink = displayLink;
+
+    result = CVDisplayLinkStart(displayLink);
+    assert(result == kCVReturnSuccess);
+
+    NSLog(@"DisplayLink launched for screen with ID: %@", screenID);
 }
 
 - (void)handleDisplayLinkFired {

--- a/skiko/src/awtMain/objectiveC/macos/MetalRedrawer.mm
+++ b/skiko/src/awtMain/objectiveC/macos/MetalRedrawer.mm
@@ -21,8 +21,8 @@
 extern "C"
 {
 
-void* objc_autoreleasePoolPush(void);
-void objc_autoreleasePoolPop(void*);
+void *objc_autoreleasePoolPush(void);
+void objc_autoreleasePoolPop(void *);
 
 JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_redrawer_MetalRedrawer_startRendering(
     JNIEnv * env, jobject redrawer)
@@ -31,9 +31,9 @@ JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_redrawer_MetalRedrawer_startRen
 }
 
 JNIEXPORT void JNICALL Java_org_jetbrains_skiko_redrawer_MetalRedrawer_endRendering(
-    JNIEnv * env, jobject redrawer, jlong handle)
+    JNIEnv *env, jobject redrawer, jlong handle)
 {
-    objc_autoreleasePoolPop((void*)handle);
+    objc_autoreleasePoolPop((void *)handle);
 }
 
 BOOL isUsingIntegratedGPU() {
@@ -108,7 +108,7 @@ JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_redrawer_MetalRedrawer_createMe
     @autoreleasepool {
         id<MTLDevice> adapter = (__bridge_transfer id<MTLDevice>) (void *) adapterPtr;
         NSObject<JAWT_SurfaceLayers>* dsi_mac = (__bridge NSObject<JAWT_SurfaceLayers> *) (void*) platformInfoPtr;
-        NSWindow* window = (__bridge NSWindow*) (void *) windowPtr;
+        NSWindow *window = (__bridge NSWindow *) (void *) windowPtr;
 
         CALayer *container = [dsi_mac windowLayer];
 

--- a/skiko/src/awtMain/objectiveC/macos/MetalRedrawer.mm
+++ b/skiko/src/awtMain/objectiveC/macos/MetalRedrawer.mm
@@ -103,7 +103,7 @@ JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_redrawer_MetalRedrawer_chooseAd
 }
 
 JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_redrawer_MetalRedrawer_createMetalDevice(
-    JNIEnv *env, jobject redrawer, jlong windowPtr, jboolean transparency, jlong adapterPtr, jlong platformInfoPtr, jobject displayLinkCallback)
+    JNIEnv *env, jobject redrawer, jlong windowPtr, jboolean transparency, jlong adapterPtr, jlong platformInfoPtr)
 {
     @autoreleasepool {
         id<MTLDevice> adapter = (__bridge_transfer id<MTLDevice>) (void *) adapterPtr;
@@ -112,7 +112,7 @@ JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_redrawer_MetalRedrawer_createMe
 
         CALayer *container = [dsi_mac windowLayer];
 
-        MetalDevice *device = [[MetalDevice alloc] initWithContainer:container adapter:adapter window:window env:env displayLinkCallback:displayLinkCallback];
+        MetalDevice *device = [[MetalDevice alloc] initWithContainer:container adapter:adapter window:window];
 
         device.layer.javaRef = env->NewGlobalRef(redrawer);
 

--- a/skiko/src/awtMain/objectiveC/macos/MetalRedrawer.mm
+++ b/skiko/src/awtMain/objectiveC/macos/MetalRedrawer.mm
@@ -62,8 +62,8 @@
 extern "C"
 {
 
-extern "C" void* objc_autoreleasePoolPush(void);
-extern "C" void objc_autoreleasePoolPop(void*);
+void* objc_autoreleasePoolPush(void);
+void objc_autoreleasePoolPop(void*);
 
 JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_redrawer_MetalRedrawer_startRendering(
     JNIEnv * env, jobject redrawer)

--- a/skiko/src/awtMain/objectiveC/macos/MetalRedrawer.mm
+++ b/skiko/src/awtMain/objectiveC/macos/MetalRedrawer.mm
@@ -103,7 +103,7 @@ JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_redrawer_MetalRedrawer_chooseAd
 }
 
 JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_redrawer_MetalRedrawer_createMetalDevice(
-    JNIEnv *env, jobject redrawer, jlong windowPtr, jboolean transparency, jlong adapterPtr, jlong platformInfoPtr)
+    JNIEnv *env, jobject redrawer, jlong windowPtr, jboolean transparency, jlong adapterPtr, jlong platformInfoPtr, jobject displayLinkCallback)
 {
     @autoreleasepool {
         id<MTLDevice> adapter = (__bridge_transfer id<MTLDevice>) (void *) adapterPtr;
@@ -112,7 +112,7 @@ JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_redrawer_MetalRedrawer_createMe
 
         CALayer *container = [dsi_mac windowLayer];
 
-        MetalDevice *device = [[MetalDevice alloc] initWithContainer:container adapter:adapter window:window];
+        MetalDevice *device = [[MetalDevice alloc] initWithContainer:container adapter:adapter window:window env:env displayLinkCallback:displayLinkCallback];
 
         device.layer.javaRef = env->NewGlobalRef(redrawer);
 

--- a/skiko/src/awtMain/objectiveC/macos/MetalRedrawer.mm
+++ b/skiko/src/awtMain/objectiveC/macos/MetalRedrawer.mm
@@ -3,12 +3,6 @@
 #import <jawt.h>
 #import <jawt_md.h>
 
-#import <Cocoa/Cocoa.h>
-#import <AppKit/AppKit.h>
-#import <QuartzCore/QuartzCore.h>
-#import <Metal/Metal.h>
-#import <QuartzCore/CAMetalLayer.h>
-
 #import <GrBackendSurface.h>
 #import <GrDirectContext.h>
 #import <mtl/GrMtlBackendContext.h>
@@ -23,42 +17,6 @@
 #define AdpapterPriorityAuto 0
 #define AdpapterPriorityIntegrated 1
 #define AdpapterPriorityDiscrete 2
-
-@implementation AWTMetalLayer
-
-- (id)init
-{
-    self = [super init];
-
-    assert(self != NULL);
-
-    [self removeAllAnimations];
-    [self setAutoresizingMask: (kCALayerWidthSizable|kCALayerHeightSizable)];
-    [self setNeedsDisplayOnBoundsChange: YES];
-
-    return self;
-}
-
-@end
-
-@implementation MetalDevice
-
-- (id) init
-{
-    self = [super init];
-
-    if (self)
-    {
-        self.layer = nil;
-        self.adapter = nil;
-        self.queue = nil;
-        self.drawableHandle = nil;
-    }
-
-    return self;
-}
-
-@end
 
 extern "C"
 {
@@ -149,37 +107,14 @@ JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_redrawer_MetalRedrawer_createMe
 {
     @autoreleasepool {
         id<MTLDevice> adapter = (__bridge_transfer id<MTLDevice>) (void *) adapterPtr;
-
-        MetalDevice *device = [MetalDevice new];
-
         NSObject<JAWT_SurfaceLayers>* dsi_mac = (__bridge NSObject<JAWT_SurfaceLayers> *) (void*) platformInfoPtr;
+        NSWindow* window = (__bridge NSWindow*) (void *) windowPtr;
 
         CALayer *container = [dsi_mac windowLayer];
-        [container removeAllAnimations];
-        [container setAutoresizingMask: (kCALayerWidthSizable|kCALayerHeightSizable)];
-        [container setNeedsDisplayOnBoundsChange: YES];
 
-        AWTMetalLayer *layer = [AWTMetalLayer new];
-        [container addSublayer: layer];
-        layer.javaRef = env->NewGlobalRef(redrawer);
+        MetalDevice *device = [[MetalDevice alloc] initWithContainer:container adapter:adapter window:window];
 
-        id<MTLCommandQueue> fQueue = [adapter newCommandQueue];
-
-        device.container = container;
-        device.layer = layer;
-        device.adapter = adapter;
-        device.queue = fQueue;
-
-        device.layer.device = device.adapter;
-        device.layer.pixelFormat = MTLPixelFormatBGRA8Unorm;
-        device.layer.contentsGravity = kCAGravityTopLeft;
-
-        CGFloat transparent[] = { 0.0f, 0.0f, 0.0f, 0.0f };
-        device.layer.backgroundColor = CGColorCreate(CGColorSpaceCreateDeviceRGB(), transparent);
-        device.layer.opaque = NO;
-
-        NSWindow* window = (__bridge NSWindow*) (void *) windowPtr;
-//        device.window = window;
+        device.layer.javaRef = env->NewGlobalRef(redrawer);
 
         if (transparency)
         {
@@ -285,10 +220,11 @@ JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_redrawer_MetalRedrawer_getAdapt
 }
 
 JNIEXPORT jboolean JNICALL Java_org_jetbrains_skiko_redrawer_MetalRedrawer_isOccluded(
-    JNIEnv *env, jobject redrawer, jlong windowPtr) {
+    JNIEnv *env, jobject redrawer, jlong devicePtr) {
     @autoreleasepool {
-        NSWindow* window = (__bridge NSWindow*) (void *) windowPtr;
-        return ([window occlusionState] & NSWindowOcclusionStateVisible) == 0;
+        MetalDevice *device = (__bridge MetalDevice *)(void *)devicePtr;
+
+        return ([device.window occlusionState] & NSWindowOcclusionStateVisible) == 0;
     }
 }
 

--- a/skiko/src/awtMain/objectiveC/macos/MetalRedrawer.mm
+++ b/skiko/src/awtMain/objectiveC/macos/MetalRedrawer.mm
@@ -4,6 +4,7 @@
 #import <jawt_md.h>
 
 #import <Cocoa/Cocoa.h>
+#import <AppKit/AppKit.h>
 #import <QuartzCore/QuartzCore.h>
 #import <Metal/Metal.h>
 #import <QuartzCore/CAMetalLayer.h>
@@ -177,9 +178,11 @@ JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_redrawer_MetalRedrawer_createMe
         device.layer.backgroundColor = CGColorCreate(CGColorSpaceCreateDeviceRGB(), transparent);
         device.layer.opaque = NO;
 
+        NSWindow* window = (__bridge NSWindow*) (void *) windowPtr;
+//        device.window = window;
+
         if (transparency)
         {
-            NSWindow* window = (__bridge NSWindow*) (void *) windowPtr;
             window.hasShadow = NO;
         }
 

--- a/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
+++ b/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
@@ -96,7 +96,7 @@ class SkiaLayerTest {
     }
 
     @OptIn(ExperimentalTime::class)
-//    @Ignore
+    @Ignore
     @Test
     fun `frame is rendered immediately`() = uiTest {
         val window = UiTestWindow(

--- a/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
+++ b/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
@@ -2,6 +2,7 @@ package org.jetbrains.skiko
 
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.yield
 import org.jetbrains.skia.Canvas
 import org.jetbrains.skia.FontMgr
@@ -12,6 +13,7 @@ import org.jetbrains.skia.paragraph.ParagraphBuilder
 import org.jetbrains.skia.paragraph.ParagraphStyle
 import org.jetbrains.skia.paragraph.TextStyle
 import org.jetbrains.skiko.context.JvmContextHandler
+import org.jetbrains.skiko.redrawer.MetalRedrawer
 import org.jetbrains.skiko.redrawer.Redrawer
 import org.jetbrains.skiko.util.ScreenshotTestRule
 import org.jetbrains.skiko.util.UiTestScope
@@ -24,9 +26,7 @@ import org.junit.Test
 import java.awt.BorderLayout
 import java.awt.Color
 import java.awt.Dimension
-import java.awt.event.ComponentAdapter
-import java.awt.event.ComponentEvent
-import java.awt.event.WindowEvent
+import java.awt.event.*
 import javax.swing.JFrame
 import javax.swing.JLayeredPane
 import javax.swing.JPanel
@@ -35,6 +35,8 @@ import javax.swing.WindowConstants
 import kotlin.random.Random
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
 
 @Suppress("BlockingMethodInNonBlockingContext", "SameParameterValue")
 class SkiaLayerTest {
@@ -55,6 +57,68 @@ class SkiaLayerTest {
 
     @get:Rule
     val screenshots = ScreenshotTestRule()
+
+    @OptIn(ExperimentalTime::class)
+    @Test
+    fun `frame is rendered immediately`() = uiTest {
+        val window = UiTestWindow(
+            properties = SkiaLayerProperties(
+                isVsyncEnabled = true
+            )
+        )
+        val colors = arrayOf(
+            Color.RED,
+            Color.GREEN,
+            Color.BLUE,
+            Color.YELLOW
+        )
+
+        var counter1 = 0
+        var counter2 = 0
+        val paint = Paint()
+
+        try {
+            window.setLocation(200, 200)
+            window.setSize(400, 600)
+            window.defaultCloseOperation = WindowConstants.EXIT_ON_CLOSE
+            window.layer.skikoView = object : SkikoView {
+                override fun onRender(canvas: Canvas, width: Int, height: Int, nanoTime: Long) {
+                    val c1 = counter1
+                    val c2 = counter2
+
+                    paint.color = colors[c1.mod(colors.size)].rgb
+                    canvas.drawRect(Rect(0f, 0f, width.toFloat(), height / 2f), paint)
+
+                    paint.color = colors[c2.mod(colors.size)].rgb
+                    canvas.drawRect(Rect(0f, height / 2f, width.toFloat(), height.toFloat()), paint)
+                }
+            }
+            window.isVisible = true
+
+            window.addKeyListener(object : KeyAdapter() {
+                override fun keyTyped(e: KeyEvent?) {
+                    launch {
+                        val redrawer = window.layer.redrawer as MetalRedrawer
+                        redrawer.drawSync()
+                        counter1 += 1
+                        redrawer.drawSync()
+                        counter2 += 1
+                        redrawer.drawSync()
+                    }
+                }
+            });
+
+            window.addWindowListener(object : WindowAdapter() {
+                override fun windowActivated(e: WindowEvent?) {
+                    window.requestFocus()
+                }
+            })
+
+            delay(Duration.INFINITE)
+        } finally {
+            window.close()
+        }
+    }
 
     @Test
     fun `should not leak native windows`() = uiTest {

--- a/skiko/src/awtTest/kotlin/org/jetbrains/skiko/util/UiTest.kt
+++ b/skiko/src/awtTest/kotlin/org/jetbrains/skiko/util/UiTest.kt
@@ -10,9 +10,10 @@ import javax.swing.JFrame
 
 internal fun uiTest(block: suspend UiTestScope.() -> Unit) {
     assumeFalse(GraphicsEnvironment.isHeadless())
-    assumeTrue(System.getProperty("skiko.test.ui.enabled", "false") == "true")
+//    assumeTrue(System.getProperty("skiko.test.ui.enabled", "false") == "true")
 
-    val renderApi = System.getProperty("skiko.test.ui.renderApi", "all")
+//    val renderApi = System.getProperty("skiko.test.ui.renderApi", "all")
+    val renderApi = "metal"
 
     runBlocking(MainUIDispatcher) {
         if (renderApi == "all") {

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skiko/FrameDispatcher.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skiko/FrameDispatcher.kt
@@ -28,7 +28,7 @@ class FrameDispatcher(
 
     private val job = scope.launch {
         while (true) {
-            /// Await for draw request
+            // Await for draw request
             frameChannel.receive()
 
             frameScheduled = false

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skiko/FrameDispatcher.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skiko/FrameDispatcher.kt
@@ -13,22 +13,36 @@ import kotlin.coroutines.CoroutineContext
  */
 class FrameDispatcher(
     scope: CoroutineScope,
-    private val onFrame: suspend () -> Unit
+    private val displayLinkLocked: Boolean,
+    private val onFrame: suspend () -> Unit,
 ) {
+    constructor(scope: CoroutineScope, onFrame: suspend () -> Unit) : this(scope, false, onFrame)
+
     constructor(
         context: CoroutineContext,
-        onFrame: suspend () -> Unit
+        displayLinkLocked: Boolean = false,
+        onFrame: suspend () -> Unit,
     ) : this(
         CoroutineScope(context),
+        displayLinkLocked,
         onFrame
     )
 
     private val frameChannel = Channel<Unit>(Channel.CONFLATED)
     private var frameScheduled = false
 
+    private val displayLinkChannel: Channel<Unit>? =
+        if (displayLinkLocked) Channel(Channel.CONFLATED)
+        else null
+
     private val job = scope.launch {
         while (true) {
+            /// Await for draw request
             frameChannel.receive()
+
+            /// Await for displayLink vsync if needed
+            displayLinkChannel?.receive()
+
             frameScheduled = false
             onFrame()
             // As per `yield()` documentation:
@@ -39,6 +53,12 @@ class FrameDispatcher(
             // What means for Swing dispatcher we'll process all pending events and resume renderer.
             yield()
         }
+    }
+
+    fun handleDisplayLinkFired() {
+        require(displayLinkLocked)
+
+        displayLinkChannel?.trySend(Unit)
     }
 
     fun cancel() {

--- a/skiko/src/jvmMain/cpp/common/impl/Library.cc
+++ b/skiko/src/jvmMain/cpp/common/impl/Library.cc
@@ -5,7 +5,19 @@
 #include "../paragraph/interop.hh"
 #include "../svg/interop.hh"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    JavaVM* jvm;
+
+#ifdef __cplusplus
+};
+#endif
+
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved) {
+    jvm = vm;
+
     JNIEnv* env;
     if (vm->GetEnv(reinterpret_cast<void**>(&env), SKIKO_JNI_VERSION) != JNI_OK)
         return JNI_ERR;

--- a/skiko/src/jvmMain/cpp/common/impl/Library.cc
+++ b/skiko/src/jvmMain/cpp/common/impl/Library.cc
@@ -5,19 +5,7 @@
 #include "../paragraph/interop.hh"
 #include "../svg/interop.hh"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-    JavaVM* jvm;
-
-#ifdef __cplusplus
-};
-#endif
-
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved) {
-    jvm = vm;
-
     JNIEnv* env;
     if (vm->GetEnv(reinterpret_cast<void**>(&env), SKIKO_JNI_VERSION) != JNI_OK)
         return JNI_ERR;


### PR DESCRIPTION
The idea is to throttle command buffers creation on condition variable, awaking waiters on it only once vsync is coming.

### Changes

- Implement blocking for generating commandBuffers with presentation using vsync. Vsync signals are controlled by DisplayLink which is dynamically created whenever NSWindow backing JPanel enters different screens (FPS can vary).
- Fix for potential problem with command buffers exhaustion, which can be arise in situation where CPU can encode commands faster, than GPU can render them (GPU bottleneck). In proposed implementation max 3 buffers can be inflight (as per triple buffering strategy).
- Minor refactor of Obj-C code and removal of redundant `@property` modifiers and nested `extern "C"`.
- NSWindow handle moved to MetalDevice