### PR TITLE
fix: compileWasm on Windows

### DIFF
--- a/skiko/buildSrc/src/main/kotlin/CompileSkikoCppTask.kt
+++ b/skiko/buildSrc/src/main/kotlin/CompileSkikoCppTask.kt
@@ -104,6 +104,7 @@ abstract class CompileSkikoCppTask() : AbstractSkikoNativeToolTask() {
 
     override fun createArgBuilder(): ArgBuilder =
         if (buildTargetOS.get().isWindows) VisualCppCompilerArgBuilder()
+        else if(hostOs.isWindows && buildTargetOS.get() == OS.Wasm) WindowsSanitizedPathsArgBuilder()
         else super.createArgBuilder()
 
     override fun execute(mode: ToolMode, args: ArgBuilder) {
@@ -157,6 +158,7 @@ abstract class CompileSkikoCppTask() : AbstractSkikoNativeToolTask() {
                 executable = compilerExecutablePath
                 workingDir = outDir
                 this.args = listOf(workArgs.createArgFile(argFile))
+                print("")
             }
         }
 

--- a/skiko/buildSrc/src/main/kotlin/LinkSkikoTask.kt
+++ b/skiko/buildSrc/src/main/kotlin/LinkSkikoTask.kt
@@ -32,6 +32,7 @@ abstract class LinkSkikoTask : AbstractSkikoNativeToolTask() {
 
     override fun createArgBuilder(): ArgBuilder =
         if (buildTargetOS.get().isWindows) VisualCppLinkerArgBuilder()
+        else if(hostOs.isWindows && buildTargetOS.get() == OS.Wasm) WindowsSanitizedPathsArgBuilder()
         else super.createArgBuilder()
 
     override fun execute(mode: ToolMode, args: ArgBuilder) {

--- a/skiko/buildSrc/src/main/kotlin/internal/utils/ArgBuilder.kt
+++ b/skiko/buildSrc/src/main/kotlin/internal/utils/ArgBuilder.kt
@@ -134,3 +134,7 @@ internal class VisualCppLinkerArgBuilder : BaseVisualStudioBuildToolsArgBuilder(
         }
     }
 }
+
+internal class WindowsSanitizedPathsArgBuilder: BaseVisualStudioBuildToolsArgBuilder() {
+    override fun newSelfInstance(): ArgBuilder = WindowsSanitizedPathsArgBuilder()
+}

--- a/skiko/buildSrc/src/main/kotlin/properties.kt
+++ b/skiko/buildSrc/src/main/kotlin/properties.kt
@@ -40,7 +40,7 @@ fun compilerForTarget(os: OS, arch: Arch): String =
         OS.Android -> "clang++"
         OS.Windows -> "cl.exe"
         OS.MacOS, OS.IOS -> "clang++"
-        OS.Wasm -> "emcc"
+        OS.Wasm -> if(hostOs == OS.Windows) "emcc.bat" else "emcc"
     }
 
 fun linkerForTarget(os: OS, arch: Arch): String =


### PR DESCRIPTION
So I've tried to build skiko by myself and encountered few issues:

1. [emscripten](https://github.com/emscripten-core/emscripten) contains both `emcc` (shell script) and `emcc.bat` files but [OS.compilerForTarget](https://github.com/nev3rfail/skiko/blob/52c586f9b509715e7466f0355e440a39f12f187a/skiko/buildSrc/src/main/kotlin/properties.kt#L43) returns "emcc" which causes Gradle to create tasks that attempt to execute a non-executable and the fix is to add ".bat" to `emcc` executable.

2. Paths to includes are broken with a combination of Windows host and WASM because someone in "emcc.bat -> emcc.py -> clang.exe" chain eats Windows' directory separators. Solution is to create one more arg builder that would convert `\` to `\\` but also wouldn't convert arguments themselves like BaseVisualStudioBuildToolsArgBuilder does.