### PR TITLE
Fix crash on Windows machines without OpenGL

### DIFF
--- a/skiko/build.gradle.kts
+++ b/skiko/build.gradle.kts
@@ -1036,12 +1036,18 @@ fun createLinkJvmBindings(
                 addAll(buildType.msvcLinkerFlags)
                 addAll(
                     arrayOf(
+                        // ignore https://learn.microsoft.com/en-us/cpp/error-messages/tool-errors/linker-tools-warning-lnk4217
+                        // because we link OpenGl dynamically, defining functions in our own file in OpenGLLibrary.cc
+                        "/ignore:4217"
+                    )
+                )
+                addAll(
+                    arrayOf(
                         "/NOLOGO",
                         "/DLL",
                         "Advapi32.lib",
                         "gdi32.lib",
                         "Dwmapi.lib",
-                        "opengl32.lib",
                         "shcore.lib",
                         "user32.lib",
                     )

--- a/skiko/src/awtMain/cpp/include/exceptions_handler.h
+++ b/skiko/src/awtMain/cpp/include/exceptions_handler.h
@@ -4,6 +4,7 @@
 #include <windows.h>
 #include <stdio.h>
 
-void throwJavaRenderException(JNIEnv *env, const char * function, DWORD sehCode);
+void throwJavaRenderExceptionByExceptionCode(JNIEnv *env, const char * function, DWORD code);
+void throwJavaRenderExceptionByErrorCode(JNIEnv *env, const char * function, DWORD code);
 
 #endif

--- a/skiko/src/awtMain/cpp/include/exceptions_handler.h
+++ b/skiko/src/awtMain/cpp/include/exceptions_handler.h
@@ -4,6 +4,6 @@
 #include <windows.h>
 #include <stdio.h>
 
-void throwJavaException(JNIEnv *env, const char * function, DWORD sehCode);
+void throwJavaRenderException(JNIEnv *env, const char * function, DWORD sehCode);
 
 #endif

--- a/skiko/src/awtMain/cpp/windows/OpenGLLibrary.cc
+++ b/skiko/src/awtMain/cpp/windows/OpenGLLibrary.cc
@@ -2,18 +2,18 @@
 #include <gl/GL.h>
 #include <jawt_md.h>
 
-typedef void (*PROC_glFinish) (void);
-typedef void (*PROC_glGetIntegerv) (GLenum pname, GLint *data);
-typedef const GLubyte *(*PROC_glGetString) (GLenum name);
-typedef HGLRC (WINAPI * PROC_wglCreateContext) (HDC hDc);
-typedef BOOL (WINAPI * PROC_wglDeleteContext) (HGLRC oldContext);
-typedef PROC (WINAPI * PROC_wglGetProcAddress) (LPCSTR lpszProc);
-typedef BOOL (WINAPI * PROC_wglMakeCurrent) (HDC hDc, HGLRC newContext);
-typedef HGLRC (WINAPI * PROC_wglGetCurrentContext) (void);
+namespace OpenGL32Library {
+    typedef void (*PROC_glFinish) (void);
+    typedef void (*PROC_glGetIntegerv) (GLenum pname, GLint *data);
+    typedef const GLubyte *(*PROC_glGetString) (GLenum name);
+    typedef HGLRC (WINAPI * PROC_wglCreateContext) (HDC hDc);
+    typedef BOOL (WINAPI * PROC_wglDeleteContext) (HGLRC oldContext);
+    typedef PROC (WINAPI * PROC_wglGetProcAddress) (LPCSTR lpszProc);
+    typedef BOOL (WINAPI * PROC_wglMakeCurrent) (HDC hDc, HGLRC newContext);
+    typedef HGLRC (WINAPI * PROC_wglGetCurrentContext) (void);
 
-class OpenGL32Library {
-public:
-    HINSTANCE lib;
+    bool isLoaded = false;
+    HINSTANCE lib = 0;
 
     PROC_glFinish glFinish;
     PROC_glGetIntegerv glGetIntegerv;
@@ -24,62 +24,60 @@ public:
     PROC_wglMakeCurrent wglMakeCurrent;
     PROC_wglGetCurrentContext wglGetCurrentContext;
 
-    OpenGL32Library(HINSTANCE lib) {
-        this->lib = lib;
-        glFinish = (PROC_glFinish) GetProcAddress(lib, "glFinish");
-        glGetIntegerv = (PROC_glGetIntegerv) GetProcAddress(lib, "glGetIntegerv");
-        glGetString = (PROC_glGetString) GetProcAddress(lib, "glGetString");
-        wglCreateContext = (PROC_wglCreateContext) GetProcAddress(lib, "wglCreateContext");
-        wglDeleteContext = (PROC_wglDeleteContext) GetProcAddress(lib, "wglDeleteContext");
-        wglGetProcAddress = (PROC_wglGetProcAddress) GetProcAddress(lib, "wglGetProcAddress");
-        wglMakeCurrent = (PROC_wglMakeCurrent) GetProcAddress(lib, "wglMakeCurrent");
-        wglGetCurrentContext = (PROC_wglGetCurrentContext) GetProcAddress(lib, "wglGetCurrentContext");
+    void load() {
+        if (!isLoaded) {
+            isLoaded = true;
+            lib = LoadLibrary("opengl32.dll");
+            if (lib) {
+                glFinish = (PROC_glFinish) GetProcAddress(lib, "glFinish");
+                glGetIntegerv = (PROC_glGetIntegerv) GetProcAddress(lib, "glGetIntegerv");
+                glGetString = (PROC_glGetString) GetProcAddress(lib, "glGetString");
+                wglCreateContext = (PROC_wglCreateContext) GetProcAddress(lib, "wglCreateContext");
+                wglDeleteContext = (PROC_wglDeleteContext) GetProcAddress(lib, "wglDeleteContext");
+                wglGetProcAddress = (PROC_wglGetProcAddress) GetProcAddress(lib, "wglGetProcAddress");
+                wglMakeCurrent = (PROC_wglMakeCurrent) GetProcAddress(lib, "wglMakeCurrent");
+                wglGetCurrentContext = (PROC_wglGetCurrentContext) GetProcAddress(lib, "wglGetCurrentContext");
+            }
+        }
     }
 };
-
-OpenGL32Library* openGL32Library = nullptr;
 
 extern "C"
 {
     void glFinish(void) {
-        openGL32Library->glFinish();
+        OpenGL32Library::glFinish();
     }
 
     void glGetIntegerv(GLenum pname, GLint *data) {
-        openGL32Library->glGetIntegerv(pname, data);
+        OpenGL32Library::glGetIntegerv(pname, data);
     }
 
     const GLubyte * glGetString(GLenum name) {
-        return openGL32Library->glGetString(name);
+        return OpenGL32Library::glGetString(name);
     }
 
     HGLRC WINAPI wglCreateContext(HDC hDc) {
-        return openGL32Library->wglCreateContext(hDc);
+        return OpenGL32Library::wglCreateContext(hDc);
     }
 
     BOOL WINAPI wglDeleteContext(HGLRC oldContext) {
-        return openGL32Library->wglDeleteContext(oldContext);
+        return OpenGL32Library::wglDeleteContext(oldContext);
     }
 
     PROC WINAPI wglGetProcAddress(LPCSTR lpszProc) {
-        return openGL32Library->wglGetProcAddress(lpszProc);
+        return OpenGL32Library::wglGetProcAddress(lpszProc);
     }
 
     BOOL WINAPI wglMakeCurrent(HDC hDc, HGLRC newContext) {
-        return openGL32Library->wglMakeCurrent(hDc, newContext);
+        return OpenGL32Library::wglMakeCurrent(hDc, newContext);
     }
 
     HGLRC WINAPI wglGetCurrentContext() {
-        return openGL32Library->wglGetCurrentContext();
+        return OpenGL32Library::wglGetCurrentContext();
     }
 
     JNIEXPORT jboolean JNICALL Java_org_jetbrains_skiko_OpenGLLibraryKt_loadOpenGLLibraryWindows(JNIEnv *env, jobject obj) {
-        if (openGL32Library == 0) {
-            HINSTANCE lib = LoadLibrary("opengl32.dll");
-            if (lib) {
-                openGL32Library = new OpenGL32Library(lib);
-            }
-        }
-        return openGL32Library != 0;
+        OpenGL32Library::load();
+        return OpenGL32Library::lib != 0;
     }
 }

--- a/skiko/src/awtMain/cpp/windows/OpenGLLibrary.cc
+++ b/skiko/src/awtMain/cpp/windows/OpenGLLibrary.cc
@@ -58,7 +58,7 @@ extern "C" {
         OpenGL32Library = LoadLibrary("opengl32.dll");
         if (OpenGL32Library == nullptr) {
             auto code = GetLastError();
-            throwJavaRenderException(env, __FUNCTION__, code);
+            throwJavaRenderExceptionByErrorCode(env, __FUNCTION__, code);
         }
     }
 }

--- a/skiko/src/awtMain/cpp/windows/OpenGLLibrary.cc
+++ b/skiko/src/awtMain/cpp/windows/OpenGLLibrary.cc
@@ -24,6 +24,9 @@ namespace OpenGL32Library {
     PROC_wglMakeCurrent wglMakeCurrent;
     PROC_wglGetCurrentContext wglGetCurrentContext;
 
+    // Loads the opengl32.dll into memory
+    // If loading isn't successful, skip loading the next time
+    // Isn't thread safe, call it in synchronized block
     void load() {
         if (!isLoaded) {
             isLoaded = true;
@@ -42,8 +45,7 @@ namespace OpenGL32Library {
     }
 };
 
-extern "C"
-{
+extern "C" {
     void glFinish(void) {
         OpenGL32Library::glFinish();
     }

--- a/skiko/src/awtMain/cpp/windows/OpenGLLibrary.cc
+++ b/skiko/src/awtMain/cpp/windows/OpenGLLibrary.cc
@@ -1,0 +1,85 @@
+#include <windows.h>
+#include <gl/GL.h>
+#include <jawt_md.h>
+
+typedef void (*PROC_glFinish) (void);
+typedef void (*PROC_glGetIntegerv) (GLenum pname, GLint *data);
+typedef const GLubyte *(*PROC_glGetString) (GLenum name);
+typedef HGLRC (WINAPI * PROC_wglCreateContext) (HDC hDc);
+typedef BOOL (WINAPI * PROC_wglDeleteContext) (HGLRC oldContext);
+typedef PROC (WINAPI * PROC_wglGetProcAddress) (LPCSTR lpszProc);
+typedef BOOL (WINAPI * PROC_wglMakeCurrent) (HDC hDc, HGLRC newContext);
+typedef HGLRC (WINAPI * PROC_wglGetCurrentContext) (void);
+
+class OpenGL32Library {
+public:
+    HINSTANCE lib;
+
+    PROC_glFinish glFinish;
+    PROC_glGetIntegerv glGetIntegerv;
+    PROC_glGetString glGetString;
+    PROC_wglCreateContext wglCreateContext;
+    PROC_wglDeleteContext wglDeleteContext;
+    PROC_wglGetProcAddress wglGetProcAddress;
+    PROC_wglMakeCurrent wglMakeCurrent;
+    PROC_wglGetCurrentContext wglGetCurrentContext;
+
+    OpenGL32Library(HINSTANCE lib) {
+        this->lib = lib;
+        glFinish = (PROC_glFinish) GetProcAddress(lib, "glFinish");
+        glGetIntegerv = (PROC_glGetIntegerv) GetProcAddress(lib, "glGetIntegerv");
+        glGetString = (PROC_glGetString) GetProcAddress(lib, "glGetString");
+        wglCreateContext = (PROC_wglCreateContext) GetProcAddress(lib, "wglCreateContext");
+        wglDeleteContext = (PROC_wglDeleteContext) GetProcAddress(lib, "wglDeleteContext");
+        wglGetProcAddress = (PROC_wglGetProcAddress) GetProcAddress(lib, "wglGetProcAddress");
+        wglMakeCurrent = (PROC_wglMakeCurrent) GetProcAddress(lib, "wglMakeCurrent");
+        wglGetCurrentContext = (PROC_wglGetCurrentContext) GetProcAddress(lib, "wglGetCurrentContext");
+    }
+};
+
+OpenGL32Library* openGL32Library = nullptr;
+
+extern "C"
+{
+    void glFinish(void) {
+        openGL32Library->glFinish();
+    }
+
+    void glGetIntegerv(GLenum pname, GLint *data) {
+        openGL32Library->glGetIntegerv(pname, data);
+    }
+
+    const GLubyte * glGetString(GLenum name) {
+        return openGL32Library->glGetString(name);
+    }
+
+    HGLRC WINAPI wglCreateContext(HDC hDc) {
+        return openGL32Library->wglCreateContext(hDc);
+    }
+
+    BOOL WINAPI wglDeleteContext(HGLRC oldContext) {
+        return openGL32Library->wglDeleteContext(oldContext);
+    }
+
+    PROC WINAPI wglGetProcAddress(LPCSTR lpszProc) {
+        return openGL32Library->wglGetProcAddress(lpszProc);
+    }
+
+    BOOL WINAPI wglMakeCurrent(HDC hDc, HGLRC newContext) {
+        return openGL32Library->wglMakeCurrent(hDc, newContext);
+    }
+
+    HGLRC WINAPI wglGetCurrentContext() {
+        return openGL32Library->wglGetCurrentContext();
+    }
+
+    JNIEXPORT jboolean JNICALL Java_org_jetbrains_skiko_OpenGLLibraryKt_loadOpenGLLibraryWindows(JNIEnv *env, jobject obj) {
+        if (openGL32Library == 0) {
+            HINSTANCE lib = LoadLibrary("opengl32.dll");
+            if (lib) {
+                openGL32Library = new OpenGL32Library(lib);
+            }
+        }
+        return openGL32Library != 0;
+    }
+}

--- a/skiko/src/awtMain/cpp/windows/SoftwareRedrawer.cc
+++ b/skiko/src/awtMain/cpp/windows/SoftwareRedrawer.cc
@@ -64,7 +64,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            throwJavaRenderException(env, __FUNCTION__, code);
+            throwJavaRenderExceptionByExceptionCode(env, __FUNCTION__, code);
         }
     }
 
@@ -91,7 +91,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            throwJavaRenderException(env, __FUNCTION__, code);
+            throwJavaRenderExceptionByExceptionCode(env, __FUNCTION__, code);
         }
     }
 

--- a/skiko/src/awtMain/cpp/windows/SoftwareRedrawer.cc
+++ b/skiko/src/awtMain/cpp/windows/SoftwareRedrawer.cc
@@ -64,7 +64,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            throwJavaException(env, __FUNCTION__, code);
+            throwJavaRenderException(env, __FUNCTION__, code);
         }
     }
 
@@ -91,7 +91,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            throwJavaException(env, __FUNCTION__, code);
+            throwJavaRenderException(env, __FUNCTION__, code);
         }
     }
 

