### PR TITLE
Fix complex blending on iOS

### DIFF
--- a/skiko/src/iosMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.ios.kt
+++ b/skiko/src/iosMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.ios.kt
@@ -224,6 +224,7 @@ internal class MetalLayer : CAMetalLayer {
             this.backgroundColor =
                 CGColorCreate(CGColorSpaceCreateDeviceRGB(), it.addressOf(0))
         }
+        this.framebufferOnly = false
         this.opaque = false // For UIKit interop through a "Hole"
         skiaLayer.view?.let {
             this.frame = it.frame


### PR DESCRIPTION
Skia performs complex blending via generaged shaders that require reading already drawn pixels. Setting [`framebufferOnly`](https://developer.apple.com/documentation/quartzcore/cametallayer/1478168-framebufferonly) to `false` allows it.
Google's similar issue: https://groups.google.com/g/skia-discuss/c/FTO0NSR_09Q

Partially fixes https://github.com/JetBrains/compose-multiplatform/issues/3222

PS Metal on desktop is still broken. Adding this flag is not enough there.