### PR TITLE
Download and use a codesign-client from an internal jb repository instead of using a hardcoded one

### DIFF
--- a/skiko/build.gradle.kts
+++ b/skiko/build.gradle.kts
@@ -517,7 +517,7 @@ publishing {
 }
 
 val mavenCentral = MavenCentralProperties(project)
-if (skiko.isCIBuild || mavenCentral.signArtifacts) {
+if (skiko.isTeamcityCIBuild || mavenCentral.signArtifacts) {
     signing {
         sign(publishing.publications)
         useInMemoryPgpKeys(mavenCentral.signArtifactsKey.get(), mavenCentral.signArtifactsPassword.get())

--- a/skiko/buildSrc/build.gradle.kts
+++ b/skiko/buildSrc/build.gradle.kts
@@ -11,5 +11,5 @@ dependencies {
     implementation(kotlin("stdlib"))
     compileOnly(gradleApi())
     implementation(kotlin("gradle-plugin", "1.9.21"))
-    implementation("de.undercouch:gradle-download-task:5.4.0")
+    implementation("de.undercouch:gradle-download-task:5.5.0")
 }

--- a/skiko/buildSrc/src/main/kotlin/properties.kt
+++ b/skiko/buildSrc/src/main/kotlin/properties.kt
@@ -16,6 +16,9 @@ enum class OS(
     val isWindows
         get() = this == Windows
 
+    val isMacOs
+        get() = this == MacOS
+
     fun idWithSuffix(isIosSim: Boolean = false): String {
         return id + if (isIosSim) "Sim" else ""
     }

--- a/skiko/buildSrc/src/main/kotlin/properties.kt
+++ b/skiko/buildSrc/src/main/kotlin/properties.kt
@@ -116,7 +116,7 @@ fun targetId(os: OS, arch: Arch) = "${os.id}-${arch.id}"
 val jdkHome = System.getProperty("java.home") ?: error("'java.home' is null")
 
 class SkikoProperties(private val myProject: Project) {
-    val isCIBuild: Boolean
+    val isTeamcityCIBuild: Boolean
         get() = myProject.hasProperty("teamcity")
 
     val planeDeployVersion: String = myProject.property("deploy.version") as String

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/JvmTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/JvmTasksConfiguration.kt
@@ -347,7 +347,7 @@ fun SkikoProjectContext.createDownloadCodeSignClientDarwinTask(
     overwrite(false)
 
     // only Teamcity agents have access to download the codesign-client executable file
-     enabled = this@createDownloadCodeSignClientDarwinTask.skiko.isTeamcityCIBuild
+    enabled = this@createDownloadCodeSignClientDarwinTask.skiko.isTeamcityCIBuild
 
     doLast {
         val downloadedFile = project.layout.buildDirectory.get().asFile.resolve(hostArch.darwinSignClientName)

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/JvmTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/JvmTasksConfiguration.kt
@@ -11,6 +11,7 @@ import SkikoProjectContext
 import compilerForTarget
 import dynamicLibExt
 import hostOs
+import joinToTitleCamelCase
 import linkerForTarget
 import org.gradle.api.GradleException
 import org.gradle.api.JavaVersion
@@ -327,12 +328,35 @@ fun SkikoProjectContext.createLinkJvmBindings(
     flags.set(listOf(*osFlags))
 }
 
+private val Arch.darwinSignClientName: String
+    get() = when (this) {
+        Arch.X64 -> "codesign-client-darwin-amd64"
+        Arch.Arm64 -> "codesign-client-darwin-arm64"
+        else -> error("Unexpected Arch = $this for codesign-client")
+    }
+
+fun SkikoProjectContext.createDownloadCodeSignClientDarwinTask(
+    targetOs: OS,
+    targetArch: Arch
+) = project.registerSkikoTask<de.undercouch.gradle.tasks.download.Download>("downloadCodeSignClient", targetOs, targetArch) {
+    val fileUrl = "https://codesign-distribution.labs.jb.gg/${targetArch.darwinSignClientName}"
+
+    src(fileUrl)
+    dest(project.layout.buildDirectory)
+    overwrite(false)
+}
+
 fun SkikoProjectContext.maybeSignOrSealTask(
     targetOs: OS,
     targetArch: Arch,
     linkJvmBindings: Provider<LinkSkikoTask>
 ) = project.registerSkikoTask<SealAndSignSharedLibraryTask>("maybeSign", targetOs, targetArch) {
     dependsOn(linkJvmBindings)
+
+    if (targetOs.isMacOs) {
+        val downloadCodesignClientTask = "downloadCodeSignClient" + joinToTitleCamelCase(targetOs.id, targetArch.id)
+        dependsOn(project.tasks.getByName(downloadCodesignClientTask))
+    }
 
     val linkOutputFile = linkJvmBindings.map { task ->
         task.outDir.get().asFile.walk().single { it.name.endsWith(targetOs.dynamicLibExt) }.absoluteFile
@@ -353,7 +377,7 @@ fun SkikoProjectContext.maybeSignOrSealTask(
     }
 
     if (hostOs == OS.MacOS) {
-        codesignClient.set(toolsDir.file("codesign-client-darwin-x64"))
+        codesignClient.set(project.layout.buildDirectory.file(targetArch.darwinSignClientName))
     }
     signHost.set(skiko.signHost)
     signUser.set(skiko.signUser)
@@ -379,6 +403,9 @@ fun SkikoProjectContext.createSkikoJvmJarTask(os: OS, arch: Arch, commonJar: Tas
     val objcCompile = if (os == OS.MacOS) createObjcCompileTask(os, arch, skiaBindingsDir) else null
     val linkBindings =
         createLinkJvmBindings(os, arch, skiaBindingsDir, compileBindings, objcCompile)
+    if (os.isMacOs) {
+        createDownloadCodeSignClientDarwinTask(os, arch)
+    }
     val maybeSign = maybeSignOrSealTask(os, arch, linkBindings)
     val nativeLib = maybeSign.map { it.outputFiles.get().single() }
     val createChecksums = createChecksumsTask(os, arch, nativeLib)

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/JvmTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/JvmTasksConfiguration.kt
@@ -348,6 +348,11 @@ fun SkikoProjectContext.createDownloadCodeSignClientDarwinTask(
 
     // only Teamcity agents have access to download the codesign-client executable file
      enabled = this@createDownloadCodeSignClientDarwinTask.skiko.isTeamcityCIBuild
+
+    doLast {
+        val downloadedFile = project.layout.buildDirectory.get().asFile.resolve(hostArch.darwinSignClientName)
+         downloadedFile.setExecutable(true)
+    }
 }
 
 fun SkikoProjectContext.maybeSignOrSealTask(


### PR DESCRIPTION
According to https://youtrack.jetbrains.com/articles/SRE-A-36/How-To-Use-CodeSign#by-codesign-client-utility
It was asked by SRE team. 