### PR TITLE
Fix complex blending on Metal

### DIFF
--- a/skiko/src/awtMain/objectiveC/macos/MetalRedrawer.mm
+++ b/skiko/src/awtMain/objectiveC/macos/MetalRedrawer.mm
@@ -176,6 +176,7 @@ JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_redrawer_MetalRedrawer_createMe
         CGFloat transparent[] = { 0.0f, 0.0f, 0.0f, 0.0f };
         device.layer.backgroundColor = CGColorCreate(CGColorSpaceCreateDeviceRGB(), transparent);
         device.layer.opaque = NO;
+        device.layer.framebufferOnly = NO;
 
         if (transparency)
         {

--- a/skiko/src/macosMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.macos.kt
+++ b/skiko/src/macosMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.macos.kt
@@ -167,6 +167,7 @@ internal class MetalLayer : CAMetalLayer {
             this.backgroundColor =
                 CGColorCreate(CGColorSpaceCreateDeviceRGB(), it.addressOf(0))
         }
+        this.framebufferOnly = false
         skiaLayer.nsView.layer = this
         skiaLayer.nsView.wantsLayer = true
         this.contentsGravity = kCAGravityTopLeft;


### PR DESCRIPTION
Addition to #728

The problem on macOS was that the device is not cleared properly (for blending purposes), so blending might look different, but after this fix it

1. can be solved on user side (manual extra clearing)
2. it does not affect gooey effect demo (with compose)

So, it's not directly related to that and doesn't block this fix.