### PR TITLE
Make dispatcherToBlockOn dispatcher based on daemon threads.

### DIFF
--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/DispatcherToBlockOn.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/DispatcherToBlockOn.kt
@@ -3,6 +3,7 @@ package org.jetbrains.skiko.redrawer
 import kotlinx.coroutines.asCoroutineDispatcher
 import java.util.concurrent.Executors
 
+private val defaultFactory = Executors.defaultThreadFactory()
 
 /**
  * Dispatcher intended for use in coroutines that blocks (not suspends) for indefinite amount of time.
@@ -10,4 +11,8 @@ import java.util.concurrent.Executors
  * We can't use `Dispatchers.IO` here because it's limited by 64 threads and under heavy IO workload all of them might be occupied
  * which leads to skipped frames
  */
-internal val dispatcherToBlockOn = Executors.newCachedThreadPool().asCoroutineDispatcher()
+internal val dispatcherToBlockOn = Executors.newCachedThreadPool {
+    defaultFactory.newThread(it).apply {
+        isDaemon = true
+    }
+}.asCoroutineDispatcher()


### PR DESCRIPTION
After https://github.com/JetBrains/skiko/pull/798, we changed Dispatcher.IO to a custom dispatcher.

Dispatcher.IO is based on daemon threads (threads that receive InterruptedException on application exit).

Our new dispatcher isn't. The proof:
```
import java.util.concurrent.Executors
import kotlinx.coroutines.Dispatchers
import kotlinx.coroutines.asCoroutineDispatcher
import kotlinx.coroutines.runBlocking

fun main() {
    runBlocking(Dispatchers.IO) {
        println(Thread.currentThread().isDaemon) // prints true
    }
    runBlocking(Executors.newCachedThreadPool().asCoroutineDispatcher()) {
        println(Thread.currentThread().isDaemon) // prints false
    }
    val defaultFactory = Executors.defaultThreadFactory()
    runBlocking(Executors.newCachedThreadPool {
        defaultFactory.newThread(it).apply {
            isDaemon = true
        }
    }.asCoroutineDispatcher()) {
        println(Thread.currentThread().isDaemon) // prints true
    }
}
```

This PR makes threads daemon.

Reported in [Kotlin Slack](https://kotlinlang.slack.com/archives/C01D6HTPATV/p1697400320739369) - applications exits too long.