### PR TITLE
Fix skiko-js mavenCentral publication: Add SkikoArtifacts.jsArtifactId to skikoArtifactIds list

### DIFF
--- a/skiko/ci/build.gradle.kts
+++ b/skiko/ci/build.gradle.kts
@@ -16,6 +16,7 @@ val skikoArtifactIds: List<String> =
         SkikoArtifacts.jvmRuntimeArtifactIdFor(OS.MacOS, Arch.X64),
         SkikoArtifacts.jvmRuntimeArtifactIdFor(OS.MacOS, Arch.Arm64),
         SkikoArtifacts.jsWasmArtifactId,
+        SkikoArtifacts.jsArtifactId,
         SkikoArtifacts.nativeArtifactIdFor(OS.Linux, Arch.X64),
         SkikoArtifacts.nativeArtifactIdFor(OS.MacOS, Arch.Arm64),
         SkikoArtifacts.nativeArtifactIdFor(OS.MacOS, Arch.X64),


### PR DESCRIPTION
Currently skiko-js is not uploaded to mavenCentral and we have an error when using only mavenCentral:

```
 Could not resolve all dependencies for configuration ':jsApp:jsCompileClasspath'.
   > Could not find org.jetbrains.skiko:skiko-js:0.7.85.
     Searched in the following locations:
       - https://dl.google.com/dl/android/maven2/org/jetbrains/skiko/skiko-js/0.7.85/skiko-js-0.7.85.pom
       - https://repo.maven.apache.org/maven2/org/jetbrains/skiko/skiko-js/0.7.85/skiko-js-0.7.85.pom
     Required by:
         project :jsApp > org.jetbrains.compose.ui:ui:1.5.10-rc02 > org.jetbrains.compose.ui:ui-js:1.5.10-rc02 > org.jetbrains.skiko:skiko:0.7.85
> Could not resolve all dependencies for configuration ':shared:jsCompileClasspath'.
   > Could not find org.jetbrains.skiko:skiko-js:0.7.85.
     Required by:
         project :shared > org.jetbrains.compose.ui:ui:1.5.10-rc02 > org.jetbrains.compose.ui:ui-js:1.5.10-rc02 > org.jetbrains.skiko:skiko:0.7.85
         ```