### PR TITLE
Remove checks from Rect creation

### DIFF
--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/IRect.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/IRect.kt
@@ -60,23 +60,17 @@ class IRect internal constructor(val left: Int, val top: Int, val right: Int, va
     companion object {
         @JvmStatic
         fun makeLTRB(l: Int, t: Int, r: Int, b: Int): IRect {
-            require(l <= r) { "IRect::makeLTRB expected l <= r, got $l > $r" }
-            require(t <= b) { "IRect::makeLTRB expected t <= b, got $t > $b" }
             return IRect(l, t, r, b)
         }
 
         @JvmStatic
         fun makeXYWH(l: Int, t: Int, w: Int, h: Int): IRect {
-            require(w >= 0) { "IRect::makeXYWH expected w >= 0, got: $w" }
-            require(h >= 0) { "IRect::makeXYWH expected h >= 0, got: $h" }
-            return if (w >= 0 && h >= 0) IRect(l, t, l + w, t + h) else throw IllegalArgumentException()
+            return IRect(l, t, l + w, t + h)
         }
 
         @JvmStatic
         fun makeWH(w: Int, h: Int): IRect {
-            require(w >= 0) { "IRect::makeWH expected w >= 0, got: $w" }
-            require(h >= 0) { "IRect::makeWH expected h >= 0, got: $h" }
-            return if (w >= 0 && h >= 0) IRect(0, 0, w, h) else throw IllegalArgumentException()
+            return IRect(0, 0, w, h)
         }
     }
 }

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Rect.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Rect.kt
@@ -88,15 +88,11 @@ open class Rect constructor(val left: Float, val top: Float, val right: Float, v
     companion object {
         @JvmStatic
         fun makeLTRB(l: Float, t: Float, r: Float, b: Float): Rect {
-            require(l <= r) { "Rect::makeLTRB expected l <= r, got $l > $r" }
-            require(t <= b) { "Rect::makeLTRB expected t <= b, got $t > $b" }
             return Rect(l, t, r, b)
         }
 
         @JvmStatic
         fun makeWH(w: Float, h: Float): Rect {
-            require(w >= 0) { "Rect::makeWH expected w >= 0, got: $w" }
-            require(h >= 0) { "Rect::makeWH expected h >= 0, got: $h" }
             return Rect(0f, 0f, w, h)
         }
 
@@ -107,8 +103,6 @@ open class Rect constructor(val left: Float, val top: Float, val right: Float, v
 
         @JvmStatic
         fun makeXYWH(l: Float, t: Float, w: Float, h: Float): Rect {
-            require(w >= 0) { "Rect::makeXYWH expected w >= 0, got: $w" }
-            require(h >= 0) { "Rect::makeXYWH expected h >= 0, got: $h" }
             return Rect(l, t, l + w, t + h)
         }
 


### PR DESCRIPTION
Skia doesn't require such limitations during creation and [sorts](https://github.com/search?q=repo%3AJetBrains%2Fskia+.makeSorted%28%29+path%3A%2F%5Esrc%5C%2F%2F&type=code) values in a few methods during drawing.

Replacement of https://github.com/JetBrains/compose-multiplatform-core/pull/1062

Fixes https://github.com/JetBrains/compose-multiplatform/issues/4250
Fixes https://github.com/JetBrains/compose-multiplatform/issues/3794
Fixes https://github.com/JetBrains/compose-multiplatform/issues/3964