### PR TITLE
Update skiko build for ICU renamed symbols

### DIFF
--- a/skiko/build-with-local-skia.sh
+++ b/skiko/build-with-local-skia.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 ####### Variables you can edit to change build config, or set same environment variables before script execution #######
-SKIA_VERSION="${SKIA_VERSION:="m116-b54492e-3"}" # Version of Skia m###-commit-sha-#. This commit sha will be cloned from repository https://github.com/JetBrains/skia
+SKIA_VERSION="${SKIA_VERSION:="m116-47d3027-1"}" # Version of Skia m###-commit-sha-#. This commit sha will be cloned from repository https://github.com/JetBrains/skia
 SKIA_DEBUG_MODE="${SKIA_DEBUG_MODE:="false"}" # in debug mode Skiko will be published with postix "+debug", for example "0.0.0-SNAPSHOT+debug"
 SKIA_TARGET="${SKIA_TARGET:="iosSim"}" # possible values: "ios", "iosSim", "macos", "windows", "linux", "wasm", "android", "tvos", "tvosSim"
 # For M1 Mac use "iosSim" to build for simulator, and ios to build for device.

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/CommonTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/CommonTasksConfiguration.kt
@@ -56,6 +56,11 @@ fun skiaPreprocessorFlags(os: OS, buildType: SkiaBuildType): Array<String> {
         "-DSK_UNICODE_AVAILABLE",
         "-DU_DISABLE_RENAMING",
         "-DSK_USING_THIRD_PARTY_ICU",
+        // For ICU symbols renaming:
+        "-DU_DISABLE_RENAMING=0",
+        "-DU_DISABLE_VERSION_SUFFIX=1",
+        "-DU_HAVE_LIB_SUFFIX=1",
+        "-DU_LIB_SUFFIX_C_NAME=_skiko",
         *buildType.flags
     )
 

--- a/skiko/gradle.properties
+++ b/skiko/gradle.properties
@@ -1,19 +1,19 @@
 kotlin.code.style=official
 deploy.version=0.0.0
 
-dependencies.skia.windows-x64=m116-b54492e-3
-dependencies.skia.linux-x64=m116-b54492e-3
-dependencies.skia.macos-x64=m116-b54492e-3
-dependencies.skia.windows-arm64=m116-b54492e-3
-dependencies.skia.linux-arm64=m116-b54492e-3
-dependencies.skia.macos-arm64=m116-b54492e-3
-dependencies.skia.wasm-wasm=m116-b54492e-3
-dependencies.skia.ios-x64=m116-b54492e-3
-dependencies.skia.ios-arm64=m116-b54492e-3
-dependencies.skia.iosSim-arm64=m116-b54492e-3
-dependencies.skia.iosSim-x64=m116-b54492e-3
-dependencies.skia.android-x64=m116-b54492e-3
-dependencies.skia.android-arm64=m116-b54492e-3
+dependencies.skia.windows-x64=m116-47d3027-1
+dependencies.skia.linux-x64=m116-47d3027-1
+dependencies.skia.macos-x64=m116-47d3027-1
+dependencies.skia.windows-arm64=m116-47d3027-1
+dependencies.skia.linux-arm64=m116-47d3027-1
+dependencies.skia.macos-arm64=m116-47d3027-1
+dependencies.skia.wasm-wasm=m116-47d3027-1
+dependencies.skia.ios-x64=m116-47d3027-1
+dependencies.skia.ios-arm64=m116-47d3027-1
+dependencies.skia.iosSim-arm64=m116-47d3027-1
+dependencies.skia.iosSim-x64=m116-47d3027-1
+dependencies.skia.android-x64=m116-47d3027-1
+dependencies.skia.android-arm64=m116-47d3027-1
 
 org.gradle.jvmargs=-Xmx3G -XX:MaxMetaspaceSize=512m
 

--- a/skiko/src/nativeMain/kotlin/org/jetbrains/skia/Actuals.native.kt
+++ b/skiko/src/nativeMain/kotlin/org/jetbrains/skia/Actuals.native.kt
@@ -46,7 +46,7 @@ internal actual fun compilePattern(regex: String): Pattern = Pattern(regex)
 
 actual typealias ExternalSymbolName = kotlin.native.SymbolName
 
-@SymbolName("uloc_getDefault")
+@SymbolName("uloc_getDefault_skiko")
 private external fun uloc_getDefault(): CPointer<ByteVar>
-@SymbolName("uloc_toLanguageTag")
+@SymbolName("uloc_toLanguageTag_skiko")
 private external fun uloc_toLanguageTag(localeId: CPointer<ByteVar>, buffer: InteropPointer, size: Int, strict: Boolean, err: InteropPointer): Int


### PR DESCRIPTION
Now we build skia/icu with _skiko suffix to avoid clashes with Apple SDK

Corresponding skia change: https://github.com/JetBrains/skia/pull/3

Corresponding skia commit: https://github.com/JetBrains/skia/commit/47d3027b8cbeea76135c0995d5886aa2e58e7512