### PR TITLE
Prevent needRedraw reentry on iOS

### DIFF
--- a/skiko/src/commonMain/kotlin/org/jetbrains/skiko/context/ContextHandler.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skiko/context/ContextHandler.kt
@@ -40,15 +40,11 @@ internal abstract class ContextHandler(
             throw RenderException("Cannot init graphic context")
         }
         initCanvas()
-
-        try {
-            canvas?.apply {
-                clear(if (isTransparentBackground()) Color.TRANSPARENT else Color.WHITE)
-                drawContent()
-            }
-        } finally {
-            flush()
+        canvas?.apply {
+            clear(if (isTransparentBackground()) Color.TRANSPARENT else Color.WHITE)
+            drawContent()
         }
+        flush()
     }
 
     protected open fun isTransparentBackground(): Boolean {

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skiko/context/ContextHandler.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skiko/context/ContextHandler.kt
@@ -40,11 +40,15 @@ internal abstract class ContextHandler(
             throw RenderException("Cannot init graphic context")
         }
         initCanvas()
-        canvas?.apply {
-            clear(if (isTransparentBackground()) Color.TRANSPARENT else Color.WHITE)
-            drawContent()
+
+        try {
+            canvas?.apply {
+                clear(if (isTransparentBackground()) Color.TRANSPARENT else Color.WHITE)
+                drawContent()
+            }
+        } finally {
+            flush()
         }
-        flush()
     }
 
     protected open fun isTransparentBackground(): Boolean {

--- a/skiko/src/iosMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.ios.kt
+++ b/skiko/src/iosMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.ios.kt
@@ -80,9 +80,9 @@ internal class MetalRedrawer(
             }
 
             DrawSchedulingState.SCHEDULED_ON_NEXT_FRAME -> {
-                drawIfLayerIsShowing()
-
                 drawSchedulingState = DrawSchedulingState.AVAILABLE_ON_NEXT_FRAME
+
+                drawIfLayerIsShowing()
             }
 
             DrawSchedulingState.AVAILABLE_ON_CURRENT_FRAME -> {

--- a/skiko/src/iosMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.ios.kt
+++ b/skiko/src/iosMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.ios.kt
@@ -164,9 +164,9 @@ internal class MetalRedrawer(
             }
 
             DrawSchedulingState.AVAILABLE_ON_CURRENT_FRAME -> {
-                drawIfLayerIsShowing()
-
                 drawSchedulingState = DrawSchedulingState.AVAILABLE_ON_NEXT_FRAME
+
+                drawIfLayerIsShowing()
             }
 
             DrawSchedulingState.SCHEDULED_ON_NEXT_FRAME -> {


### PR DESCRIPTION
Draw could flush coroutines resulting in remeasurement, immediate invalidation and needRedraw reentry. Change the flag before the draw call to avoid this situation.