### PR TITLE
Call `Library.load()` before calling native getCurrentSystemTheme()

### DIFF
--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SystemTheme.awt.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SystemTheme.awt.kt
@@ -1,10 +1,13 @@
 package org.jetbrains.skiko
 
 actual val currentSystemTheme: SystemTheme
-    get() = when (getCurrentSystemTheme()) {
-        0 -> SystemTheme.LIGHT
-        1 -> SystemTheme.DARK
-        else -> SystemTheme.UNKNOWN
+    get() {
+        Library.load()
+        return when (getCurrentSystemTheme()) {
+            0 -> SystemTheme.LIGHT
+            1 -> SystemTheme.DARK
+            else -> SystemTheme.UNKNOWN
+        }
     }
 
 // Common

--- a/skiko/src/awtTest/kotlin/org/jetbrains/skiko/LibraryLoadedTest.kt
+++ b/skiko/src/awtTest/kotlin/org/jetbrains/skiko/LibraryLoadedTest.kt
@@ -1,0 +1,13 @@
+package org.jetbrains.skiko
+
+import org.junit.Test
+
+/**
+ * Verifies that the native Skiko library is correctly loaded in various scenarios.
+ */
+class LibraryLoadedTest {
+    @Test
+    fun getSystemTheme() {
+        currentSystemTheme
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/JetBrains/compose-multiplatform/issues/4208