### PR TITLE
set OS name and architecture as archive classifier for JVM artifacts

### DIFF
--- a/skiko/build.gradle.kts
+++ b/skiko/build.gradle.kts
@@ -1168,7 +1168,8 @@ fun skikoJvmRuntimeJarTask(
 ) = project.registerSkikoTask<Jar>("skikoJvmRuntimeJar", targetOs, targetArch) {
     dependsOn(awtJar)
     val target = targetId(targetOs, targetArch)
-    archiveBaseName.set("skiko-$target")
+    archiveBaseName.set("skiko")
+    archiveClassifier.set(target)
     nativeFiles.forEach { provider -> from(provider) }
 }
 


### PR DESCRIPTION
With OS name and architecture moved to classifier, it would be easier to reference these artifacts in some Gradle features, such as dependency verification and locking.