### PR TITLE
Use `CreateSwapChainForHwnd` without transparency

### DIFF
--- a/skiko/src/awtMain/cpp/windows/directXRedrawer.cc
+++ b/skiko/src/awtMain/cpp/windows/directXRedrawer.cc
@@ -58,12 +58,15 @@ public:
         device.reset(nullptr);
     }
 
-    void initSwapChain(UINT width, UINT height) {
+    void initSwapChain(UINT width, UINT height, jboolean transparency) {
         gr_cp<IDXGIFactory4> swapChainFactory4;
         gr_cp<IDXGISwapChain1> swapChain1;
         CreateDXGIFactory2(0, IID_PPV_ARGS(&swapChainFactory4));
-        HRESULT result = CreateSwapChainForComposition(swapChainFactory4.get(), width, height, &swapChain1);
-        if (FAILED(result)) {
+        HRESULT result = S_OK;
+        if (transparency) {
+            result = CreateSwapChainForComposition(swapChainFactory4.get(), width, height, &swapChain1);
+        }
+        if (!transparency || FAILED(result)) {
             /*
              * It's just a fallback path that added for compatibility.
              * In this case transparency won't be supported.
@@ -360,12 +363,12 @@ extern "C"
     }
 
     JNIEXPORT void JNICALL Java_org_jetbrains_skiko_redrawer_Direct3DRedrawer_initSwapChain(
-        JNIEnv *env, jobject redrawer, jlong devicePtr, jint width, jint height)
+        JNIEnv *env, jobject redrawer, jlong devicePtr, jint width, jint height, jboolean transparency)
     {
         __try
         {
             DirectXDevice *d3dDevice = fromJavaPointer<DirectXDevice *>(devicePtr);
-            d3dDevice->initSwapChain((UINT) width, (UINT) height);
+            d3dDevice->initSwapChain((UINT) width, (UINT) height, transparency);
         }
         __except(EXCEPTION_EXECUTE_HANDLER) {
             auto code = GetExceptionCode();

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/Direct3DRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/Direct3DRedrawer.kt
@@ -104,7 +104,7 @@ internal class Direct3DRedrawer(
 
     fun changeSize(width: Int, height: Int): Boolean {
         return if (!isSwapChainInitialized) {
-            initSwapChain(device, width, height)
+            initSwapChain(device, width, height, layer.transparency)
             isSwapChainInitialized = true
             true
         } else {
@@ -134,7 +134,7 @@ internal class Direct3DRedrawer(
     private external fun swap(device: Long, isVsyncEnabled: Boolean)
     private external fun disposeDevice(device: Long)
     private external fun getBufferIndex(device: Long): Int
-    private external fun initSwapChain(device: Long, width: Int, height: Int)
+    private external fun initSwapChain(device: Long, width: Int, height: Int, transparency: Boolean)
     private external fun initFence(device: Long)
     private external fun getAdapterName(adapter: Long): String
     private external fun getAdapterMemorySize(adapter: Long): Long


### PR DESCRIPTION
Merging a fix from `0.7.95.1` to the main branch for https://github.com/JetBrains/compose-multiplatform/issues/4397