### PR TITLE
Fix segfault of color space gradient makers upon pos=null

### DIFF
--- a/skiko/src/commonTest/kotlin/org/jetbrains/skia/ShaderTest.kt
+++ b/skiko/src/commonTest/kotlin/org/jetbrains/skia/ShaderTest.kt
@@ -16,6 +16,7 @@ class ShaderTest {
         Shader.makeLinearGradient(start, end, colors)
         Shader.makeLinearGradient(start, end, colors, positions)
         Shader.makeLinearGradient(start, end, colors, positions, style = GradientStyle.DEFAULT)
+        Shader.makeLinearGradient(start, end, colorsF, colorSpace, null, GradientStyle.DEFAULT)
         Shader.makeLinearGradient(start, end, colorsF, colorSpace, positions, GradientStyle.DEFAULT)
     }
 
@@ -32,6 +33,7 @@ class ShaderTest {
         Shader.makeRadialGradient(center, radius, colors)
         Shader.makeRadialGradient(center, radius, colors, positions)
         Shader.makeRadialGradient(center, radius, colors, positions, style = GradientStyle.DEFAULT)
+        Shader.makeRadialGradient(center, radius, colorsF, colorSpace, null, GradientStyle.DEFAULT)
         Shader.makeRadialGradient(center, radius, colorsF, colorSpace, positions, GradientStyle.DEFAULT)
     }
 
@@ -50,6 +52,7 @@ class ShaderTest {
         Shader.makeTwoPointConicalGradient(start, startRadius, end, endRadius, colors)
         Shader.makeTwoPointConicalGradient(start, startRadius, end, endRadius, colors, positions)
         Shader.makeTwoPointConicalGradient(start, startRadius, end, endRadius, colors, positions, style = GradientStyle.DEFAULT)
+        Shader.makeTwoPointConicalGradient(start, startRadius, end, endRadius, colorsF, colorSpace, null, GradientStyle.DEFAULT)
         Shader.makeTwoPointConicalGradient(start, startRadius, end, endRadius, colorsF, colorSpace, positions, GradientStyle.DEFAULT)
     }
 
@@ -67,6 +70,7 @@ class ShaderTest {
         Shader.makeSweepGradient(center, colors, positions)
         Shader.makeSweepGradient(center, colors, positions, style = GradientStyle.DEFAULT)
         Shader.makeSweepGradient(center, startAngle, endAngle, colors, positions, GradientStyle.DEFAULT)
+        Shader.makeSweepGradient(center, startAngle, endAngle, colorsF, colorSpace, null, GradientStyle.DEFAULT)
         Shader.makeSweepGradient(center, startAngle, endAngle, colorsF, colorSpace, positions, GradientStyle.DEFAULT)
     }
 

--- a/skiko/src/jvmMain/cpp/common/Shader.cc
+++ b/skiko/src/jvmMain/cpp/common/Shader.cc
@@ -23,7 +23,7 @@ extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_ShaderKt__1nMakeLinea
     float* pos = posArray == nullptr ? nullptr : env->GetFloatArrayElements(posArray, nullptr);
     SkTileMode tileMode = static_cast<SkTileMode>(tileModeInt);
     std::unique_ptr<SkMatrix> localMatrix = skMatrix(env, matrixArray);
-    SkShader* ptr = SkGradientShader::MakeLinear(pts, reinterpret_cast<SkColor*>(colors), pos, env->GetArrayLength(colorsArray), tileMode, static_cast<uint32_t>(flags), localMatrix.get()).release();
+    SkShader* ptr = SkGradientShader::MakeLinear(pts, reinterpret_cast<SkColor*>(colors), pos, _count, tileMode, static_cast<uint32_t>(flags), localMatrix.get()).release();
     env->ReleaseIntArrayElements(colorsArray, colors, 0);
     if (posArray != nullptr)
         env->ReleaseFloatArrayElements(posArray, pos, 0);
@@ -35,12 +35,13 @@ extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_ShaderKt__1nMakeLinea
     SkPoint pts[2] {SkPoint::Make(x0, y0), SkPoint::Make(x1, y1)};
     float* colors = env->GetFloatArrayElements(colorsArray, nullptr);
     sk_sp<SkColorSpace> colorSpace = sk_ref_sp<SkColorSpace>(reinterpret_cast<SkColorSpace*>(static_cast<uintptr_t>(colorSpacePtr)));
-    float* pos = env->GetFloatArrayElements(posArray, nullptr);
+    float* pos = posArray == nullptr ? nullptr : env->GetFloatArrayElements(posArray, nullptr);
     SkTileMode tileMode = static_cast<SkTileMode>(tileModeInt);
     std::unique_ptr<SkMatrix> localMatrix = skMatrix(env, matrixArray);
