### PR TITLE
Optimizations for Metal offscreen rendering for Swing interop

### DIFF
--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/MetalSwingRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/MetalSwingRedrawer.kt
@@ -46,6 +46,7 @@ internal class MetalSwingRedrawer(
     private val swingOffscreenDrawer = SwingOffscreenDrawer(swingLayerProperties)
 
     override fun dispose() {
+        bytesToDraw = ByteArray(0)
         storage.close()
         disposeMetalTexture(texturePtr)
         adapter.dispose()

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/MetalSwingRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/MetalSwingRedrawer.kt
@@ -35,6 +35,8 @@ internal class MetalSwingRedrawer(
 
     private var texturePtr: Long = 0
 
+    private val storage = Bitmap()
+
     init {
         onContextInit()
     }
@@ -42,8 +44,9 @@ internal class MetalSwingRedrawer(
     private val swingOffscreenDrawer = SwingOffscreenDrawer(swingLayerProperties)
 
     override fun dispose() {
-        adapter.dispose()
+        storage.close()
         disposeMetalTexture(texturePtr)
+        adapter.dispose()
         super.dispose()
     }
 
@@ -75,9 +78,9 @@ internal class MetalSwingRedrawer(
         val width = surface.width
         val height = surface.height
 
-        val storage = Bitmap()
-        storage.setImageInfo(ImageInfo.makeN32Premul(width, height))
-        storage.allocPixels()
+        if (storage.width != width || storage.height != height) {
+            storage.allocPixelsFlags(ImageInfo.makeS32(width, height, ColorAlphaType.PREMUL), false)
+        }
         // TODO: it copies pixels from GPU to CPU, so it is really slow
         surface.readPixels(storage, 0, 0)
 

--- a/skiko/src/awtMain/objectiveC/macos/MetalSwingRedrawer.mm
+++ b/skiko/src/awtMain/objectiveC/macos/MetalSwingRedrawer.mm
@@ -26,17 +26,38 @@ JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_swing_MetalSwingRedrawer_makeMe
     }
 }
 
-JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_swing_MetalSwingRedrawer_makeMetalRenderTargetOffScreen(
-        JNIEnv *env, jobject contextHandler, jlong adapterPtr, jint width, jint height) {
+JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_swing_MetalSwingRedrawer_makeMetalTexture(
+        JNIEnv *env, jobject contextHandler, jlong adapterPtr, jlong oldTexturePtr, jint width, jint height
+) {
     @autoreleasepool {
-        id <MTLDevice> adapter = (__bridge id <MTLDevice>) (void *) adapterPtr;
-        MTLTextureDescriptor *textureDescriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatBGRA8Unorm width:width height:height mipmapped:NO];
-        // TODO: use double buffer
-        id <MTLTexture> metalTexture = [adapter newTextureWithDescriptor:textureDescriptor];
+        id <MTLTexture> oldTexture = (__bridge_transfer id <MTLTexture>) (void *) oldTexturePtr;
+        id <MTLTexture> metalTexture;
+        if (oldTexture == nil || oldTexture.width != width || oldTexture.height != height) {
+            id <MTLDevice> adapter = (__bridge id <MTLDevice>) (void *) adapterPtr;
+            MTLTextureDescriptor *textureDescriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatBGRA8Unorm width:width height:height mipmapped:NO];
+            metalTexture = [adapter newTextureWithDescriptor:textureDescriptor];
+        } else {
+            metalTexture = oldTexture;
+        }
+
+        return (jlong) (__bridge_retained void *) metalTexture;
+    }
+}
+
+JNIEXPORT void JNICALL Java_org_jetbrains_skiko_swing_MetalSwingRedrawer_disposeMetalTexture(JNIEnv *env, jobject contextHandler, jlong texturePtr) {
+    @autoreleasepool {
+        id <MTLTexture> oldTexture = (__bridge_transfer id <MTLTexture>) (void *) texturePtr;
+    }
+}
+
+JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_swing_MetalSwingRedrawer_makeMetalRenderTargetOffScreen(
+        JNIEnv *env, jobject contextHandler, jlong texturePtr) {
+    @autoreleasepool {
+        id <MTLTexture> texture = (__bridge id <MTLTexture>) (void *) texturePtr;
         GrMtlTextureInfo info;
-        info.fTexture.retain((__bridge GrMTLHandle) metalTexture);
+        info.fTexture.retain((__bridge GrMTLHandle) texture);
         GrBackendRenderTarget *renderTarget = NULL;
-        renderTarget = new GrBackendRenderTarget(width, height, 0, info);
+        renderTarget = new GrBackendRenderTarget(texture.width, texture.height, 0, info);
         return (jlong) renderTarget;
     }
 }

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Bitmap.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Bitmap.kt
@@ -941,8 +941,9 @@ class Bitmap internal constructor(ptr: NativePointer) : Managed(ptr, _FinalizerH
         }
         try {
             Stats.onNativeCall()
-            return interopScope {
-                _nReadPixels(
+            interopScope {
+                val byteArrayHandle = toInteropForResult(byteArray)
+                val successfulRead = _nReadPixels(
                     _ptr,
                     dstInfo.width,
                     dstInfo.height,
@@ -952,8 +953,12 @@ class Bitmap internal constructor(ptr: NativePointer) : Managed(ptr, _FinalizerH
                     dstRowBytes,
                     srcX,
                     srcY,
-                    toInterop(byteArray)
+                    byteArrayHandle
                 )
+                if (successfulRead) {
+                    byteArrayHandle.fromInterop(byteArray)
+                }
+                return successfulRead
             }
         } finally {
             reachabilityBarrier(this)


### PR DESCRIPTION
There are 3 optimizations:
1. Reuse Metal texture if size is not changed
2. Reuse Bitmap where we read pixels from GPU and reallocate pixels only if size is changed
3. Reuse bytearray where we read raw pixels from bitmap, since now it is created for every readPixels (not sure about this one, since Bitmap is changed)
