### PR TITLE
Skip presenting CAMetalDrawable for CAMetalLayer that changed size

### DIFF
--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
@@ -112,11 +112,9 @@ internal class MetalRedrawer(
     override fun redrawImmediately() {
         check(!isDisposed) { "MetalRedrawer is disposed" }
         inDrawScope {
-            setVSyncEnabled(device.ptr, enabled = false)
             update(System.nanoTime())
             if (!isDisposed) { // Redrawer may be disposed in user code, during `update`
                 performDraw()
-                setVSyncEnabled(device.ptr, properties.isVsyncEnabled)
             }
         }
     }

--- a/skiko/src/awtMain/objectiveC/macos/MetalContextHandler.mm
+++ b/skiko/src/awtMain/objectiveC/macos/MetalContextHandler.mm
@@ -61,13 +61,11 @@ JNIEXPORT void JNICALL Java_org_jetbrains_skiko_context_MetalContextHandler_fini
         if (currentDrawable) {
             id<MTLCommandBuffer> commandBuffer = [device.queue commandBuffer];
             commandBuffer.label = @"Present";
-            // [commandBuffer presentDrawable:currentDrawable];
+
             [commandBuffer addCompletedHandler:^(id<MTLCommandBuffer> buffer) {
                 /// commands have completed, allow next waiting (if any) to start encoding new work to gpu
                 dispatch_semaphore_signal(device.inflightSemaphore);
             }];
-
-            [commandBuffer waitUntilScheduled];
 
             [commandBuffer addScheduledHandler:^(id<MTLCommandBuffer> buffer) {
                 int drawableWidth = currentDrawable.texture.width;

--- a/skiko/src/awtMain/objectiveC/macos/MetalContextHandler.mm
+++ b/skiko/src/awtMain/objectiveC/macos/MetalContextHandler.mm
@@ -71,10 +71,10 @@ JNIEXPORT void JNICALL Java_org_jetbrains_skiko_context_MetalContextHandler_fini
                 int drawableWidth = currentDrawable.texture.width;
                 int drawableHeight = currentDrawable.texture.height;
 
-                //device.layer.drawableSize.width, device.layer.drawableSize.height
                 int layerWidth = device.layer.drawableSize.width;
                 int layerHeight = device.layer.drawableSize.height;
 
+                /// Avoid presenting drawable on layer that has already changed size by the moment it was scheduled
                 if (drawableWidth == layerWidth && drawableHeight == layerHeight) {
                     [currentDrawable present];
                 }


### PR DESCRIPTION
Drawable of right size will be presented from within `redrawImmediately`

https://github.com/JetBrains/skiko/assets/4167681/c56f7c40-5629-4b2f-8abf-1538192816fa

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/3420

