### PR TITLE
iOS TextField add keyboard options

### DIFF
--- a/skiko/RELEASE.md
+++ b/skiko/RELEASE.md
@@ -20,33 +20,33 @@ build configuration.
 ## Publishing
 
 ##### Publish JVM target to Maven local
-```
+```bash
 ./gradlew publishToMavenLocal
 ```
 
 ##### Publish all targets to Maven Local
-```
+```bash
 ./gradlew publishToMavenLocal -Pskiko.native.enabled=true -Pskiko.wasm.enabled=true -Pskiko.android.enabled=true
 ```
 
 ##### Publish to `build/repo` directory
-```
+```bash
 ./gradlew publishToBuildRepo
 ```
 
 ##### Publish to Compose repo
 Set up environment variables `COMPOSE_REPO_USERNAME` and `COMPOSE_REPO_KEY`.
-```
+```bash
 ./gradlew publishToComposeRepo
 ```
 
 ##### Publish to all repositories
-```
+```bash
 ./gradlew publish
 ```
 
 ##### Publish local version
-```
+```bash
 ./gradlew <PUBLISH_TASK> -Pdeploy.version=0.2.0 -Pdeploy.release=true
 ```
 
@@ -54,7 +54,7 @@ Set up environment variables `COMPOSE_REPO_USERNAME` and `COMPOSE_REPO_KEY`.
 
 macOS for Apple Silicon builds aimed for distribution require mandatory code signing,
 so use command like
