### PR TITLE
WIP: Fix frames scheduling on iOS

### DIFF
--- a/skiko/src/iosMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.ios.kt
+++ b/skiko/src/iosMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.ios.kt
@@ -16,10 +16,7 @@ import platform.Metal.MTLCreateSystemDefaultDevice
 import platform.Metal.MTLDeviceProtocol
 import platform.Metal.MTLPixelFormatBGRA8Unorm
 import platform.QuartzCore.*
-import platform.UIKit.UIScreen
-import platform.UIKit.UIView
 import platform.UIKit.window
-import platform.darwin.NSInteger
 import platform.darwin.NSObject
 
 internal class MetalRedrawer(
@@ -101,7 +98,7 @@ internal class MetalRedrawer(
     }
 
     private fun topUpRundownCounter() {
-        rundownCounter = 3
+        rundownCounter = RUNDOWN_COUNTER_TOP_VALUE
     }
 
     override fun needRedraw() {
@@ -136,6 +133,16 @@ internal class MetalRedrawer(
                 currentDrawable = null
             }
         }
+    }
+
+    companion object {
+        /**
+         * This value indicates how many frames CADisplayLink will continue to draw after the last [needRedraw] call
+         * until it pauses itself. The value is arbitrarily chosen. Must be at least 2 to avoid incorrect scheduling.
+         * It doesn't affect correctness, and the actual optimal value (if this machinery is needed at all)
+         * will be set once [rundownCounter] _todo_ investigation is finished.
+         */
+        private const val RUNDOWN_COUNTER_TOP_VALUE = 3
     }
 }
 

--- a/skiko/src/iosMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.ios.kt
+++ b/skiko/src/iosMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.ios.kt
@@ -51,8 +51,7 @@ internal class MetalRedrawer(
     private val frameListener: NSObject = FrameTickListener {
         rundownCounter -= 1
 
-        if (rundownCounter <= 0) {
-            rundownCounter = 0
+        if (rundownCounter == 0) {
             caDisplayLink.setPaused(true)
         }
 


### PR DESCRIPTION
The initial problem was caused by frames scheduling missing every second frame 70% of time. It was reliably reproduced by logging setPaused inside MetalRedrawer, where for each two `needRedraw` and consequent unpause, only one actual draw and consequent pause were happening, and timing between draw calls was twice the minimal refresh rate timing.

This PR fixes the problem by making CADisplayLink draw at least 3 consequent frames after last redrawCall before pausing.
While it certainly improves FPS almost twice as much for both 60hz and 120hz screens and make rendering hit actual max FPS targets (check TextDirection example in core repo), I still have some doubts about it actually solving the true reason it happens like that. Will require further investigation. Interesting finding is that original problem is noticeable during user input, animation driven by compose itself in normal cadence doesn't cause this issue.

For now enjoy _smoothness_ on all iOS targets.