### PR TITLE
Implement hostOs detection for web target

### DIFF
--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/Actuals.awt.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/Actuals.awt.kt
@@ -36,7 +36,7 @@ internal actual fun makeDefaultRenderFactory(): RenderFactory =
                 GraphicsApi.SOFTWARE_FAST -> LinuxSoftwareRedrawer(layer, analytics, properties)
                 else -> LinuxOpenGLRedrawer(layer, analytics, properties)
             }
-            OS.Android, OS.JS, OS.Ios -> throw UnsupportedOperationException("The AWT target doesn't support $hostOs")
+            OS.Android, OS.JS, OS.Ios, OS.Unknown -> throw UnsupportedOperationException("The AWT target doesn't support $hostOs")
         }
     }
 

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/PlatformOperations.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/PlatformOperations.kt
@@ -125,7 +125,7 @@ internal val platformOperations: PlatformOperations by lazy {
             }
         }
         OS.Android -> TODO()
-        OS.JS, OS.Ios -> {
+        OS.JS, OS.Ios, OS.Unknown -> {
             TODO("Commonize me")
         }
     }

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skiko/OsArch.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skiko/OsArch.kt
@@ -30,6 +30,7 @@ enum class KotlinBackend(val id: String) {
     JVM("jvm"),
     JS("js"),
     Native("native"),
+    WASM("wasm"),
     ;
 
     fun isNotJs() = this != JS

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skiko/OsArch.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skiko/OsArch.kt
@@ -6,7 +6,10 @@ enum class OS(val id: String) {
     Windows("windows"),
     MacOS("macos"),
     Ios("ios"),
-    JS("js")
+
+    @Deprecated("JS is invalid host OS name. Consider using enum KotlinBackend to detect JS.")
+    JS("js"),
+    Unknown("unknown")
     ;
 
     val isLinux

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skiko/OsArch.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skiko/OsArch.kt
@@ -25,8 +25,12 @@ enum class OS(val id: String) {
 enum class Arch(val id: String) {
     X64("x64"),
     Arm64("arm64"),
+    @Deprecated("JS is not valid Arch value")
     JS("js"),
-    WASM("wasm")
+    @Deprecated("WASM is not valid Arch value")
+    WASM("wasm"),
+    Unknown("unknown"),
+    ;
 }
 
 enum class KotlinBackend(val id: String) {

--- a/skiko/src/jsMain/kotlin/org/jetbrains/skiko/OsArch.js.kt
+++ b/skiko/src/jsMain/kotlin/org/jetbrains/skiko/OsArch.js.kt
@@ -47,6 +47,6 @@ internal fun detectHostOs(): OS {
         platformInfo.contains("Linux", true) -> OS.Linux
         platformInfo.contains("Mac", true) -> OS.MacOS
         platformInfo.contains("Win", true) -> OS.Windows
-        else -> OS.JS
+        else -> OS.Unknown
     }
 }

--- a/skiko/src/jsMain/kotlin/org/jetbrains/skiko/OsArch.js.kt
+++ b/skiko/src/jsMain/kotlin/org/jetbrains/skiko/OsArch.js.kt
@@ -2,9 +2,7 @@ package org.jetbrains.skiko
 
 import kotlinx.browser.window
 
-actual val hostOs: OS by lazy {
-    detectHostOs()
-}
+actual val hostOs: OS = detectHostOs()
 
 actual val hostArch: Arch = Arch.JS
 

--- a/skiko/src/jsMain/kotlin/org/jetbrains/skiko/OsArch.js.kt
+++ b/skiko/src/jsMain/kotlin/org/jetbrains/skiko/OsArch.js.kt
@@ -1,6 +1,10 @@
 package org.jetbrains.skiko
 
-actual val hostOs: OS = OS.JS
+import kotlinx.browser.window
+
+actual val hostOs: OS by lazy {
+    detectHostOs()
+}
 
 actual val hostArch: Arch = Arch.JS
 
@@ -10,3 +14,41 @@ actual val hostId by lazy {
 
 actual val kotlinBackend: KotlinBackend
     get() = KotlinBackend.JS
+
+/**
+ * A string identifying the platform on which the user's browser is running; for example:
+ * "MacIntel", "Win32", "Linux x86_64", "Linux x86_64".
+ * See https://developer.mozilla.org/en-US/docs/Web/API/Navigator/platform - deprecated
+ *
+ * A string containing the platform brand. For example, "Windows".
+ * See https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/platform - new API,
+ * but not supported in all browsers
+ */
+private fun getNavigatorInfo(): String =
+    js("navigator.userAgentData ? navigator.userAgentData.platform : navigator.platform") as String
+
+
+/**
+ * In a browser, user platform can be obtained from different places:
+ * - we attempt to use not-deprecated but experimental option first (not available in all browsers)
+ * - then we attempt to use a deprecated option
+ * - if both above return an empty string, we attempt to get `Platform` from `userAgent`
+ *
+ * Note: a client can spoof these values, so it's okay only for non-critical use cases.
+ */
+internal fun detectHostOs(): OS {
+    val platformInfo = getNavigatorInfo().takeIf {
+        it.isNotEmpty()
+    } ?: window.navigator.userAgent
+
+    return when {
+        platformInfo.contains("Android", true) -> OS.Android
+        platformInfo.contains("iPhone", true) -> OS.Ios
+        platformInfo.contains("iOS", true) -> OS.Ios
+        platformInfo.contains("iPad", true) -> OS.Ios
+        platformInfo.contains("Linux", true) -> OS.Linux
+        platformInfo.contains("Mac", true) -> OS.MacOS
+        platformInfo.contains("Win", true) -> OS.Windows
+        else -> OS.JS
+    }
+}

--- a/skiko/src/jsMain/kotlin/org/jetbrains/skiko/OsArch.js.kt
+++ b/skiko/src/jsMain/kotlin/org/jetbrains/skiko/OsArch.js.kt
@@ -4,7 +4,7 @@ import kotlinx.browser.window
 
 actual val hostOs: OS = detectHostOs()
 
-actual val hostArch: Arch = Arch.JS
+actual val hostArch: Arch = Arch.Unknown
 
 actual val hostId by lazy {
     "${hostOs.id}-${hostArch.id}"

--- a/skiko/src/jsTest/kotlin/org/jetbrains/skiko/HostOsTest.kt
+++ b/skiko/src/jsTest/kotlin/org/jetbrains/skiko/HostOsTest.kt
@@ -1,0 +1,56 @@
+package org.jetbrains.skiko.tests.org.jetbrains.skiko
+
+import org.jetbrains.skiko.OS
+import org.jetbrains.skiko.detectHostOs
+import org.jetbrains.skiko.hostOs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class HostOsTest {
+    @Test
+    fun canGetHostOs() {
+        assertNotEquals(OS.JS, hostOs)
+    }
+
+    @Test
+    fun canGetLinux() {
+        spoofUserAgentData("linux")
+        assertEquals(OS.Linux, detectHostOs())
+    }
+
+    @Test
+    fun canGetWindows() {
+        spoofUserAgentData("Windows")
+        assertEquals(OS.Windows, detectHostOs())
+    }
+
+    @Test
+    fun canGetMacos() {
+        spoofUserAgentData("macos")
+        assertEquals(OS.MacOS, detectHostOs())
+    }
+
+    @Test
+    fun canGetAndroid() {
+        spoofUserAgentData("android")
+        assertEquals(OS.Android, detectHostOs())
+    }
+
+    @Test
+    fun canGetIos() {
+        spoofUserAgentData("ios")
+        assertEquals(OS.Ios, detectHostOs())
+    }
+
+
+    @Test
+    fun fallbackToJs() {
+        spoofUserAgentData("somerandomedata")
+        assertEquals(OS.JS, detectHostOs())
+    }
+}
+
+private fun spoofUserAgentData(newValue: String) =
+    js("""navigator.__defineGetter__('userAgentData', function () { return { platform:newValue }; });""")
+

--- a/skiko/src/jsTest/kotlin/org/jetbrains/skiko/HostOsTest.kt
+++ b/skiko/src/jsTest/kotlin/org/jetbrains/skiko/HostOsTest.kt
@@ -45,9 +45,9 @@ class HostOsTest {
 
 
     @Test
-    fun fallbackToJs() {
+    fun fallbackToUnknown() {
         spoofUserAgentData("somerandomedata")
-        assertEquals(OS.JS, detectHostOs())
+        assertEquals(OS.Unknown, detectHostOs())
     }
 }
 

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/SkikoProperties.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/SkikoProperties.kt
@@ -70,7 +70,7 @@ object SkikoProperties {
             OS.Linux -> return GraphicsApi.OPENGL
             OS.Windows -> return GraphicsApi.DIRECT3D
             OS.Android -> return GraphicsApi.OPENGL
-            OS.JS, OS.Ios -> TODO("commonize me")
+            OS.JS, OS.Ios, OS.Unknown -> TODO("commonize me")
         }
     }
 
@@ -84,7 +84,7 @@ object SkikoProperties {
                 else -> listOf(GraphicsApi.DIRECT3D, GraphicsApi.OPENGL, GraphicsApi.SOFTWARE_FAST, GraphicsApi.SOFTWARE_COMPAT)
             }
             OS.Android -> return listOf(GraphicsApi.OPENGL)
-            OS.JS, OS.Ios -> TODO("commonize me")
+            OS.JS, OS.Ios, OS.Unknown -> TODO("commonize me")
         }
 
         val indexOfInitialApi = fallbackApis.indexOf(initialApi)


### PR DESCRIPTION
It's going to be used in compose to propertly configure KeyMapping and other os-specific features/configurations (potentially for scroll physics, etc). 