### PR TITLE
[build] Following warning removed from skiko and samples

### DIFF
--- a/samples/SkiaAwtSample/build.gradle.kts
+++ b/samples/SkiaAwtSample/build.gradle.kts
@@ -83,5 +83,5 @@ tasks.register("runInterop") {
 }
 
 tasks.withType<KotlinCompile>().configureEach {
-    kotlinOptions.freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
+    kotlinOptions.freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
 }

--- a/samples/SkiaMultiplatformSample/build.gradle.kts
+++ b/samples/SkiaMultiplatformSample/build.gradle.kts
@@ -341,6 +341,6 @@ fun KotlinNativeTarget.configureToLaunchFromXcode() {
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile>().configureEach {
     kotlinOptions {
-        freeCompilerArgs += "-Xopt-in=kotlinx.cinterop.ExperimentalForeignApi"
+        freeCompilerArgs += "-opt-in=kotlinx.cinterop.ExperimentalForeignApi"
     }
 }

--- a/skiko/build.gradle.kts
+++ b/skiko/build.gradle.kts
@@ -557,5 +557,9 @@ tasks.findByName("publishSkikoWasmRuntimePublicationToComposeRepoRepository")
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile>().configureEach {
     // https://youtrack.jetbrains.com/issue/KT-56583
     compilerOptions.freeCompilerArgs.add("-XXLanguage:+ImplicitSignedToUnsignedIntegerConversion")
-    kotlinOptions.freeCompilerArgs += "-Xopt-in=kotlinx.cinterop.ExperimentalForeignApi"
+    kotlinOptions.freeCompilerArgs += "-opt-in=kotlinx.cinterop.ExperimentalForeignApi"
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.dsl.KotlinCompile<*>>().configureEach {
+    kotlinOptions.freeCompilerArgs += "-Xexpect-actual-classes"
 }


### PR DESCRIPTION
    * Argument -Xopt-in is deprecated. Please use -opt-in instead
    * 'expect'/'actual' classes (including interfaces, objects, annotations, enums, and 'actual' typealiases) are in Beta