### PR TITLE
Make CI automatically choose iPhone for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 # Default Skiko CI
 name: CI
 
-env:
-  IOS_SIM_UUID: '856515E5-1A3B-4E89-93E4-421B21D79892' # take a look at `xcrun simctl list devices` at GitHub Actions log
-
 on:
   push:
     branches: [ master ]
@@ -15,6 +12,7 @@ on:
 
 jobs:
   macos:
+    if: false
     runs-on: macos-11
     steps:
       - uses: actions/checkout@v3
@@ -62,7 +60,8 @@ jobs:
           java-version: '11'
           cache: 'gradle'
 
-      - run: xcrun simctl list devices # Look here to get device ids
+      - run: brew install jq # json cli tool
+      - run: export IOS_SIM_UUID=$(xcrun simctl list devices available --json | jq -r '.devices."com.apple.CoreSimulator.SimRuntime.iOS-17-0"[] | select(.name == "iPhone 15") | .udid')
 
       - name: 'Compile and run iOS x64 tests'
         uses: nick-fields/retry@v2
@@ -92,6 +91,7 @@ jobs:
 
   linux:
     runs-on: ubuntu-20.04
+    if: false
     steps:
       - uses: actions/checkout@v3
         name: 'Check out code'
@@ -162,6 +162,7 @@ jobs:
 
   js:
     runs-on: ubuntu-20.04
+    if: false
     steps:
       - uses: actions/checkout@v3
         name: 'Check out code'
@@ -211,6 +212,7 @@ jobs:
 
   windows:
     runs-on: windows-2019
+    if: false
     steps:
       - uses: actions/checkout@v3
         name: 'Check out code'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,13 +60,17 @@ jobs:
           java-version: '11'
           cache: 'gradle'
 
+      - name: 'Print devices'
+        run: xcrun simctl list devices available --json
+
       # install jq - cli tool for json querying
       # retrieve the device .udid to use in tests and store it in env var
       - name: 'Set Up Simulator UUID'
         run: |
           brew install jq &&
           IOS_SIM_UUID=$(xcrun simctl list devices available --json | jq -r '.devices."com.apple.CoreSimulator.SimRuntime.iOS-17-0"[] | select(.name == "iPhone 15") | .udid') &&
-          echo "IOS_SIM_UUID=$IOS_SIM_UUID" >> $GITHUB_ENV
+          echo "IOS_SIM_UUID=$IOS_SIM_UUID" >> $GITHUB_ENV &&
+          echo $IOS_SIM_UUID
 
       - name: 'Compile and run iOS x64 tests'
         uses: nick-fields/retry@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,13 @@ jobs:
           java-version: '11'
           cache: 'gradle'
 
-      - run: brew install jq # json cli tool
-      - run: export IOS_SIM_UUID=$(xcrun simctl list devices available --json | jq -r '.devices."com.apple.CoreSimulator.SimRuntime.iOS-17-0"[] | select(.name == "iPhone 15") | .udid')
+      # install jq - cli tool for json querying
+      # retrieve the device .udid to use in tests and store it in env var
+      - name: 'Set Up Simulator UUID'
+        run: |
+          brew install jq &&
+          IOS_SIM_UUID=$(xcrun simctl list devices available --json | jq -r '.devices."com.apple.CoreSimulator.SimRuntime.iOS-17-0"[] | select(.name == "iPhone 15") | .udid') &&
+          echo "IOS_SIM_UUID=$IOS_SIM_UUID" >> $GITHUB_ENV
 
       - name: 'Compile and run iOS x64 tests'
         uses: nick-fields/retry@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ on:
 
 jobs:
   macos:
-    if: false
     runs-on: macos-11
     steps:
       - uses: actions/checkout@v3
@@ -102,7 +101,6 @@ jobs:
 
   linux:
     runs-on: ubuntu-20.04
-    if: false
     steps:
       - uses: actions/checkout@v3
         name: 'Check out code'
@@ -173,7 +171,6 @@ jobs:
 
   js:
     runs-on: ubuntu-20.04
-    if: false
     steps:
       - uses: actions/checkout@v3
         name: 'Check out code'
@@ -223,7 +220,6 @@ jobs:
 
   windows:
     runs-on: windows-2019
-    if: false
     steps:
       - uses: actions/checkout@v3
         name: 'Check out code'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           java-version: '11'
           cache: 'gradle'
 
-      - name: 'Print devices'
+      - name: 'Print the devices list'
         run: xcrun simctl list devices available --json
 
       # install jq - cli tool for json querying
@@ -68,9 +68,11 @@ jobs:
       - name: 'Set Up Simulator UUID'
         run: |
           brew install jq &&
-          IOS_SIM_UUID=$(xcrun simctl list devices available --json | jq -r '.devices."com.apple.CoreSimulator.SimRuntime.iOS-17-0"[] | select(.name == "iPhone 15") | .udid') &&
-          echo "IOS_SIM_UUID=$IOS_SIM_UUID" >> $GITHUB_ENV &&
-          echo $IOS_SIM_UUID
+          IOS_SIM_UUID=$(xcrun simctl list devices available --json | jq -r '.devices."com.apple.CoreSimulator.SimRuntime.iOS-17-0"[] | select(.name == "iPhone 14") | .udid') &&
+          echo "IOS_SIM_UUID=$IOS_SIM_UUID" >> $GITHUB_ENV
+
+      - name: 'Print Selected UUID'
+        run: echo $IOS_SIM_UUID
 
       - name: 'Compile and run iOS x64 tests'
         uses: nick-fields/retry@v2


### PR DESCRIPTION
Add a step to automatically choose a device (iosSimulatorUUID) from `xcrun simctl list devices`