--- a/skiko/src/awtMain/cpp/windows/direct3DContext.cc
+++ b/skiko/src/awtMain/cpp/windows/direct3DContext.cc
@@ -25,7 +25,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            throwJavaException(env, __FUNCTION__, code);
+            throwJavaRenderException(env, __FUNCTION__, code);
         }
     }
 }

--- a/skiko/src/awtMain/cpp/windows/direct3DContext.cc
+++ b/skiko/src/awtMain/cpp/windows/direct3DContext.cc
@@ -25,7 +25,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            throwJavaRenderException(env, __FUNCTION__, code);
+            throwJavaRenderExceptionByExceptionCode(env, __FUNCTION__, code);
         }
     }
 }

--- a/skiko/src/awtMain/cpp/windows/directXRedrawer.cc
+++ b/skiko/src/awtMain/cpp/windows/directXRedrawer.cc
@@ -321,7 +321,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            throwJavaException(env, __FUNCTION__, code);
+            throwJavaRenderException(env, __FUNCTION__, code);
         }
     }
 
@@ -341,7 +341,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            throwJavaException(env, __FUNCTION__, code);
+            throwJavaRenderException(env, __FUNCTION__, code);
         }
     }
 
@@ -396,7 +396,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            throwJavaException(env, __FUNCTION__, code);
+            throwJavaRenderException(env, __FUNCTION__, code);
         }
     }
 
