### PR TITLE
In MetalRedrawer, stop delaying rendering as soon as the window becomes non-occluded.

### DIFF
--- a/skiko/build.gradle.kts
+++ b/skiko/build.gradle.kts
@@ -765,6 +765,7 @@ fun createObjcCompileTask(
     includeHeadersNonRecursive(skiaHeadersDirs(skiaJvmBindingsDir.get()))
     includeHeadersNonRecursive(projectDir.resolve("src/awtMain/cpp/include"))
     includeHeadersNonRecursive(projectDir.resolve("src/commonMain/cpp/common/include"))
+    includeHeadersNonRecursive(projectDir.resolve("src/jvmMain/cpp"))
 
     compiler.set("clang")
     buildVariant.set(buildType)

--- a/skiko/src/awtMain/objectiveC/macos/MetalDevice.h
+++ b/skiko/src/awtMain/objectiveC/macos/MetalDevice.h
@@ -14,6 +14,7 @@
 @property (strong) id<MTLCommandQueue> queue;
 @property (strong) id<CAMetalDrawable> drawableHandle;
 @property (strong) dispatch_semaphore_t inflightSemaphore;
+@property (strong) id<NSObject> occlusionObserver;
 
 @end
 

--- a/skiko/src/awtMain/objectiveC/macos/MetalRedrawer.mm
+++ b/skiko/src/awtMain/objectiveC/macos/MetalRedrawer.mm
@@ -17,7 +17,7 @@
 
 #include <assert.h>
 
-#include "../../../jvmMain/cpp/common/interop.hh"
+#include "common/interop.hh"
 
 @implementation AWTMetalLayer
 

--- a/skiko/src/awtMain/objectiveC/macos/MetalRedrawer.mm
+++ b/skiko/src/awtMain/objectiveC/macos/MetalRedrawer.mm
@@ -72,6 +72,15 @@ static JNIEnv *resolveJNIEnvForCurrentThread() {
     return env;
 }
 
+static jmethodID getOnOcclusionStateChangedMethodID(JNIEnv *env, jobject redrawer) {
+    static jmethodID onOcclusionStateChanged = NULL;
+    if (onOcclusionStateChanged == NULL) {
+        jclass redrawerClass = env->GetObjectClass(redrawer);
+        onOcclusionStateChanged = env->GetMethodID(redrawerClass, "onOcclusionStateChanged", "(Z)V");
+    }
+    return onOcclusionStateChanged;
+}
+
 extern "C"
 {
 
@@ -119,9 +128,7 @@ JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_redrawer_MetalRedrawer_createMe
             window.hasShadow = NO;
         }
 
-        jclass redrawerClass = env->GetObjectClass(redrawer);
-        jmethodID onOcclusionStateChanged = env->GetMethodID(redrawerClass, "onOcclusionStateChanged", "(Z)V");
-
+        jmethodID onOcclusionStateChanged = getOnOcclusionStateChangedMethodID(env, redrawer);
         device.occlusionObserver =
             [[NSNotificationCenter defaultCenter] addObserverForName:NSWindowDidChangeOcclusionStateNotification
                                                               object:window

--- a/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
+++ b/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
@@ -719,7 +719,7 @@ class SkiaLayerTest {
                 renderTimes.clear()
             }
         } finally {
-            window.close()
+            window.dispose()
         }
     }
 

--- a/skiko/src/awtTest/kotlin/org/jetbrains/skiko/util/UiTest.kt
+++ b/skiko/src/awtTest/kotlin/org/jetbrains/skiko/util/UiTest.kt
@@ -8,21 +8,34 @@ import org.junit.Assume.assumeTrue
 import java.awt.GraphicsEnvironment
 import javax.swing.JFrame
 
-internal fun uiTest(block: suspend UiTestScope.() -> Unit) {
+internal fun uiTest(
+    excludeRenderApis: List<GraphicsApi> = emptyList(),
+    block: suspend UiTestScope.() -> Unit
+) {
     assumeFalse(GraphicsEnvironment.isHeadless())
     assumeTrue(System.getProperty("skiko.test.ui.enabled", "false") == "true")
 
-    val renderApi = System.getProperty("skiko.test.ui.renderApi", "all")
+    val renderApiProperty = System.getProperty("skiko.test.ui.renderApi", "all")
 
     runBlocking(MainUIDispatcher) {
-        if (renderApi == "all") {
-            SkikoProperties.fallbackRenderApiQueue(SkikoProperties.renderApi).forEach {
-                println("Testing $it renderApi")
+        if (renderApiProperty == "all") {
+            for (renderApi in SkikoProperties.fallbackRenderApiQueue(SkikoProperties.renderApi)) {
+                if (renderApi in excludeRenderApis) {
+                    println("Skipping $renderApi renderApi")
+                    continue
+                }
+                println("Testing $renderApi renderApi")
                 println()
-                UiTestScope(scope = this, renderApi = it).block()
+                UiTestScope(scope = this, renderApi = renderApi).block()
             }
         } else {
-            UiTestScope(scope = this, renderApi = SkikoProperties.parseRenderApi(renderApi)).block()
+            val renderApi = SkikoProperties.parseRenderApi(renderApiProperty)
+            if (renderApi in excludeRenderApis) {
+                println("Skipping $renderApi renderApi")
+            }
+            else {
+                UiTestScope(scope = this, renderApi = renderApi).block()
+            }
         }
     }
 }

--- a/skiko/src/jvmMain/cpp/common/impl/Library.cc
+++ b/skiko/src/jvmMain/cpp/common/impl/Library.cc
@@ -5,7 +5,12 @@
 #include "../paragraph/interop.hh"
 #include "../svg/interop.hh"
 
+
+extern "C" JavaVM *jvm = NULL;
+
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved) {
+    jvm = vm;
+
     JNIEnv* env;
     if (vm->GetEnv(reinterpret_cast<void**>(&env), SKIKO_JNI_VERSION) != JNI_OK)
         return JNI_ERR;


### PR DESCRIPTION
Occasionally, when the window is just getting show, `isOccluded` will return `true` while we're already trying to draw into it. This causes `MetalRedrawer.draw` to delay for 300ms in order to avoid wasting resources drawing while the window is occluded. But because this delay is not interrupted even when the window becomes non-occluded, we get a delay drawing the 2nd frame.

This PR adds a call from native code `NSWindowDidChangeOcclusionStateNotification` that interrupts the delay when the window becomes non-occluded, so that drawing can resume immediately.