### PR TITLE
Draft: iOS frames scheduling fix

### DIFF
--- a/skiko/src/iosMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.ios.kt
+++ b/skiko/src/iosMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.ios.kt
@@ -16,10 +16,7 @@ import platform.Metal.MTLCreateSystemDefaultDevice
 import platform.Metal.MTLDeviceProtocol
 import platform.Metal.MTLPixelFormatBGRA8Unorm
 import platform.QuartzCore.*
-import platform.UIKit.UIScreen
-import platform.UIKit.UIView
 import platform.UIKit.window
-import platform.darwin.NSInteger
 import platform.darwin.NSObject
 
 internal class MetalRedrawer(
@@ -101,7 +98,7 @@ internal class MetalRedrawer(
     }
 
     private fun topUpRundownCounter() {
-        rundownCounter = 3
+        rundownCounter = RUNDOWN_COUNTER_TOP_VALUE
     }
 
     override fun needRedraw() {
@@ -136,6 +133,16 @@ internal class MetalRedrawer(
                 currentDrawable = null
             }
         }
+    }
+
+    companion object {
+        /**
+         * This value indicates how many frames CADisplayLink will continue to draw after the last [needRedraw] call
+         * until it pauses itself. The value is arbitrarily chosen. Must be at least 2 to avoid incorrect scheduling.
+         * It doesn't affect correctness, and the actual optimal value (if this machinery is needed at all)
+         * will be set once [rundownCounter] _todo_ investigation is finished.
+         */
+        private const val RUNDOWN_COUNTER_TOP_VALUE = 3
     }
 }
 

--- a/skiko/src/iosMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.ios.kt
+++ b/skiko/src/iosMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.ios.kt
@@ -51,8 +51,7 @@ internal class MetalRedrawer(
     private val frameListener: NSObject = FrameTickListener {
         rundownCounter -= 1
 
-        if (rundownCounter <= 0) {
-            rundownCounter = 0
+        if (rundownCounter == 0) {
             caDisplayLink.setPaused(true)
         }
 


### PR DESCRIPTION
Start processing pointer event : 17035.92367720834
needRedraw : 17035.92496145834
schedule for next frame : 17035.924975958336
Finish processing pointer event : 17035.924986083337
displayLink callback : 17035.925012208336
dispatch draw : 17035.925722250005

Start processing pointer event : 17037.975465708336
Finish processing pointer event : 17037.975889250003
displayLink callback : 17037.975940083335
skip : 17037.975952958335
needRedraw : 17037.97625058334
dispatch immediately : 17037.978999875002