@@ -413,7 +413,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            throwJavaException(env, __FUNCTION__, code);
+            throwJavaRenderException(env, __FUNCTION__, code);
         }
     }
 
@@ -441,7 +441,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            throwJavaException(env, __FUNCTION__, code);
+            throwJavaRenderException(env, __FUNCTION__, code);
         }
     }
 

--- a/skiko/src/awtMain/cpp/windows/directXRedrawer.cc
+++ b/skiko/src/awtMain/cpp/windows/directXRedrawer.cc
@@ -321,7 +321,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            throwJavaRenderException(env, __FUNCTION__, code);
+            throwJavaRenderExceptionByExceptionCode(env, __FUNCTION__, code);
         }
     }
 
@@ -341,7 +341,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            throwJavaRenderException(env, __FUNCTION__, code);
+            throwJavaRenderExceptionByExceptionCode(env, __FUNCTION__, code);
         }
     }
 
@@ -396,7 +396,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            throwJavaRenderException(env, __FUNCTION__, code);
+            throwJavaRenderExceptionByExceptionCode(env, __FUNCTION__, code);
         }
     }
 
@@ -413,7 +413,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            throwJavaRenderException(env, __FUNCTION__, code);
+            throwJavaRenderExceptionByExceptionCode(env, __FUNCTION__, code);
         }
     }
 
