### PR TITLE
iOS TextField, interface SkikoUITextInputTraits

### DIFF
--- a/skiko/src/iosMain/kotlin/org/jetbrains/skiko/SkikoUIView.kt
+++ b/skiko/src/iosMain/kotlin/org/jetbrains/skiko/SkikoUIView.kt
@@ -31,7 +31,7 @@ class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol,
 
     private var skiaLayer: SkiaLayer? = null
     private var _pointInside: (Point, UIEvent?) -> Boolean = { _, _ -> true }
-    private var _keyboardOptions: SkikoUITextInputTraits = object : SkikoUITextInputTraits {}
+    private var _skikoUITextInputTrains: SkikoUITextInputTraits = object : SkikoUITextInputTraits {}
     private var _inputDelegate: UITextInputDelegateProtocol? = null
     private var _currentTextMenuActions: TextActions? = null
 
@@ -39,11 +39,11 @@ class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol,
         skiaLayer: SkiaLayer,
         frame: CValue<CGRect> = CGRectNull.readValue(),
         pointInside: (Point, UIEvent?) -> Boolean = {_,_-> true },
-        keyboardOptions: SkikoUITextInputTraits = object : SkikoUITextInputTraits {},
+        skikoUITextInputTrains: SkikoUITextInputTraits = object : SkikoUITextInputTraits {},
     ) : super(frame) {
         this.skiaLayer = skiaLayer
         _pointInside = pointInside
-        _keyboardOptions = keyboardOptions
+        _skikoUITextInputTrains = skikoUITextInputTrains
     }
 
     /**
@@ -488,14 +488,14 @@ class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol,
             else -> false
         }
 
-    override fun keyboardType(): UIKeyboardType = _keyboardOptions.keyboardType()
-    override fun keyboardAppearance(): UIKeyboardAppearance = _keyboardOptions.keyboardAppearance()
-    override fun returnKeyType(): UIReturnKeyType = _keyboardOptions.returnKeyType()
-    override fun textContentType(): UITextContentType? = _keyboardOptions.textContentType()
-    override fun isSecureTextEntry(): Boolean = _keyboardOptions.isSecureTextEntry()
-    override fun enablesReturnKeyAutomatically(): Boolean = _keyboardOptions.enablesReturnKeyAutomatically()
-    override fun autocapitalizationType(): UITextAutocapitalizationType = _keyboardOptions.autocapitalizationType()
-    override fun autocorrectionType(): UITextAutocorrectionType = _keyboardOptions.autocorrectionType()
+    override fun keyboardType(): UIKeyboardType = _skikoUITextInputTrains.keyboardType()
+    override fun keyboardAppearance(): UIKeyboardAppearance = _skikoUITextInputTrains.keyboardAppearance()
+    override fun returnKeyType(): UIReturnKeyType = _skikoUITextInputTrains.returnKeyType()
+    override fun textContentType(): UITextContentType? = _skikoUITextInputTrains.textContentType()
+    override fun isSecureTextEntry(): Boolean = _skikoUITextInputTrains.isSecureTextEntry()
+    override fun enablesReturnKeyAutomatically(): Boolean = _skikoUITextInputTrains.enablesReturnKeyAutomatically()
+    override fun autocapitalizationType(): UITextAutocapitalizationType = _skikoUITextInputTrains.autocapitalizationType()
+    override fun autocorrectionType(): UITextAutocorrectionType = _skikoUITextInputTrains.autocorrectionType()
 
     override fun dictationRecognitionFailed() {
         //todo may be useful

--- a/skiko/src/iosMain/kotlin/org/jetbrains/skiko/SkikoUIView.kt
+++ b/skiko/src/iosMain/kotlin/org/jetbrains/skiko/SkikoUIView.kt
@@ -3,7 +3,7 @@ package org.jetbrains.skiko
 import kotlinx.cinterop.*
 import org.jetbrains.skia.Point
 import org.jetbrains.skia.Rect
-import org.jetbrains.skiko.ios.UIKitKeyboardOptions
+import org.jetbrains.skiko.ios.SkikoUITextInputTraits
 import platform.CoreGraphics.*
 import platform.Foundation.*
 import platform.UIKit.*
@@ -31,7 +31,7 @@ class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol,
 
     private var skiaLayer: SkiaLayer? = null
     private var _pointInside: (Point, UIEvent?) -> Boolean = { _, _ -> true }
-    private var _keyboardOptions: UIKitKeyboardOptions = object : UIKitKeyboardOptions {}
+    private var _keyboardOptions: SkikoUITextInputTraits = object : SkikoUITextInputTraits {}
     private var _inputDelegate: UITextInputDelegateProtocol? = null
     private var _currentTextMenuActions: TextActions? = null
 
@@ -39,7 +39,7 @@ class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol,
         skiaLayer: SkiaLayer,
         frame: CValue<CGRect> = CGRectNull.readValue(),
         pointInside: (Point, UIEvent?) -> Boolean = {_,_-> true },
-        keyboardOptions: UIKitKeyboardOptions = object : UIKitKeyboardOptions {},
+        keyboardOptions: SkikoUITextInputTraits = object : SkikoUITextInputTraits {},
     ) : super(frame) {
         this.skiaLayer = skiaLayer
         _pointInside = pointInside

--- a/skiko/src/iosMain/kotlin/org/jetbrains/skiko/ios/SkikoUITextInputTraits.kt
+++ b/skiko/src/iosMain/kotlin/org/jetbrains/skiko/ios/SkikoUITextInputTraits.kt
@@ -3,10 +3,10 @@ package org.jetbrains.skiko.ios
 import platform.UIKit.*
 
 /**
-* Represents a part of UITextInputTraits protocol. Needs to control onscreen keyboard features.
-* @see https://developer.apple.com/documentation/uikit/uitextinputtraits?language=objc
-*/
-interface UIKitKeyboardOptions {
+ * Represents a part of UITextInputTraits protocol. Needs to control onscreen keyboard features.
+ * https://developer.apple.com/documentation/uikit/uitextinputtraits?language=objc
+ */
+interface SkikoUITextInputTraits {
 
     fun keyboardType(): UIKeyboardType =
         UIKeyboardTypeDefault
@@ -31,5 +31,17 @@ interface UIKitKeyboardOptions {
 
     fun autocorrectionType(): UITextAutocorrectionType =
         UITextAutocorrectionType.UITextAutocorrectionTypeYes
+
+    fun spellCheckingType(): UITextSpellCheckingType =
+        UITextSpellCheckingType.UITextSpellCheckingTypeDefault
+
+    fun smartQuotesType(): UITextSmartQuotesType =
+        UITextSmartQuotesType.UITextSmartQuotesTypeDefault
+
+    fun smartDashesType(): UITextSmartDashesType =
+        UITextSmartDashesType.UITextSmartDashesTypeDefault
+
+    fun smartInsertDeleteType(): UITextSmartInsertDeleteType =
+        UITextSmartInsertDeleteType.UITextSmartInsertDeleteTypeDefault
 
 }


### PR DESCRIPTION
Rename interface to SkikoUITextInputTraits
It is better represented the purpose.
Also added missing functions from https://developer.apple.com/documentation/uikit/uitextinputtraits?language=objc