### PR TITLE
Don't try to init D3D with zero size

### DIFF
--- a/skiko/src/awtMain/cpp/windows/directXRedrawer.cc
+++ b/skiko/src/awtMain/cpp/windows/directXRedrawer.cc
@@ -58,12 +58,7 @@ public:
         device.reset(nullptr);
     }
 
-    void initSwapChain() {
-        RECT windowRect;
-        GetClientRect(window, &windowRect);
-        UINT width = windowRect.right - windowRect.left;
-        UINT height = windowRect.bottom - windowRect.top;
-
+    void initSwapChain(UINT width, UINT height) {
         gr_cp<IDXGIFactory4> swapChainFactory4;
         gr_cp<IDXGISwapChain1> swapChain1;
         CreateDXGIFactory2(0, IID_PPV_ARGS(&swapChainFactory4));
@@ -330,12 +325,12 @@ extern "C"
     }
 
     JNIEXPORT void JNICALL Java_org_jetbrains_skiko_redrawer_Direct3DRedrawer_initSwapChain(
-        JNIEnv *env, jobject redrawer, jlong devicePtr)
+        JNIEnv *env, jobject redrawer, jlong devicePtr, jint width, jint height)
     {
         __try
         {
             DirectXDevice *d3dDevice = fromJavaPointer<DirectXDevice *>(devicePtr);
-            d3dDevice->initSwapChain();
+            d3dDevice->initSwapChain((UINT) width, (UINT) height);
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/context/Direct3DContextHandler.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/context/Direct3DContextHandler.kt
@@ -54,7 +54,7 @@ internal class Direct3DContextHandler(layer: SkiaLayer) : JvmContextHandler(laye
             context?.flush()
             
             if (!isD3DInited) {
-                directXRedrawer.initSwapChain()
+                directXRedrawer.initSwapChain(w, h)
             } else {
                 directXRedrawer.resizeBuffers(w, h)
             }

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/Direct3DRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/Direct3DRedrawer.kt
@@ -107,7 +107,7 @@ internal class Direct3DRedrawer(
     fun resizeBuffers(width: Int, height: Int) = resizeBuffers(device, width, height)
 
     fun getBufferIndex() = getBufferIndex(device)
-    fun initSwapChain() = initSwapChain(device)
+    fun initSwapChain(width: Int, height: Int) = initSwapChain(device, width, height)
     fun initFence() = initFence(device)
 
     // Called from native code
@@ -121,7 +121,7 @@ internal class Direct3DRedrawer(
     private external fun swap(device: Long, isVsyncEnabled: Boolean)
     private external fun disposeDevice(device: Long)
     private external fun getBufferIndex(device: Long): Int
-    private external fun initSwapChain(device: Long)
+    private external fun initSwapChain(device: Long, width: Int, height: Int)
     private external fun initFence(device: Long)
     private external fun getAdapterName(adapter: Long): String
     private external fun getAdapterMemorySize(adapter: Long): Long

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/Direct3DRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/Direct3DRedrawer.kt
@@ -84,10 +84,14 @@ internal class Direct3DRedrawer(
     }
 
     private fun drawAndSwap(withVsync: Boolean) = synchronized(drawLock) {
-        if (!isDisposed) {
-            contextHandler.draw()
-            swap(device, withVsync)
+        if (isDisposed) {
+            return
         }
+        if (layer.width <= 0 || layer.height <= 0) {
+            return
+        }
+        contextHandler.draw()
+        swap(device, withVsync)
     }
 
     fun makeContext() = DirectContext(


### PR DESCRIPTION
Currently it fails to init swap chain because the size of the element is zero. It's not valid parameter in `DXGI_SWAP_CHAIN_DESC1`

`[SKIKO] warn: Exception in draw scope org.jetbrains.skiko.RenderException: Native exception in [Java_org_jetbrains_skiko_redrawer_Direct3DRedrawer_initSwapChain], code 3221225477: EXCEPTION_ACCESS_VIOLATION`

Fixes https://github.com/JetBrains/compose-multiplatform/issues/4105