@@ -441,7 +441,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            throwJavaRenderException(env, __FUNCTION__, code);
+            throwJavaRenderExceptionByExceptionCode(env, __FUNCTION__, code);
         }
     }
 

--- a/skiko/src/awtMain/cpp/windows/exceptions_handler.cc
+++ b/skiko/src/awtMain/cpp/windows/exceptions_handler.cc
@@ -1,65 +1,15 @@
-#if SK_BUILD_FOR_WIN
-
 #include "exceptions_handler.h"
 #include "../common/interop.hh"
 
-const char *getDescription(DWORD code)
-{
-    switch (code)
-    {
-    case EXCEPTION_ACCESS_VIOLATION:
-        return "EXCEPTION_ACCESS_VIOLATION";
-    case EXCEPTION_ARRAY_BOUNDS_EXCEEDED:
-        return "EXCEPTION_ARRAY_BOUNDS_EXCEEDED";
-    case EXCEPTION_BREAKPOINT:
-        return "EXCEPTION_BREAKPOINT";
-    case EXCEPTION_DATATYPE_MISALIGNMENT:
-        return "EXCEPTION_DATATYPE_MISALIGNMENT";
-    case EXCEPTION_FLT_DENORMAL_OPERAND:
-        return "EXCEPTION_FLT_DENORMAL_OPERAND";
-    case EXCEPTION_FLT_DIVIDE_BY_ZERO:
-        return "EXCEPTION_FLT_DIVIDE_BY_ZERO";
-    case EXCEPTION_FLT_INEXACT_RESULT:
-        return "EXCEPTION_FLT_INEXACT_RESULT";
-    case EXCEPTION_FLT_INVALID_OPERATION:
-        return "EXCEPTION_FLT_INVALID_OPERATION";
-    case EXCEPTION_FLT_OVERFLOW:
-        return "EXCEPTION_FLT_OVERFLOW";
-    case EXCEPTION_FLT_STACK_CHECK:
-        return "EXCEPTION_FLT_STACK_CHECK";
-    case EXCEPTION_FLT_UNDERFLOW:
-        return "EXCEPTION_FLT_UNDERFLOW";
-    case EXCEPTION_ILLEGAL_INSTRUCTION:
-        return "EXCEPTION_ILLEGAL_INSTRUCTION";
-    case EXCEPTION_IN_PAGE_ERROR:
-        return "EXCEPTION_IN_PAGE_ERROR";
-    case EXCEPTION_INT_DIVIDE_BY_ZERO:
-        return "EXCEPTION_INT_DIVIDE_BY_ZERO";
-    case EXCEPTION_INT_OVERFLOW:
-        return "EXCEPTION_INT_OVERFLOW";
-    case EXCEPTION_INVALID_DISPOSITION:
-        return "EXCEPTION_INVALID_DISPOSITION";
-    case EXCEPTION_NONCONTINUABLE_EXCEPTION:
-        return "EXCEPTION_NONCONTINUABLE_EXCEPTION";
-    case EXCEPTION_PRIV_INSTRUCTION:
-        return "EXCEPTION_PRIV_INSTRUCTION";
-    case EXCEPTION_SINGLE_STEP:
-        return "EXCEPTION_SINGLE_STEP";
-    case EXCEPTION_STACK_OVERFLOW:
-        return "EXCEPTION_STACK_OVERFLOW";
-    default:
-        return "UNKNOWN EXCEPTION";
-    }
-}
+void throwJavaRenderException(JNIEnv *env, const char *function, DWORD code) {
+    char fullMsg[1024];
+    char *msg = 0;
+    FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM,
+        NULL, code, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR) &msg, 0, NULL);
+    int result = snprintf(fullMsg, sizeof(fullMsg) - 1, "Native exception in [%s], code %lu: %s", function, code, msg);
+    LocalFree(msg);
 
