### PR TITLE
Remove synchronous draw reentry logic inside needRedraw completely

### DIFF
--- a/skiko/src/iosMain/kotlin/org/jetbrains/skiko/SkikoUIView.kt
+++ b/skiko/src/iosMain/kotlin/org/jetbrains/skiko/SkikoUIView.kt
@@ -259,8 +259,6 @@ class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol {
                 platform = event
             )
         )
-         // If invalidation doesn't happen while onPointerEvent is processed, it's too late to schedule any work for this frame.
-        skiaLayer?.redrawer?.preventDrawDispatchDuringCurrentFrame()
     }
 
     private val UITouch.isPressed get() =


### PR DESCRIPTION
The situation for which previous 3-state vsync tracking was introduced actually happened and caused violation of implicit internal compose invariant prohibiting synchronous draw during invalidation. Reverted back to minimal version using a bool flag to avoid redundant draw calls on blank vsyncs.

Fixes edge case of:
https://github.com/JetBrains/compose-multiplatform/issues/3396#issuecomment-1647516120