### PR TITLE
Fix SVGLength.withUnit

### DIFF
--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/svg/SVGLength.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/svg/SVGLength.kt
@@ -40,6 +40,6 @@ class SVGLength(val value: Float, val unit: SVGLengthUnit) {
     }
 
     fun withUnit(_unit: SVGLengthUnit): SVGLength {
-        return if (this.unit === _unit) this else SVGLength(value, unit)
+        return if (this.unit === _unit) this else SVGLength(value, _unit)
     }
 }

--- a/skiko/src/commonTest/kotlin/org/jetbrains/skia/SvgTest.kt
+++ b/skiko/src/commonTest/kotlin/org/jetbrains/skia/SvgTest.kt
@@ -38,11 +38,28 @@ class SvgTest {
         require(e.tag == SVGTag.SVG)
         e.viewBox = Rect(0f, 1f, 100f, 200f)
         assertCloseEnough(Rect(0f, 1f, 100f, 200f), e.viewBox!!)
-        val aspectRatio = SVGPreserveAspectRatio(SVGPreserveAspectRatioAlign.XMIN_YMIN, SVGPreserveAspectRatioScale.MEET)
+        val aspectRatio =
+            SVGPreserveAspectRatio(SVGPreserveAspectRatioAlign.XMIN_YMIN, SVGPreserveAspectRatioScale.MEET)
         e.preserveAspectRatio = aspectRatio
         assertEquals(aspectRatio, e.preserveAspectRatio)
         require(e.getIntrinsicSize(SVGLengthContext(100f, 100f)).x == 300f)
         e.viewBox = Rect.makeXYWH(0f, 1f, 2f, 3f)
         require(e.viewBox == Rect.makeXYWH(0f, 1f, 2f, 3f))
+    }
+
+    @Test
+    fun SvgLength() {
+        val l = SVGLength(123f)
+
+        assertEquals(123f, l.value)
+        assertEquals(SVGLengthUnit.NUMBER, l.unit)
+
+        val lpx = l.withUnit(SVGLengthUnit.PX)
+        assertEquals(123f, lpx.value)
+        assertEquals(SVGLengthUnit.PX, lpx.unit)
+
+        val newLpx = lpx.withValue(321f)
+        assertEquals(321f, newLpx.value)
+        assertEquals(SVGLengthUnit.PX, newLpx.unit)
     }
 }


### PR DESCRIPTION
create a new SVGLength with a `_unit` from the input and not `this.unit`
___

It seems that this typo didn't cause any real issue so far. 
The only it was used in compose is here: https://github.com/JetBrains/compose-multiplatform-core/blob/bcaacc85477f959cac171b60258679b6244f512b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/DesktopSvgResources.desktop.kt#L66

```kotlin
val width = root?.width?.withUnit(SVGLengthUnit.PX)?.value ?: 0f
val height = root?.height?.withUnit(SVGLengthUnit.PX)?.value ?: 0f
```

But here `withUnit` does nothing really useful, since `withUnit` doesn't do any conversion of the `value` - it preserves the original `value` .       
