### PR TITLE
Fix problem with conversion of Kotlin String to C char *

### DIFF
--- a/skiko/RELEASE.md
+++ b/skiko/RELEASE.md
@@ -21,6 +21,7 @@ build configuration.
 ```bash
 ./gradlew publishToMavenLocal -Pskiko.native.enabled=true -Pskiko.wasm.enabled=true -Pskiko.android.enabled=true
 ```
+Use flag `-Pskiko.debug=true` to build with debug build type.
 
 ##### Publish to `build/repo` directory
 ```bash

--- a/skiko/src/nativeMain/kotlin/org/jetbrains/skia/impl/Native.native.kt
+++ b/skiko/src/nativeMain/kotlin/org/jetbrains/skia/impl/Native.native.kt
@@ -283,11 +283,12 @@ private external fun initCallbacks(
 )
 
 /**
- * C++ needs char* with zero byte at the end. So, we need to increase original string and write 0 at end.
+ * Converts String to zero-terminated utf-8 byte array.
  */
 private fun convertToZeroTerminatedString(string: String): ByteArray {
-    // encodeToByteArray encodes to utf8
-    val utf8 = string.encodeToByteArray()
+    //  C++ needs char* with zero byte at the end. So we need to copy array with an extra zero byte.
+
+    val utf8 = string.encodeToByteArray() // encodeToByteArray encodes to utf8
     // TODO Remove array copy, use `skString(data, length)` instead of `skString(data)`
     return utf8.copyOf(utf8.size + 1)
 }

--- a/skiko/src/nativeMain/kotlin/org/jetbrains/skia/impl/Native.native.kt
+++ b/skiko/src/nativeMain/kotlin/org/jetbrains/skia/impl/Native.native.kt
@@ -66,10 +66,7 @@ internal actual inline fun <T> interopScope(block: InteropScope.() -> T): T {
 internal actual class InteropScope actual constructor() {
     actual fun toInterop(string: String?): InteropPointer {
         return if (string != null) {
-            // encodeToByteArray encodes to utf8
-            val utf8 = string.encodeToByteArray()
-            // TODO Remove array copy, use `skString(data, length)` instead of `skString(data)`
-            val pinned = utf8.copyOf(utf8.size + 1).pin()
+            val pinned = convertToZeroTerminatedString(string).pin()
             elements.add(pinned)
             val result = pinned.addressOf(0).rawValue
             result
@@ -186,7 +183,7 @@ internal actual class InteropScope actual constructor() {
         if (stringArray == null || stringArray.isEmpty()) return NativePtr.NULL
 
         val pins = stringArray.toList()
-            .map { it.encodeToByteArray().pin() }
+            .map { convertToZeroTerminatedString(it).pin() }
 
         val nativePointerArray = NativePointerArray(stringArray.size)
         pins.forEachIndexed { index, pin ->
@@ -284,3 +281,13 @@ private external fun initCallbacks(
     callVoid: COpaquePointer,
     dispose: COpaquePointer
 )
+
+/**
+ * C++ needs char* with zero byte at the end. So, we need to increase original string and write 0 at end.
+ */
+private fun convertToZeroTerminatedString(string: String): ByteArray {
+    // encodeToByteArray encodes to utf8
+    val utf8 = string.encodeToByteArray()
+    // TODO Remove array copy, use `skString(data, length)` instead of `skString(data)`
+    return utf8.copyOf(utf8.size + 1)
+}

--- a/skiko/src/nativeMain/kotlin/org/jetbrains/skia/impl/Native.native.kt
+++ b/skiko/src/nativeMain/kotlin/org/jetbrains/skia/impl/Native.native.kt
@@ -282,9 +282,6 @@ private external fun initCallbacks(
     dispose: COpaquePointer
 )
 
-/**
- * C++ needs char* with zero byte at the end. So, we need to increase original string and write 0 at end.
- */
 private fun convertToZeroTerminatedString(string: String): ByteArray {
     // encodeToByteArray encodes to utf8
     val utf8 = string.encodeToByteArray()

--- a/skiko/src/nativeMain/kotlin/org/jetbrains/skia/impl/Native.native.kt
+++ b/skiko/src/nativeMain/kotlin/org/jetbrains/skia/impl/Native.native.kt
@@ -282,6 +282,9 @@ private external fun initCallbacks(
     dispose: COpaquePointer
 )
 
+/**
+ * C++ needs char* with zero byte at the end. So, we need to increase original string and write 0 at end.
+ */
 private fun convertToZeroTerminatedString(string: String): ByteArray {
     // encodeToByteArray encodes to utf8
     val utf8 = string.encodeToByteArray()


### PR DESCRIPTION
Previously it was a problem with converting  Kotlin `Array<String>` to C `char**`, because Kotlin String was conterted without Zero byte at the end.