### PR TITLE
[wasm],[js] Trigger change scale event only once for every possible s…

### DIFF
--- a/samples/SkiaJsSample/build.gradle.kts
+++ b/samples/SkiaJsSample/build.gradle.kts
@@ -3,9 +3,9 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
+    mavenLocal()
 }
 
 var version = "0.0.0-SNAPSHOT"

--- a/skiko/src/jsMain/kotlin/org/jetbrains/skiko/SkiaLayer.js.kt
+++ b/skiko/src/jsMain/kotlin/org/jetbrains/skiko/SkiaLayer.js.kt
@@ -1,6 +1,8 @@
 package org.jetbrains.skiko
 
 import kotlinx.browser.window
+import org.w3c.dom.AddEventListenerOptions
+import org.w3c.dom.MediaQueryListEvent
 import org.w3c.dom.events.KeyboardEvent
 import org.w3c.dom.events.UIEvent
 
@@ -13,6 +15,11 @@ actual typealias SkikoPlatformPointerEvent = UIEvent
 internal actual fun SkiaLayer.setOnChangeScaleNotifier() {
     state?.initCanvas(desiredWidth, desiredHeight, contentScale, this.pixelGeometry)
     window.matchMedia("(resolution: ${contentScale}dppx)")
-        .addEventListener("change", { setOnChangeScaleNotifier() }, true)
+        .addEventListener("change", { evt ->
+            evt as MediaQueryListEvent
+            if (!evt.matches) {
+                setOnChangeScaleNotifier()
+            }
+        }, AddEventListenerOptions(capture = true, once = true))
     onContentScaleChanged?.invoke(contentScale)
 }

--- a/skiko/src/wasmJsMain/kotlin/org/jetbrains/skiko/SkiaLayer.js.wasmJs.kt
+++ b/skiko/src/wasmJsMain/kotlin/org/jetbrains/skiko/SkiaLayer.js.wasmJs.kt
@@ -1,6 +1,8 @@
 package org.jetbrains.skiko
 
 import kotlinx.browser.window
+import org.w3c.dom.AddEventListenerOptions
+import org.w3c.dom.MediaQueryListEvent
 
 import org.w3c.dom.events.KeyboardEvent
 import org.w3c.dom.events.UIEvent
@@ -14,6 +16,11 @@ actual typealias SkikoPlatformPointerEvent = UIEvent
 internal actual fun SkiaLayer.setOnChangeScaleNotifier() {
     state?.initCanvas(desiredWidth, desiredHeight, contentScale, this.pixelGeometry)
     window.matchMedia("(resolution: ${contentScale}dppx)")
-        .addEventListener("change", { setOnChangeScaleNotifier() }, true)
+        .addEventListener("change", { evt ->
+            evt as MediaQueryListEvent
+            if (!evt.matches) {
+                setOnChangeScaleNotifier()
+            }
+         }, AddEventListenerOptions(capture = true, once = true))
     onContentScaleChanged?.invoke(contentScale)
 }


### PR DESCRIPTION
See more at https://youtrack.jetbrains.com/issue/COMPOSE-1129/Skiko-Change-resolution-event-was-reassigned-each-time-in-handler