### PR TITLE
Offscreen, Linux. Fix native crash when OpenGL isn't available

### DIFF
--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/LinuxOpenGLSwingRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/LinuxOpenGLSwingRedrawer.kt
@@ -15,7 +15,12 @@ internal class LinuxOpenGLSwingRedrawer(
 
     private val swingOffscreenDrawer = SwingOffscreenDrawer(swingLayerProperties)
 
-    private val offScreenContextPtr: Long = makeOffScreenContext()
+    private val offScreenContextPtr: Long = makeOffScreenContext().also {
+        if (it == 0L) {
+            throw RenderException("Cannot create OpenGL context")
+        }
+    }
+
 
     private var offScreenBufferPtr: Long = 0L
 


### PR DESCRIPTION
Instead, fallback to Software.

Discovered during https://github.com/JetBrains/skiko/issues/876 investigation

## Explanation

We throw RenderException, and Fallback mechanism catches it and switches to Software

## Testing

1. Setup the system without OpenGL
2. Run SkiaSwingLayer
3. See the native crash