### PR TITLE
Remove old TODO comment

### DIFF
--- a/skiko/src/iosMain/kotlin/org/jetbrains/skiko/SkikoUIView.kt
+++ b/skiko/src/iosMain/kotlin/org/jetbrains/skiko/SkikoUIView.kt
@@ -16,10 +16,6 @@ import platform.darwin.NSInteger
 import kotlin.math.max
 import kotlin.math.min
 
-/*
- TODO: remove org.jetbrains.skiko.objc.UIViewExtensionProtocol after Kotlin 1.8.20
- https://youtrack.jetbrains.com/issue/KT-40426
-*/
 @Suppress("CONFLICTING_OVERLOADS")
 @ExportObjCClass
 class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol {


### PR DESCRIPTION
This comment was added with cinterop and def file in iOS. In def file was protocol UIViewExtensionProtocol. Now, we already removed UIViewExtensionProtocol.