-    SkShader* ptr = SkGradientShader::MakeLinear(pts, reinterpret_cast<SkColor4f*>(colors), colorSpace, pos, env->GetArrayLength(posArray), tileMode, static_cast<uint32_t>(flags), localMatrix.get()).release();
+    SkShader* ptr = SkGradientShader::MakeLinear(pts, reinterpret_cast<SkColor4f*>(colors), colorSpace, pos, _count, tileMode, static_cast<uint32_t>(flags), localMatrix.get()).release();
     env->ReleaseFloatArrayElements(colorsArray, colors, 0);
-    env->ReleaseFloatArrayElements(posArray, pos, 0);
+    if (posArray != nullptr)
+        env->ReleaseFloatArrayElements(posArray, pos, 0);
     return reinterpret_cast<jlong>(ptr);
 }
 
@@ -50,7 +51,7 @@ extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_ShaderKt__1nMakeRadia
     float* pos = posArray == nullptr ? nullptr : env->GetFloatArrayElements(posArray, nullptr);
     SkTileMode tileMode = static_cast<SkTileMode>(tileModeInt);
     std::unique_ptr<SkMatrix> localMatrix = skMatrix(env, matrixArray);
-    SkShader* ptr = SkGradientShader::MakeRadial(SkPoint::Make(x, y), r, reinterpret_cast<SkColor*>(colors), pos, env->GetArrayLength(colorsArray), tileMode, static_cast<uint32_t>(flags), localMatrix.get()).release();
+    SkShader* ptr = SkGradientShader::MakeRadial(SkPoint::Make(x, y), r, reinterpret_cast<SkColor*>(colors), pos, _count, tileMode, static_cast<uint32_t>(flags), localMatrix.get()).release();
     env->ReleaseIntArrayElements(colorsArray, colors, 0);
     if (posArray != nullptr)
         env->ReleaseFloatArrayElements(posArray, pos, 0);
@@ -61,12 +62,13 @@ extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_ShaderKt__1nMakeRadia
   (JNIEnv* env, jclass jclass, jfloat x, jfloat y, jfloat r, jfloatArray colorsArray, jlong colorSpacePtr, jfloatArray posArray, jint _count, jint tileModeInt, jint flags, jfloatArray matrixArray) {
     float* colors = env->GetFloatArrayElements(colorsArray, nullptr);
     sk_sp<SkColorSpace> colorSpace = sk_ref_sp<SkColorSpace>(reinterpret_cast<SkColorSpace*>(static_cast<uintptr_t>(colorSpacePtr)));
-    float* pos = env->GetFloatArrayElements(posArray, nullptr);
+    float* pos = posArray == nullptr ? nullptr : env->GetFloatArrayElements(posArray, nullptr);
     SkTileMode tileMode = static_cast<SkTileMode>(tileModeInt);
     std::unique_ptr<SkMatrix> localMatrix = skMatrix(env, matrixArray);
-    SkShader* ptr = SkGradientShader::MakeRadial(SkPoint::Make(x, y), r, reinterpret_cast<SkColor4f*>(colors), colorSpace, pos, env->GetArrayLength(posArray), tileMode, static_cast<uint32_t>(flags), localMatrix.get()).release();
+    SkShader* ptr = SkGradientShader::MakeRadial(SkPoint::Make(x, y), r, reinterpret_cast<SkColor4f*>(colors), colorSpace, pos, _count, tileMode, static_cast<uint32_t>(flags), localMatrix.get()).release();
     env->ReleaseFloatArrayElements(colorsArray, colors, 0);
-    env->ReleaseFloatArrayElements(posArray, pos, 0);
+    if (posArray != nullptr)
+        env->ReleaseFloatArrayElements(posArray, pos, 0);
     return reinterpret_cast<jlong>(ptr);
 }
 
@@ -76,7 +78,7 @@ extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_ShaderKt__1nMakeTwoPo
     float* pos = posArray == nullptr ? nullptr : env->GetFloatArrayElements(posArray, nullptr);
     SkTileMode tileMode = static_cast<SkTileMode>(tileModeInt);
     std::unique_ptr<SkMatrix> localMatrix = skMatrix(env, matrixArray);
-    SkShader* ptr = SkGradientShader::MakeTwoPointConical(SkPoint::Make(x0, y0), r0, SkPoint::Make(x1, y1), r1, reinterpret_cast<SkColor*>(colors), pos, env->GetArrayLength(colorsArray), tileMode, static_cast<uint32_t>(flags), localMatrix.get()).release();
+    SkShader* ptr = SkGradientShader::MakeTwoPointConical(SkPoint::Make(x0, y0), r0, SkPoint::Make(x1, y1), r1, reinterpret_cast<SkColor*>(colors), pos, _count, tileMode, static_cast<uint32_t>(flags), localMatrix.get()).release();
     env->ReleaseIntArrayElements(colorsArray, colors, 0);
     if (posArray != nullptr)
         env->ReleaseFloatArrayElements(posArray, pos, 0);
