### PR TITLE
Add isMaximized and setMaximized methods to PlatformOperations

### DIFF
--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/HardwareLayer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/HardwareLayer.kt
@@ -53,6 +53,10 @@ internal open class HardwareLayer(
         get() = platformOperations.isFullscreen(this)
         set(value) = platformOperations.setFullscreen(this, value)
 
+    var maximized: Boolean
+        get() = platformOperations.isMaximized(this)
+        set(value) = platformOperations.setMaximized(this, value)
+
     fun disableTitleBar(customHeaderHeight: Float) {
         platformOperations.disableTitleBar(this, customHeaderHeight)
     }

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/PlatformOperations.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/PlatformOperations.kt
@@ -59,6 +59,7 @@ internal class FullscreenAdapter(
 internal interface PlatformOperations {
     fun isFullscreen(component: Component): Boolean
     fun setFullscreen(component: Component, value: Boolean)
+    fun isMaximized(component: Component): Boolean
     fun setMaximized(component: Component, value: Boolean)
     fun disableTitleBar(component: Component, headerHeight: Float)
     fun orderEmojiAndSymbolsPopup()
@@ -76,8 +77,23 @@ internal val platformOperations: PlatformOperations by lazy {
                     osxSetFullscreenNative(component, value)
                 }
 
+                override fun isMaximized(component: Component): Boolean {
+                    val window = SwingUtilities.getRoot(component) as JFrame
+                    return window.extendedState and MAXIMIZED_BOTH == MAXIMIZED_BOTH
+                }
+
                 override fun setMaximized(component: Component, value: Boolean) {
-                    osxSetMaximizedNative(component, value)
+                    if (isFullscreen(component)) {
+                        osxSetMaximizedNative(component, value)
+                    } else {
+                        val window = SwingUtilities.getRoot(component) as JFrame
+
+                        if (value) {
+                            window.extendedState = window.extendedState or MAXIMIZED_BOTH
+                        } else {
+                            window.extendedState = window.extendedState and MAXIMIZED_BOTH.inv()
+                        }
+                    }
                 }
 
                 override fun disableTitleBar(component: Component, headerHeight: Float) {
@@ -101,6 +117,11 @@ internal val platformOperations: PlatformOperations by lazy {
                     val window = SwingUtilities.getRoot(component) as Window
                     val device = window.graphicsConfiguration.device
                     device.fullScreenWindow = if (value) window else null
+                }
+
+                override fun isMaximized(component: Component): Boolean {
+                    val window = SwingUtilities.getRoot(component) as JFrame
+                    return window.extendedState and MAXIMIZED_BOTH == MAXIMIZED_BOTH
                 }
 
                 override fun setMaximized(component: Component, value: Boolean) {
@@ -132,6 +153,11 @@ internal val platformOperations: PlatformOperations by lazy {
                     val window = SwingUtilities.getRoot(component) as Window
                     val device = window.graphicsConfiguration.device
                     device.fullScreenWindow = if (value) window else null
+                }
+
+                override fun isMaximized(component: Component): Boolean {
+                    val window = SwingUtilities.getRoot(component) as JFrame
+                    return window.extendedState and MAXIMIZED_BOTH == MAXIMIZED_BOTH
                 }
 
                 override fun setMaximized(component: Component, value: Boolean) {

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/PlatformOperations.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/PlatformOperations.kt
@@ -127,6 +127,10 @@ internal val platformOperations: PlatformOperations by lazy {
                 override fun setMaximized(component: Component, value: Boolean) {
                     val window = SwingUtilities.getRoot(component) as JFrame
 
+                    if (isFullscreen(component)) {
+                        setFullscreen(component, false)
+                    }
+
                     if (value) {
                         window.extendedState = window.extendedState or MAXIMIZED_BOTH
                     } else {
@@ -162,6 +166,10 @@ internal val platformOperations: PlatformOperations by lazy {
 
                 override fun setMaximized(component: Component, value: Boolean) {
                     val window = SwingUtilities.getRoot(component) as JFrame
+
+                    if (isFullscreen(component)) {
+                        setFullscreen(component, false)
+                    }
 
                     if (value) {
                         window.extendedState = window.extendedState or MAXIMIZED_BOTH

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/PlatformOperations.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/PlatformOperations.kt
@@ -1,9 +1,11 @@
 package org.jetbrains.skiko
 
 import java.awt.Component
+import java.awt.Frame.MAXIMIZED_BOTH
 import java.awt.Window
 import java.awt.event.ComponentAdapter
 import java.awt.event.ComponentEvent
+import javax.swing.JFrame
 import javax.swing.SwingUtilities
 
 /**
@@ -57,6 +59,7 @@ internal class FullscreenAdapter(
 internal interface PlatformOperations {
     fun isFullscreen(component: Component): Boolean
     fun setFullscreen(component: Component, value: Boolean)
+    fun setMaximized(component: Component, value: Boolean)
     fun disableTitleBar(component: Component, headerHeight: Float)
     fun orderEmojiAndSymbolsPopup()
 }
@@ -71,6 +74,10 @@ internal val platformOperations: PlatformOperations by lazy {
 
                 override fun setFullscreen(component: Component, value: Boolean) {
                     osxSetFullscreenNative(component, value)
+                }
+
+                override fun setMaximized(component: Component, value: Boolean) {
+                    osxSetMaximizedNative(component, value)
                 }
 
                 override fun disableTitleBar(component: Component, headerHeight: Float) {
@@ -96,6 +103,16 @@ internal val platformOperations: PlatformOperations by lazy {
                     device.fullScreenWindow = if (value) window else null
                 }
 
+                override fun setMaximized(component: Component, value: Boolean) {
+                    val window = SwingUtilities.getRoot(component) as JFrame
+
+                    if (value) {
+                        window.extendedState = window.extendedState or MAXIMIZED_BOTH
+                    } else {
+                        window.extendedState = window.extendedState and MAXIMIZED_BOTH.inv()
+                    }
+                }
+
                 override fun disableTitleBar(component: Component, headerHeight: Float) {
                 }
 
@@ -117,6 +134,16 @@ internal val platformOperations: PlatformOperations by lazy {
                     device.fullScreenWindow = if (value) window else null
                 }
 
+                override fun setMaximized(component: Component, value: Boolean) {
+                    val window = SwingUtilities.getRoot(component) as JFrame
+
+                    if (value) {
+                        window.extendedState = window.extendedState or MAXIMIZED_BOTH
+                    } else {
+                        window.extendedState = window.extendedState and MAXIMIZED_BOTH.inv()
+                    }
+                }
+
                 override fun disableTitleBar(component: Component, headerHeight: Float) {
                 }
 
@@ -134,5 +161,6 @@ internal val platformOperations: PlatformOperations by lazy {
 // OSX
 external private fun osxIsFullscreenNative(component: Component): Boolean
 external private fun osxSetFullscreenNative(component: Component, value: Boolean)
+external private fun osxSetMaximizedNative(component: Component, value: Boolean)
 external private fun osxDisableTitleBar(component: Component, headerHeight: Float)
 external private fun osxOrderEmojiAndSymbolsPopup()

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt
@@ -216,6 +216,10 @@ actual open class SkiaLayer internal constructor(
             fullscreenAdapter.fullscreen = value
         }
 
+    fun setMaximized(value: Boolean) {
+        backedLayer.setMaximized(value)
+    }
+
     actual val component: Any?
         get() = backedLayer
 

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt
@@ -216,9 +216,11 @@ actual open class SkiaLayer internal constructor(
             fullscreenAdapter.fullscreen = value
         }
 
-    fun setMaximized(value: Boolean) {
-        backedLayer.setMaximized(value)
-    }
+    var maximized: Boolean
+        get() = backedLayer.maximized
+        set(value) {
+            backedLayer.maximized = value
+        }
 
     actual val component: Any?
         get() = backedLayer

--- a/skiko/src/awtMain/objectiveC/macos/Drawlayer.mm
+++ b/skiko/src/awtMain/objectiveC/macos/Drawlayer.mm
@@ -242,6 +242,33 @@
     }
 }
 
+- (BOOL) isMaximized
+{
+    return [self.window isZoomed];
+}
+
+- (void) setMaximized: (BOOL) value
+{
+    if (self.isFullScreen)
+    {
+        [self performSelectorOnMainThread:@selector(toggleFullScreenAndZoom:) withObject:[NSNumber numberWithBool:value] waitUntilDone:NO];
+    }
+    else if (value != self.isMaximized)
+    {
+        [self.window performSelectorOnMainThread:@selector(zoom:) withObject:nil waitUntilDone:NO];
+    }
+}
+
+- (void) toggleFullScreenAndZoom: (NSNumber *) value {
+    [self.window toggleFullScreen:nil];
+
+    BOOL boolValue = [value boolValue];
+    if (boolValue != self.isMaximized)
+    {
+        [self.window zoom:nil];
+    }
+}
+
 @end
 
 NSMutableSet *layerStorage = nil;
@@ -354,6 +381,17 @@ JNIEXPORT void JNICALL Java_org_jetbrains_skiko_PlatformOperationsKt_osxSetFulls
         if (layer != NULL)
         {
             [layer makeFullscreen:value];
+        }
+    }
+}
+
+JNIEXPORT void JNICALL Java_org_jetbrains_skiko_PlatformOperationsKt_osxSetMaximizedNative(JNIEnv *env, jobject properties, jobject component, jboolean value)
+{
+    @autoreleasepool {
+        LayerHandler *layer = findByObject(env, component);
+        if (layer != NULL)
+        {
+            [layer setMaximized:value];
         }
     }
 }

--- a/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
+++ b/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
@@ -347,6 +347,62 @@ class SkiaLayerTest {
     }
 
     @Test
+    fun `window maximized state in componentResized`() = uiTest {
+        val window = UiTestWindow()
+        try {
+            window.defaultCloseOperation = WindowConstants.DISPOSE_ON_CLOSE
+            var stateRemainsMaximized = true
+            window.layer.maximized = true
+            window.addComponentListener(object: ComponentAdapter(){
+                override fun componentResized(e: ComponentEvent?) {
+                    if (!window.layer.maximized)
+                        stateRemainsMaximized = false
+                }
+            })
+            window.isVisible = true
+
+            delay(1000)
+            assertEquals(true, stateRemainsMaximized)
+        } finally {
+            window.close()
+        }
+    }
+
+    @Test
+    fun `window maximized state in fullscreen`() = uiTest {
+        val window = UiTestWindow()
+        try {
+            window.defaultCloseOperation = WindowConstants.DISPOSE_ON_CLOSE
+            window.layer.fullscreen = true
+            window.isVisible = true
+
+            // Test exiting fullscreen to maximized=true
+            delay(1000)
+            window.layer.maximized = true
+            delay(2000)
+            assertEquals(false, window.layer.fullscreen)
+            assertEquals(true, window.layer.maximized)
+
+            window.layer.fullscreen = true
+
+            // Test exiting fullscreen to maximized=false
+            delay(1000)
+            window.layer.maximized = false
+            delay(2000)
+            assertEquals(false, window.layer.fullscreen)
+            assertEquals(false, window.layer.maximized)
+        } finally {
+            window.close()
+
+            // Delay before starting next test to let the window animation to complete, and allow the next window
+            // to become fullscreen
+            if (hostOs == OS.MacOS) {
+                delay(1000)
+            }
+        }
+    }
+
+    @Test
     fun `should call onRender after init, after resize, and only once after needRedraw`() = uiTest {
         var renderCount = 0
 


### PR DESCRIPTION
Related to: https://github.com/JetBrains/compose-multiplatform-core/pull/1148

Hi,
I added `setMaximized` methods to `PlatformOperations` which is using a native implementation for macos.
I added `maximized` property in HardwareLayer and SkiaLayer.awt.
This will fix a problem that we have on Compose Desktop when we try to do something like this: floating -> fullscreen -> maximized, the window will stay fullscreen, more details in the PR above.

The swing implementation on Windows and Linux is not tested yet.

The current implementation is not final, but it's working, so let me know what you think.