### PR TITLE
Update DEVELOPMENT.md instructions for Linux

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,7 +4,7 @@
   * `macOs` Install Xcode Command Line Tools
   * `Linux` Install these tools:
     ```
-    sudo apt-get install ninja-build fontconfig libfontconfig1-dev libglu1-mesa-dev libxrandr-dev libdbus-1-dev zip
+    sudo apt-get install ninja-build fontconfig libfontconfig1-dev libglu1-mesa-dev libxrandr-dev libdbus-1-dev zip libx11-dev
     ```
   * `Windows`
     1. Download [Visual Studio Build Tools 2019](https://learn.microsoft.com/en-us/visualstudio/releases/2019/history) (search "BuildTools" on the page).

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,23 @@
 ### Building JVM bindings
 
-* Install Xcode Command Line Tools (macOS only)
+* Prepare the system
+  * `macOs` Install Xcode Command Line Tools
+  * `Linux` Install these tools:
+    ```
+    sudo apt-get install ninja-build fontconfig libfontconfig1-dev libglu1-mesa-dev libxrandr-dev libdbus-1-dev zip
+    ```
+  * `Windows`
+    1. Download [Visual Studio Build Tools 2019](https://learn.microsoft.com/en-us/visualstudio/releases/2019/history) (search "BuildTools" on the page).
+    2. During the installation, select "Desktop development with C++"
+    3. Add an environment variable SKIKO_VSBT_PATH=C:/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools
+    ```
+    Control Panel|All Control Panel Items|System|Advanced system settings|Environment variables
+    ```
+    or by running `cmd` as administrator:
+    ```
+    setx /M SKIKO_VSBT_PATH "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools"
+    ```
+
 * Install Emscripten
 * Set `JAVA_HOME` to location of JDK, at least version 11
 * `./gradlew :skiko:publishToMavenLocal` will build the artifact and publish it to local Maven repo
@@ -13,20 +30,6 @@ Gradle build downloads the necessary version of Skia by default.
 However, if downloaded sources are modified, changes are discarded (Gradle
 re-evaluates tasks, when outputs are changed).
 To use custom version of the dependencies, specify `SKIA_DIR` environment variable.
-
-#### Building on Windows
-
-##### Using Visual Studio Build Tools 2019
-1. Download [Visual Studio Build Tools 2019](https://learn.microsoft.com/en-us/visualstudio/releases/2019/history) (search "BuildTools" on the page).
-2. During the installation, select "Desktop development with C++"
-3. Add an environment variable SKIKO_VSBT_PATH=C:/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools
-```
-Control Panel|All Control Panel Items|System|Advanced system settings|Environment variables
-```
-or by running `cmd` as administrator:
-```
-setx /M SKIKO_VSBT_PATH "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools"
-```
 
 #### Running UI tests
 Add `-Dskiko.test.ui.enabled=true` to enable UI tests (integration tests, which run in the native window). Each UI test will be run on every available Graphics API of the current target.


### PR DESCRIPTION
And move Windows instructions to the first section

Commands for Linux were get from https://github.com/JetBrains/skiko/blob/78f227f19bd4cb811d34fbc2df7befb4f76be355/.github/workflows/ci.yml#L102

Except we use `libx11-dev` instead of `xvfb`. Tested on a new system (but I performed commands in other order, so I am not completely sure that they are all needed)