### PR TITLE
Fix crash during MetalAdapter initialisation

### DIFF
--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/MetalApi.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/MetalApi.kt
@@ -8,6 +8,11 @@ package org.jetbrains.skiko
  */
 internal fun chooseMetalAdapter(adapterPriority: GpuPriority): MetalAdapter {
     val adapter = chooseAdapter(adapterPriority.ordinal)
+
+    if (adapter == 0L) {
+        throw RenderException("MetalApi.chooseAdapter returned null")
+    }
+
     val adapterName = getAdapterName(adapter)
     val adapterMemorySize = getAdapterMemorySize(adapter)
 

--- a/skiko/src/awtMain/objectiveC/macos/MetalApi.mm
+++ b/skiko/src/awtMain/objectiveC/macos/MetalApi.mm
@@ -23,25 +23,22 @@
 #define AdpapterPriorityIntegrated 1
 #define AdpapterPriorityDiscrete 2
 
-extern "C"
-{
+extern "C" {
 
-extern "C" void* objc_autoreleasePoolPush(void);
-extern "C" void objc_autoreleasePoolPop(void*);
+void *objc_autoreleasePoolPush(void);
+void objc_autoreleasePoolPop(void *);
 
 JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_MetalApiKt_openAutoreleasepool(
-    JNIEnv * env, jobject redrawer)
-{
+    JNIEnv *env, jobject redrawer) {
     return (jlong)objc_autoreleasePoolPush();
 }
 
 JNIEXPORT void JNICALL Java_org_jetbrains_skiko_MetalApiKt_closeAutoreleasepool(
-    JNIEnv * env, jobject redrawer, jlong handle)
-{
-    objc_autoreleasePoolPop((void*)handle);
+    JNIEnv *env, jobject redrawer, jlong handle) {
+    objc_autoreleasePoolPop((void *)handle);
 }
 
-BOOL isUsingIntegratedGPU() {
+static BOOL isUsingIntegratedGPU() {
     kern_return_t kernResult = 0;
     io_iterator_t iterator = IO_OBJECT_NULL;
     io_service_t service = IO_OBJECT_NULL;
@@ -72,7 +69,7 @@ BOOL isUsingIntegratedGPU() {
     return output != 0;
 }
 
-id<MTLDevice> MTLCreateIntegratedDevice(int adapterPriority) {
+static id<MTLDevice> createIntegratedMTLDevice(int adapterPriority) {
     BOOL isIntegratedGPU = NO;
 
     if (adapterPriority == AdpapterPriorityAuto) {
@@ -99,35 +96,42 @@ id<MTLDevice> MTLCreateIntegratedDevice(int adapterPriority) {
 }
 
 JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_MetalApiKt_chooseAdapter(
-    JNIEnv *env, jobject obj, jlong adapterPriority)
-{
+    JNIEnv *env, jobject obj, jlong adapterPriority) {
     @autoreleasepool {
-        id<MTLDevice> adapter = MTLCreateIntegratedDevice(adapterPriority);
-        return (jlong) (__bridge_retained void *) adapter;
+        id<MTLDevice> adapter = createIntegratedMTLDevice(adapterPriority);
+
+        if (adapter) {
+            return (jlong) (__bridge_retained void *) adapter;
+        } else {
+            return 0;
+        }
     }
 }
 
 JNIEXPORT void JNICALL Java_org_jetbrains_skiko_MetalApiKt_disposeAdapter(
-    JNIEnv *env, jobject obj, jlong adapterPtr)
-{
+    JNIEnv *env, jobject obj, jlong adapterPtr) {
     @autoreleasepool {
         id<MTLDevice> adapter = (__bridge_transfer id<MTLDevice>) (void *) adapterPtr;
     }
 }
 
 JNIEXPORT jstring JNICALL Java_org_jetbrains_skiko_MetalApiKt_getAdapterName(
-    JNIEnv *env, jobject obj, jlong adapterPtr)
-{
+    JNIEnv *env, jobject obj, jlong adapterPtr) {
     @autoreleasepool {
         id<MTLDevice> adapter = (__bridge id<MTLDevice>) (void *) adapterPtr;
-        const char *currentAdapterName = [[adapter name] cStringUsingEncoding:NSASCIIStringEncoding];
-        return env->NewStringUTF(currentAdapterName);
+
+        const char *currentAdapterName = [[adapter name] cStringUsingEncoding:NSUTF8StringEncoding];
+
+        if (currentAdapterName) {
+            return env->NewStringUTF(currentAdapterName);
+        } else {
+            return env->NewStringUTF("Unknown Metal adapter");
+        }
     }
 }
 
 JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_MetalApiKt_getAdapterMemorySize(
-    JNIEnv *env, jobject obj, jlong adapterPtr)
-{
+    JNIEnv *env, jobject obj, jlong adapterPtr) {
     @autoreleasepool {
         id<MTLDevice> adapter = (__bridge id<MTLDevice>) (void *) adapterPtr;
         uint64_t totalMemory = [adapter recommendedMaxWorkingSetSize];
@@ -135,5 +139,6 @@ JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_MetalApiKt_getAdapterMemorySize
     }
 }
 
-} // extern C
-#endif
+} // extern "C"
+
+#endif // SK_METAL


### PR DESCRIPTION
## Changes
Correctly handle nulls when working with Obj-C API.
Throw RenderException if MTLDevice is null to allow RedrawerManager fallback to software renderer.
Minor refactor and typos fixes.

## Fixes
https://github.com/JetBrains/compose-multiplatform/issues/3460
https://github.com/JetBrains/skiko/issues/784