-void throwJavaException(JNIEnv *env, const char *function, DWORD sehCode)
-{
-    char buffer[200];
-    int result = snprintf(
-        buffer, sizeof(buffer) - 1, "Native exception in [%s]:\nSEH description: %s\n", function, getDescription(sehCode));
-    static jclass logClass = (jclass) env->NewGlobalRef(env->FindClass("org/jetbrains/skiko/RenderExceptionsHandler"));
-    static jmethodID logMethod = env->GetStaticMethodID(logClass, "throwException", "(Ljava/lang/String;)V");
-    env->CallStaticVoidMethod(logClass, logMethod, env->NewStringUTF(buffer));
+    static jclass cls = (jclass) env->NewGlobalRef(env->FindClass("org/jetbrains/skiko/RenderExceptionsHandler"));
+    static jmethodID method = env->GetStaticMethodID(cls, "throwException", "(Ljava/lang/String;)V");
+    env->CallStaticVoidMethod(cls, method, env->NewStringUTF(fullMsg));
 }
-
-#endif

--- a/skiko/src/awtMain/cpp/windows/exceptions_handler.cc
+++ b/skiko/src/awtMain/cpp/windows/exceptions_handler.cc
@@ -1,12 +1,74 @@
 #include "exceptions_handler.h"
 #include "../common/interop.hh"
 
