### PR TITLE
Option to not throw RenderException when use OpenGL on macOS

### DIFF
--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/OpenGLLibrary.jvm.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/OpenGLLibrary.jvm.kt
@@ -15,9 +15,13 @@ internal actual fun loadOpenGLLibrary() {
                 Library.staticLoad()
                 loadOpenGLLibraryWindows()
             }
-            // it was deprecated in macOS 10.14 and isn't supported in Skiko
+            // it was deprecated in macOS 10.14
             // see https://developer.apple.com/library/archive/documentation/GraphicsImaging/Conceptual/OpenGL-MacProgGuide/opengl_intro/opengl_intro.html
-            hostOs.isMacOS -> throw RenderException("OpenGL on macOS isn't supported")
+            hostOs.isMacOS -> {
+                if (!SkikoProperties.macOsOpenGLEnabled) {
+                    throw RenderException("OpenGL on macOS is deprecated. To enable its support, call System.setProperty(\"skiko.macos.opengl.enabled\", \"true\")")
+                }
+            }
             // Do nothing as we don't know for sure which OS supports OpenGL.
             // If there is support, we assume that it is already linked.
             // If there is no support, there will be a native crash

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/SkikoProperties.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/SkikoProperties.kt
@@ -67,6 +67,8 @@ object SkikoProperties {
         return value?.let(GpuPriority::parseOrNull) ?: GpuPriority.Auto
     }
 
+    val macOsOpenGLEnabled: Boolean get() = getProperty("skiko.macos.opengl.enabled")?.toBoolean() ?: false
+
     internal fun parseRenderApi(text: String?): GraphicsApi {
         when(text) {
             "SOFTWARE_COMPAT" -> return GraphicsApi.SOFTWARE_COMPAT


### PR DESCRIPTION
To allow using OpenGL on macOs, call:
```
System.setProperty("skiko.macos.opengl.enabled", "true")
```

By request from user in DM who uses LWJGL+Skiko on macOS.