### PR TITLE
Reimplement the Canvas transformation functions 

### DIFF
--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Canvas.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Canvas.kt
@@ -1080,11 +1080,19 @@ open class Canvas internal constructor(ptr: NativePointer, managed: Boolean, int
     }
 
     fun translate(dx: Float, dy: Float): Canvas {
-        return concat(Matrix33.makeTranslate(dx, dy))
+        interopScope {
+            Stats.onNativeCall()
+            _nTranslate(_ptr, dx, dy)
+        }
+        return this
     }
 
     fun scale(sx: Float, sy: Float): Canvas {
-        return concat(Matrix33.makeScale(sx, sy))
+        interopScope {
+            Stats.onNativeCall()
+            _nScale(_ptr, sx, sy)
+        }
+        return this
     }
 
     /**
@@ -1092,15 +1100,27 @@ open class Canvas internal constructor(ptr: NativePointer, managed: Boolean, int
      * @return     this
      */
     fun rotate(deg: Float): Canvas {
-        return concat(Matrix33.makeRotate(deg))
+        interopScope {
+            Stats.onNativeCall()
+            _nRotate(_ptr, deg, 0f, 0f)
+        }
+        return this
     }
 
     fun rotate(deg: Float, x: Float, y: Float): Canvas {
-        return concat(Matrix33.makeRotate(deg, x, y))
+        interopScope {
+            Stats.onNativeCall()
+            _nRotate(_ptr, deg, x, y)
+        }
+        return this
     }
 
     fun skew(sx: Float, sy: Float): Canvas {
-        return concat(Matrix33.makeSkew(sx, sy))
+        interopScope {
+            Stats.onNativeCall()
+            _nSkew(_ptr, sx, sy)
+        }
+        return this
     }
 
     fun concat(matrix: Matrix33): Canvas {
@@ -1542,13 +1562,23 @@ private external fun _nClipPath(ptr: NativePointer, nativePath: NativePointer, m
 @ExternalSymbolName("org_jetbrains_skia_Canvas__1nClipRegion")
 private external fun _nClipRegion(ptr: NativePointer, nativeRegion: NativePointer, mode: Int)
 
+@ExternalSymbolName("org_jetbrains_skia_Canvas__1nTranslate")
+private external fun _nTranslate(ptr: NativePointer, dx: Float, dy: Float)
+
+@ExternalSymbolName("org_jetbrains_skia_Canvas__1nScale")
+private external fun _nScale(ptr: NativePointer, sx: Float, sy: Float)
+
+@ExternalSymbolName("org_jetbrains_skia_Canvas__1nRotate")
+private external fun _nRotate(ptr: NativePointer, deg: Float, x: Float, y: Float)
+
+@ExternalSymbolName("org_jetbrains_skia_Canvas__1nSkew")
+private external fun _nSkew(ptr: NativePointer, sx: Float, sy: Float)
+
 @ExternalSymbolName("org_jetbrains_skia_Canvas__1nConcat")
 private external fun _nConcat(ptr: NativePointer, matrix: InteropPointer)
 
-
 @ExternalSymbolName("org_jetbrains_skia_Canvas__1nConcat44")
 private external fun _nConcat44(ptr: NativePointer, matrix: InteropPointer)
-
 
 @ExternalSymbolName("org_jetbrains_skia_Canvas__1nReadPixels")
 private external fun _nReadPixels(ptr: NativePointer, bitmapPtr: NativePointer, srcX: Int, srcY: Int): Boolean

--- a/skiko/src/jvmMain/cpp/common/Canvas.cc
+++ b/skiko/src/jvmMain/cpp/common/Canvas.cc
@@ -278,6 +278,30 @@ extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_CanvasKt__1nConcat44
     canvas->concat(*m);
 }
 
+extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_CanvasKt__1nTranslate
+  (JNIEnv* env, jclass jclass, jlong ptr, jfloat dx, jfloat dy) {
+    SkCanvas* canvas = reinterpret_cast<SkCanvas*>(static_cast<uintptr_t>(ptr));
+    canvas->translate(dx, dy);
+}
+
+extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_CanvasKt__1nScale
+  (JNIEnv* env, jclass jclass, jlong ptr, jfloat sx, jfloat sy) {
+    SkCanvas* canvas = reinterpret_cast<SkCanvas*>(static_cast<uintptr_t>(ptr));
+    canvas->scale(sx, sy);
+}
+
+extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_CanvasKt__1nRotate
+  (JNIEnv* env, jclass jclass, jlong ptr, jfloat deg, jfloat x, jfloat y) {
+    SkCanvas* canvas = reinterpret_cast<SkCanvas*>(static_cast<uintptr_t>(ptr));
+    canvas->rotate(deg, x, y);
+}
+
+extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_CanvasKt__1nSkew
+  (JNIEnv* env, jclass jclass, jlong ptr, jfloat sx, jfloat sy) {
+    SkCanvas* canvas = reinterpret_cast<SkCanvas*>(static_cast<uintptr_t>(ptr));
+    canvas->skew(sx, sy);
+}
+
 extern "C" JNIEXPORT jint JNICALL Java_org_jetbrains_skia_CanvasKt__1nReadPixels
   (JNIEnv* env, jclass jclass, jlong ptr, jlong bitmapPtr, jint srcX, jint srcY) {
     SkCanvas* canvas = reinterpret_cast<SkCanvas*>(static_cast<uintptr_t>(ptr));

--- a/skiko/src/nativeJsMain/cpp/Canvas.cc
+++ b/skiko/src/nativeJsMain/cpp/Canvas.cc
@@ -269,6 +269,34 @@ SKIKO_EXPORT void org_jetbrains_skia_Canvas__1nConcat44
 }
 
 
+SKIKO_EXPORT void org_jetbrains_skia_Canvas__1nTranslate
+  (KNativePointer canvasPtr, KFloat dx, KFloat dy) {
+    SkCanvas* canvas = reinterpret_cast<SkCanvas*>((canvasPtr));
+    canvas->translate(dx, dy);
+}
+
+
+SKIKO_EXPORT void org_jetbrains_skia_Canvas__1nScale
+  (KNativePointer canvasPtr, KFloat sx, KFloat sy) {
+    SkCanvas* canvas = reinterpret_cast<SkCanvas*>((canvasPtr));
+    canvas->scale(sx, sy);
+}
+
+
+SKIKO_EXPORT void org_jetbrains_skia_Canvas__1nRotate
+  (KNativePointer canvasPtr, KFloat deg, KFloat x, KFloat y) {
+    SkCanvas* canvas = reinterpret_cast<SkCanvas*>((canvasPtr));
+    canvas->rotate(deg, x, y);
+}
+
+
+SKIKO_EXPORT void org_jetbrains_skia_Canvas__1nSkew
+  (KNativePointer canvasPtr, KFloat sx, KFloat sy) {
+    SkCanvas* canvas = reinterpret_cast<SkCanvas*>((canvasPtr));
+    canvas->skew(sx, sy);
+}
+
+
 SKIKO_EXPORT KInt org_jetbrains_skia_Canvas__1nReadPixels
   (KNativePointer ptr, KNativePointer bitmapPtr, KInt srcX, KInt srcY) {
     SkCanvas* canvas = reinterpret_cast<SkCanvas*>((ptr));


### PR DESCRIPTION
via the corresponding Skia functions directly, rather than by concatenating with a transformation matrix.

This appears to be significantly faster. Specifically in Compose, the canvas is translated for every node twice (by its position, and then back). Changing the `translate` function to perform a direct call to Skia transform makes drawing simple nodes much faster.