-void throwJavaRenderException(JNIEnv *env, const char *function, DWORD code) {
+const char *getDescription(DWORD code) {
+    switch (code) {
+    case EXCEPTION_ACCESS_VIOLATION:
+        return "EXCEPTION_ACCESS_VIOLATION";
+    case EXCEPTION_ARRAY_BOUNDS_EXCEEDED:
+        return "EXCEPTION_ARRAY_BOUNDS_EXCEEDED";
+    case EXCEPTION_BREAKPOINT:
+        return "EXCEPTION_BREAKPOINT";
+    case EXCEPTION_DATATYPE_MISALIGNMENT:
+        return "EXCEPTION_DATATYPE_MISALIGNMENT";
+    case EXCEPTION_FLT_DENORMAL_OPERAND:
+        return "EXCEPTION_FLT_DENORMAL_OPERAND";
+    case EXCEPTION_FLT_DIVIDE_BY_ZERO:
+        return "EXCEPTION_FLT_DIVIDE_BY_ZERO";
+    case EXCEPTION_FLT_INEXACT_RESULT:
+        return "EXCEPTION_FLT_INEXACT_RESULT";
+    case EXCEPTION_FLT_INVALID_OPERATION:
+        return "EXCEPTION_FLT_INVALID_OPERATION";
+    case EXCEPTION_FLT_OVERFLOW:
+        return "EXCEPTION_FLT_OVERFLOW";
+    case EXCEPTION_FLT_STACK_CHECK:
+        return "EXCEPTION_FLT_STACK_CHECK";
+    case EXCEPTION_FLT_UNDERFLOW:
+        return "EXCEPTION_FLT_UNDERFLOW";
+    case EXCEPTION_ILLEGAL_INSTRUCTION:
+        return "EXCEPTION_ILLEGAL_INSTRUCTION";
+    case EXCEPTION_IN_PAGE_ERROR:
+        return "EXCEPTION_IN_PAGE_ERROR";
+    case EXCEPTION_INT_DIVIDE_BY_ZERO:
+        return "EXCEPTION_INT_DIVIDE_BY_ZERO";
+    case EXCEPTION_INT_OVERFLOW:
+        return "EXCEPTION_INT_OVERFLOW";
+    case EXCEPTION_INVALID_DISPOSITION:
+        return "EXCEPTION_INVALID_DISPOSITION";
+    case EXCEPTION_NONCONTINUABLE_EXCEPTION:
+        return "EXCEPTION_NONCONTINUABLE_EXCEPTION";
+    case EXCEPTION_PRIV_INSTRUCTION:
+        return "EXCEPTION_PRIV_INSTRUCTION";
+    case EXCEPTION_SINGLE_STEP:
+        return "EXCEPTION_SINGLE_STEP";
+    case EXCEPTION_STACK_OVERFLOW:
+        return "EXCEPTION_STACK_OVERFLOW";
+    case ERROR_MOD_NOT_FOUND:
+        return "ERROR_MOD_NOT_FOUND";
+    default:
+        return "UNKNOWN EXCEPTION";
+    }
+}
+
+void throwJavaRenderExceptionByExceptionCode(JNIEnv *env, const char *function, DWORD code) {
+    char fullMsg[200];
+    int result = snprintf(fullMsg, sizeof(fullMsg) - 1,
+        "Native exception in [%s], code %lu: %s", function, code, getDescription(code));
+
+    static jclass cls = (jclass) env->NewGlobalRef(env->FindClass("org/jetbrains/skiko/RenderExceptionsHandler"));
+    static jmethodID method = env->GetStaticMethodID(cls, "throwException", "(Ljava/lang/String;)V");
+    env->CallStaticVoidMethod(cls, method, env->NewStringUTF(fullMsg));
+}
+
+
+void throwJavaRenderExceptionByErrorCode(JNIEnv *env, const char *function, DWORD code) {
     char fullMsg[1024];
     char *msg = 0;
     FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM,
         NULL, code, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR) &msg, 0, NULL);
-    int result = snprintf(fullMsg, sizeof(fullMsg) - 1, "Native exception in [%s], code %lu: %s", function, code, msg);
+
+    int result = snprintf(fullMsg, sizeof(fullMsg) - 1,
+        "Native exception in [%s], code %lu: %s", function, code, msg);
     LocalFree(msg);
 
     static jclass cls = (jclass) env->NewGlobalRef(env->FindClass("org/jetbrains/skiko/RenderExceptionsHandler"));

--- a/skiko/src/awtMain/cpp/windows/openGLRedrawer.cc
+++ b/skiko/src/awtMain/cpp/windows/openGLRedrawer.cc
@@ -34,7 +34,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            throwJavaRenderException(env, __FUNCTION__, code);
+            throwJavaRenderExceptionByExceptionCode(env, __FUNCTION__, code);
         }
         return (jlong) 0;
     }
@@ -54,7 +54,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            throwJavaRenderException(env, __FUNCTION__, code);
+            throwJavaRenderExceptionByExceptionCode(env, __FUNCTION__, code);
         }
     }
 
@@ -67,7 +67,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            throwJavaRenderException(env, __FUNCTION__, code);
+            throwJavaRenderExceptionByExceptionCode(env, __FUNCTION__, code);
         }
     }
 
@@ -93,7 +93,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            throwJavaRenderException(env, __FUNCTION__, code);
+            throwJavaRenderExceptionByExceptionCode(env, __FUNCTION__, code);
         }
         return (jlong) 0;
     }

--- a/skiko/src/awtMain/cpp/windows/openGLRedrawer.cc
+++ b/skiko/src/awtMain/cpp/windows/openGLRedrawer.cc
@@ -34,7 +34,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            throwJavaException(env, __FUNCTION__, code);
+            throwJavaRenderException(env, __FUNCTION__, code);
         }
         return (jlong) 0;
     }
@@ -54,7 +54,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            throwJavaException(env, __FUNCTION__, code);
+            throwJavaRenderException(env, __FUNCTION__, code);
         }
     }
 