@@ -87,12 +89,13 @@ extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_ShaderKt__1nMakeTwoPo
   (JNIEnv* env, jclass jclass, jfloat x0, jfloat y0, jfloat r0, jfloat x1, jfloat y1, jfloat r1, jfloatArray colorsArray, jlong colorSpacePtr, jfloatArray posArray, jint _count, jint tileModeInt, jint flags, jfloatArray matrixArray) {
     float* colors = env->GetFloatArrayElements(colorsArray, nullptr);
     sk_sp<SkColorSpace> colorSpace = sk_ref_sp<SkColorSpace>(reinterpret_cast<SkColorSpace*>(static_cast<uintptr_t>(colorSpacePtr)));
-    float* pos = env->GetFloatArrayElements(posArray, nullptr);
+    float* pos = posArray == nullptr ? nullptr : env->GetFloatArrayElements(posArray, nullptr);
     SkTileMode tileMode = static_cast<SkTileMode>(tileModeInt);
     std::unique_ptr<SkMatrix> localMatrix = skMatrix(env, matrixArray);
-    SkShader* ptr = SkGradientShader::MakeTwoPointConical(SkPoint::Make(x0, y0), r0, SkPoint::Make(x1, y1), r1, reinterpret_cast<SkColor4f*>(colors), colorSpace, pos, env->GetArrayLength(posArray), tileMode, static_cast<uint32_t>(flags), localMatrix.get()).release();
+    SkShader* ptr = SkGradientShader::MakeTwoPointConical(SkPoint::Make(x0, y0), r0, SkPoint::Make(x1, y1), r1, reinterpret_cast<SkColor4f*>(colors), colorSpace, pos, _count, tileMode, static_cast<uint32_t>(flags), localMatrix.get()).release();
     env->ReleaseFloatArrayElements(colorsArray, colors, 0);
-    env->ReleaseFloatArrayElements(posArray, pos, 0);
+    if (posArray != nullptr)
+        env->ReleaseFloatArrayElements(posArray, pos, 0);
     return reinterpret_cast<jlong>(ptr);
 }
 
@@ -102,7 +105,7 @@ extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_ShaderKt__1nMakeSweep
     float* pos = posArray == nullptr ? nullptr : env->GetFloatArrayElements(posArray, nullptr);
     SkTileMode tileMode = static_cast<SkTileMode>(tileModeInt);
     std::unique_ptr<SkMatrix> localMatrix = skMatrix(env, matrixArray);
-    SkShader* ptr = SkGradientShader::MakeSweep(x, y, reinterpret_cast<SkColor*>(colors), pos, env->GetArrayLength(colorsArray), tileMode, start, end, static_cast<uint32_t>(flags), localMatrix.get()).release();
+    SkShader* ptr = SkGradientShader::MakeSweep(x, y, reinterpret_cast<SkColor*>(colors), pos, _count, tileMode, start, end, static_cast<uint32_t>(flags), localMatrix.get()).release();
     env->ReleaseIntArrayElements(colorsArray, colors, 0);
     if (posArray != nullptr)
         env->ReleaseFloatArrayElements(posArray, pos, 0);
@@ -113,12 +116,13 @@ extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_ShaderKt__1nMakeSweep
   (JNIEnv* env, jclass jclass, jfloat x, jfloat y, jfloat start, jfloat end, jfloatArray colorsArray, jlong colorSpacePtr, jfloatArray posArray, jint _count, jint tileModeInt, jint flags, jfloatArray matrixArray) {
     float* colors = env->GetFloatArrayElements(colorsArray, nullptr);
     sk_sp<SkColorSpace> colorSpace = sk_ref_sp<SkColorSpace>(reinterpret_cast<SkColorSpace*>(static_cast<uintptr_t>(colorSpacePtr)));
-    float* pos = env->GetFloatArrayElements(posArray, nullptr);
+    float* pos = posArray == nullptr ? nullptr : env->GetFloatArrayElements(posArray, nullptr);
     SkTileMode tileMode = static_cast<SkTileMode>(tileModeInt);
     std::unique_ptr<SkMatrix> localMatrix = skMatrix(env, matrixArray);
-    SkShader* ptr = SkGradientShader::MakeSweep(x, y, reinterpret_cast<SkColor4f*>(colors), colorSpace, pos, env->GetArrayLength(colorsArray), tileMode, start, end, static_cast<uint32_t>(flags), localMatrix.get()).release();
+    SkShader* ptr = SkGradientShader::MakeSweep(x, y, reinterpret_cast<SkColor4f*>(colors), colorSpace, pos, _count, tileMode, start, end, static_cast<uint32_t>(flags), localMatrix.get()).release();
     env->ReleaseFloatArrayElements(colorsArray, colors, 0);
-    env->ReleaseFloatArrayElements(posArray, pos, 0);
+    if (posArray != nullptr)
+        env->ReleaseFloatArrayElements(posArray, pos, 0);
     return reinterpret_cast<jlong>(ptr);
 }
 


### PR DESCRIPTION
Passing null into the "positions" parameter of a gradient shader factory that accepts a custom ColorSpace caused a segfault prior to this fix.