-```
+```bash
 ./gradlew -Psigner="Apple Distribution: Nikolay Igotti (N462MKSJ7M)" <PUBLISH_TASK>
 ```
 to codesign the JNI library.

--- a/skiko/src/iosMain/kotlin/org/jetbrains/skiko/SkikoUIView.kt
+++ b/skiko/src/iosMain/kotlin/org/jetbrains/skiko/SkikoUIView.kt
@@ -3,6 +3,7 @@ package org.jetbrains.skiko
 import kotlinx.cinterop.*
 import org.jetbrains.skia.Point
 import org.jetbrains.skia.Rect
+import org.jetbrains.skiko.ios.UIKitKeyboardOptions
 import platform.CoreGraphics.*
 import platform.Foundation.*
 import platform.UIKit.*
@@ -30,24 +31,19 @@ class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol,
 
     private var skiaLayer: SkiaLayer? = null
     private lateinit var _pointInside: (Point, UIEvent?) -> Boolean
+    private lateinit var _keyboardOptions: UIKitKeyboardOptions
     private var _inputDelegate: UITextInputDelegateProtocol? = null
     private var _currentTextMenuActions: TextActions? = null
-    var currentKeyboardType: UIKeyboardType = UIKeyboardTypeDefault
-    var currentKeyboardAppearance: UIKeyboardAppearance = UIKeyboardAppearanceDefault
-    var currentReturnKeyType: UIReturnKeyType = UIReturnKeyType.UIReturnKeyDefault
-    var currentTextContentType: UITextContentType? = null
-    var currentIsSecureTextEntry: Boolean = false
-    var currentEnablesReturnKeyAutomatically: Boolean = false
-    var currentAutocapitalizationType: UITextAutocapitalizationType = UITextAutocapitalizationType.UITextAutocapitalizationTypeSentences
-    var currentAutocorrectionType: UITextAutocorrectionType = UITextAutocorrectionType.UITextAutocorrectionTypeYes
 
     constructor(
         skiaLayer: SkiaLayer,
         frame: CValue<CGRect> = CGRectNull.readValue(),
-        pointInside: (Point, UIEvent?) -> Boolean = {_,_-> true }
+        pointInside: (Point, UIEvent?) -> Boolean = {_,_-> true },
+        keyboardOptions: UIKitKeyboardOptions = object : UIKitKeyboardOptions {},
     ) : super(frame) {
         this.skiaLayer = skiaLayer
         _pointInside = pointInside
+        _keyboardOptions = keyboardOptions
     }
 
     /**
@@ -492,37 +488,14 @@ class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol,
             else -> false
         }
 
-    override fun keyboardType(): UIKeyboardType {
-        return currentKeyboardType
-    }
-
-    override fun keyboardAppearance(): UIKeyboardAppearance {
-        return currentKeyboardAppearance
-    }
-
-    override fun returnKeyType(): UIReturnKeyType {
-        return currentReturnKeyType
-    }
-
-    override fun textContentType(): UITextContentType? {
-        return currentTextContentType
-    }
-
-    override fun isSecureTextEntry(): Boolean {
-        return currentIsSecureTextEntry //todo secure text to prevent copy
-    }
-
-    override fun enablesReturnKeyAutomatically(): Boolean {
-        return currentEnablesReturnKeyAutomatically
-    }
-
-    override fun autocapitalizationType(): UITextAutocapitalizationType {
-        return currentAutocapitalizationType
-    }
-
-    override fun autocorrectionType(): UITextAutocorrectionType {
-        return currentAutocorrectionType
-    }
+    override fun keyboardType(): UIKeyboardType = _keyboardOptions.keyboardType()
+    override fun keyboardAppearance(): UIKeyboardAppearance = _keyboardOptions.keyboardAppearance()
+    override fun returnKeyType(): UIReturnKeyType = _keyboardOptions.returnKeyType()
+    override fun textContentType(): UITextContentType? = _keyboardOptions.textContentType()
+    override fun isSecureTextEntry(): Boolean = _keyboardOptions.isSecureTextEntry()
+    override fun enablesReturnKeyAutomatically(): Boolean = _keyboardOptions.enablesReturnKeyAutomatically()
+    override fun autocapitalizationType(): UITextAutocapitalizationType = _keyboardOptions.autocapitalizationType()
+    override fun autocorrectionType(): UITextAutocorrectionType = _keyboardOptions.autocorrectionType()
 
     override fun dictationRecognitionFailed() {
         //todo may be useful

--- a/skiko/src/iosMain/kotlin/org/jetbrains/skiko/SkikoUIView.kt
+++ b/skiko/src/iosMain/kotlin/org/jetbrains/skiko/SkikoUIView.kt
@@ -30,8 +30,8 @@ class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol,
     }
 
     private var skiaLayer: SkiaLayer? = null
-    private lateinit var _pointInside: (Point, UIEvent?) -> Boolean
-    private lateinit var _keyboardOptions: UIKitKeyboardOptions
+    private var _pointInside: (Point, UIEvent?) -> Boolean = { _, _ -> true }
+    private var _keyboardOptions: UIKitKeyboardOptions = object : UIKitKeyboardOptions {}
     private var _inputDelegate: UITextInputDelegateProtocol? = null
     private var _currentTextMenuActions: TextActions? = null
 

--- a/skiko/src/iosMain/kotlin/org/jetbrains/skiko/ios/UIKitKeyboardOptions.kt
+++ b/skiko/src/iosMain/kotlin/org/jetbrains/skiko/ios/UIKitKeyboardOptions.kt
@@ -1,0 +1,31 @@
+package org.jetbrains.skiko.ios
+
+import platform.UIKit.*
+
+interface UIKitKeyboardOptions {
+
+    fun keyboardType(): UIKeyboardType =
+        UIKeyboardTypeDefault
+
+    fun keyboardAppearance(): UIKeyboardAppearance =
+        UIKeyboardAppearanceDefault
+
+    fun returnKeyType(): UIReturnKeyType =
+        UIReturnKeyType.UIReturnKeyDefault
+
+    fun textContentType(): UITextContentType? =
+        null
+
+    fun isSecureTextEntry(): Boolean =
+        false
+
+    fun enablesReturnKeyAutomatically(): Boolean =
+        false
+
+    fun autocapitalizationType(): UITextAutocapitalizationType =
+        UITextAutocapitalizationType.UITextAutocapitalizationTypeSentences
+
+    fun autocorrectionType(): UITextAutocorrectionType =
+        UITextAutocorrectionType.UITextAutocorrectionTypeYes
+
+}


### PR DESCRIPTION
Add UIKitKeyboardOptions in SikoUIView constructor arguments to forward Compose TextField keyboard options.
Need to resolve issues:
 - https://github.com/JetBrains/compose-multiplatform/issues/2735
 - https://github.com/JetBrains/compose-multiplatform/issues/2988
 - https://github.com/JetBrains/compose-multiplatform/issues/2794
 - https://github.com/JetBrains/compose-multiplatform/issues/3116