@@ -67,7 +67,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            throwJavaException(env, __FUNCTION__, code);
+            throwJavaRenderException(env, __FUNCTION__, code);
         }
     }
 
@@ -93,7 +93,7 @@ extern "C"
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();
-            throwJavaException(env, __FUNCTION__, code);
+            throwJavaRenderException(env, __FUNCTION__, code);
         }
         return (jlong) 0;
     }

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/RenderExceptionsHandler.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/RenderExceptionsHandler.kt
@@ -9,7 +9,7 @@ internal class RenderExceptionsHandler {
     companion object {
         private var output: File? = null
         @JvmStatic
-        fun logAndThrow(message: String) {
+        fun throwException(message: String) {
             if (output == null) {
                 output = File(
                     "${Library.cacheRoot}/skiko-render-exception-${ProcessHandle.current().pid()}.log"

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/LinuxOpenGLRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/LinuxOpenGLRedrawer.kt
@@ -10,9 +10,7 @@ internal class LinuxOpenGLRedrawer(
     private val properties: SkiaLayerProperties
 ) : AWTRedrawer(layer, analytics, GraphicsApi.OPENGL) {
     init {
-        if (!loadOpenGLLibrary()) {
-            throw RenderException("Cannot load OpenGL library")
-        }
+        loadOpenGLLibrary()
     }
 
     private val contextHandler = OpenGLContextHandler(layer)

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/LinuxOpenGLRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/LinuxOpenGLRedrawer.kt
@@ -9,6 +9,12 @@ internal class LinuxOpenGLRedrawer(
     analytics: SkiaLayerAnalytics,
     private val properties: SkiaLayerProperties
 ) : AWTRedrawer(layer, analytics, GraphicsApi.OPENGL) {
+    init {
+        if (!loadOpenGLLibrary()) {
+            throw RenderException("Cannot load OpenGL library")
+        }
+    }
+
     private val contextHandler = OpenGLContextHandler(layer)
     override val renderInfo: String get() = contextHandler.rendererInfo()
 

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/WindowsOpenGLRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/WindowsOpenGLRedrawer.kt
@@ -3,13 +3,18 @@ package org.jetbrains.skiko.redrawer
 import kotlinx.coroutines.*
 import org.jetbrains.skiko.*
 import org.jetbrains.skiko.context.OpenGLContextHandler
-import java.util.concurrent.Executors
 
 internal class WindowsOpenGLRedrawer(
     private val layer: SkiaLayer,
     analytics: SkiaLayerAnalytics,
     private val properties: SkiaLayerProperties
 ) : AWTRedrawer(layer, analytics, GraphicsApi.OPENGL) {
+    init {
+        if (!loadOpenGLLibrary()) {
+            throw RenderException("Cannot load OpenGL library")
+        }
+    }
+
     private val contextHandler = OpenGLContextHandler(layer)
     override val renderInfo: String get() = contextHandler.rendererInfo()
 

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/WindowsOpenGLRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/WindowsOpenGLRedrawer.kt
@@ -10,9 +10,7 @@ internal class WindowsOpenGLRedrawer(
     private val properties: SkiaLayerProperties
 ) : AWTRedrawer(layer, analytics, GraphicsApi.OPENGL) {
     init {
-        if (!loadOpenGLLibrary()) {
-            throw RenderException("Cannot load OpenGL library")
-        }
+        loadOpenGLLibrary()
     }
 
     private val contextHandler = OpenGLContextHandler(layer)

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skiko/RenderException.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skiko/RenderException.kt
@@ -1,5 +1,9 @@
 package org.jetbrains.skiko
 
+/**
+ * An exception related to a rendering failure
+ * (driver failure, rendering library failure, rendering device failure)
+ */
 internal class RenderException(
     message: String? = null,
     cause: Throwable? = null

--- a/skiko/src/jvmMain/cpp/common/openglapi.cc
+++ b/skiko/src/jvmMain/cpp/common/openglapi.cc
@@ -15,28 +15,8 @@
 
 extern "C" {
 
-JNIEXPORT void JNICALL Java_org_jetbrains_skiko_OpenGLApi_glViewport(JNIEnv * env, jobject object, jint x, jint y, jint w, jint h) {
-	glViewport(x, y, w, h);
-}
-
-JNIEXPORT void JNICALL Java_org_jetbrains_skiko_OpenGLApi_glClearColor(JNIEnv * env, jobject object, jfloat r, jfloat g, jfloat b, jfloat a) {
-	glClearColor(r, g, b, a);
-}
-
-JNIEXPORT void JNICALL Java_org_jetbrains_skiko_OpenGLApi_glClear(JNIEnv * env, jobject object, jint mask) {
-	glClear(mask);
-}
-
 JNIEXPORT void JNICALL Java_org_jetbrains_skiko_OpenGLApi_glFinish(JNIEnv * env, jobject object) {
 	glFinish();
-}
-
-JNIEXPORT void JNICALL Java_org_jetbrains_skiko_OpenGLApi_glEnable(JNIEnv * env, jobject object, jint cap) {
-	glEnable(cap);
-}
-
-JNIEXPORT void JNICALL Java_org_jetbrains_skiko_OpenGLApi_glBindTexture(JNIEnv * env, jobject object, jint target, jint texture) {
-	glBindTexture(target, texture);
 }
 
 JNIEXPORT jint JNICALL Java_org_jetbrains_skiko_OpenGLApi_glGetIntegerv(JNIEnv * env, jobject object, jint pname) {
@@ -47,8 +27,7 @@ JNIEXPORT jint JNICALL Java_org_jetbrains_skiko_OpenGLApi_glGetIntegerv(JNIEnv *
 
 JNIEXPORT jstring JNICALL Java_org_jetbrains_skiko_OpenGLApi_glGetString(JNIEnv * env, jobject object, jint value) {
 	const char *content = reinterpret_cast<const char *>(glGetString(value));
-    jstring result = env->NewStringUTF(content);
-    return result;
+    return env->NewStringUTF(content);
 }
 
 }

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/OpenGLApi.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/OpenGLApi.kt
@@ -5,23 +5,15 @@ package org.jetbrains.skiko
  * PS. In further development we should find a common pattern of using OpenGL,
  * Vulkan, Metal and implement common interface to all graphics APIs.
  */
-class OpenGLApi private constructor() {
+internal class OpenGLApi private constructor() {
     // OpenGL constants
-    val GL_TEXTURE_2D = 0x0DE1
-    val GL_TEXTURE_BINDING_2D = 0x8069
     val GL_DRAW_FRAMEBUFFER_BINDING = 0x8CA6
-    val GL_COLOR_BUFFER_BIT = 0x00004000
     val GL_VENDOR = 0x1F00
     val GL_RENDERER = 0x1F01
     val GL_TOTAL_MEMORY = 0x9048
 
     // OpenGL functions
-    external fun glViewport(x: Int, y: Int, width: Int, height: Int)
-    external fun glClearColor(r: Float, g: Float, b: Float, a: Float)
-    external fun glClear(flags: Int)
     external fun glFinish()
-    external fun glEnable(flag: Int)
-    external fun glBindTexture(target: Int, texture: Int)
     external fun glGetIntegerv(pname: Int): Int
     external fun glGetString(value: Int): String?
 

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/OpenGLLibrary.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/OpenGLLibrary.kt
@@ -1,0 +1,23 @@
+package org.jetbrains.skiko
+
+/**
+ * Load OpenGL library into memory.
+ *
+ * Should be called before any OpenGL operation.
+ *
+ * The current implementation loads OpenGl lazily on Windows, and at app startup on Linux/macOs.
+ *
+ * Some Windows machines don't have OpenGL (usually CI machines), so we'll fallback to other renderers on them.
+ *
+ * @return false if there is no OpenGL library in the system.
+ */
+internal fun loadOpenGLLibrary(): Boolean {
+    return if (hostOs.isWindows) {
+        loadOpenGLLibraryWindows()
+    } else {
+        true
+    }
+}
+
+@Synchronized
+private external fun loadOpenGLLibraryWindows(): Boolean

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/OpenGLLibrary.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/OpenGLLibrary.kt
@@ -9,15 +9,15 @@ package org.jetbrains.skiko
  *
  * Some Windows machines don't have OpenGL (usually CI machines), so we'll fallback to other renderers on them.
  *
- * @return false if there is no OpenGL library in the system.
+ * Throws [RenderException] if OpenGL library can't be loaded.
  */
-internal fun loadOpenGLLibrary(): Boolean {
-    return if (hostOs.isWindows) {
+internal fun loadOpenGLLibrary() {
+    if (hostOs.isWindows) {
         loadOpenGLLibraryWindows()
     } else {
-        true
+        // do nothing, the library should be already available
     }
 }
 
 @Synchronized
-private external fun loadOpenGLLibraryWindows(): Boolean
+private external fun loadOpenGLLibraryWindows()


### PR DESCRIPTION
Some Windows CI machines don't contain OpenGL, so Skiko/Compose will crash on them. It shouldn't crash, it should fallback to Software rendering

To properly fallback, we need to load opengl32.dll dynamically in runtime.

Fixes https://github.com/JetBrains/compose-multiplatform/issues/3243

# Test 1
- `gradlew publishToMavenLocal` is successful (if we use functions directly, it fails with "error LNK2019: unresolved external symbol")
- `SkiaLayerTest` is successful (it tests OpenGL as well)

# Test 2
1. Remove `C:\Windows\System32\opengl32.dll`
2. `SkiaLayerTest` still should be successful, but logs should contain that it fallbacks to Software rendering.

# Test 3
1. Compile local skiko
2. Run Compose run1 and tests