### PR TITLE
Support accessibility in SkiaSwingLayer

### DIFF
--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/Accessibility.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/Accessibility.kt
@@ -1,8 +1,69 @@
 package org.jetbrains.skiko
 
+import kotlinx.coroutines.*
+import java.awt.Component
+import java.awt.KeyboardFocusManager
+import java.awt.event.FocusEvent
+import java.beans.PropertyChangeEvent
 import javax.accessibility.Accessible
+import javax.accessibility.AccessibleContext
 
 /**
  * See [nativeInitializeAccessible] doc for details
  */
 internal external fun initializeCAccessible(accessible: Accessible)
+
+/**
+ * A helper class for implementing requesting accessibility focus on a given accessible.
+ */
+internal class NativeAccessibleFocusHelper(
+    private val component: Component,
+    private val externalAccessible: Accessible?,
+) {
+
+    private var focusedAccessible: Accessible? = null
+
+    val accessibleContext: AccessibleContext?
+        get() = (focusedAccessible ?: externalAccessible)?.accessibleContext
+
+    private var resetFocusAccessibleJob: Job? = null
+
+    @OptIn(DelicateCoroutinesApi::class)
+    fun requestNativeFocusOnAccessible(accessible: Accessible?) {
+        focusedAccessible = accessible
+
+        when (hostOs) {
+            OS.Windows -> requestAccessBridgeFocusOnAccessible()
+            OS.MacOS -> requestMacOSFocusOnAccessible(accessible)
+            else -> {
+                focusedAccessible = null
+                return
+            }
+        }
+
+        // Listener spawns asynchronous notification post procedure, reading current focus owner
+        // and its accessibility context. This timeout is used to deal with concurrency
+        // TODO Find more reliable procedure
+        resetFocusAccessibleJob?.cancel()
+        resetFocusAccessibleJob = GlobalScope.launch(MainUIDispatcher) {
+            delay(100)
+            focusedAccessible = null
+        }
+    }
+
+    private fun requestAccessBridgeFocusOnAccessible() {
+        val focusEvent = FocusEvent(component, FocusEvent.FOCUS_GAINED)
+        component.focusListeners.forEach { it.focusGained(focusEvent) }
+    }
+
+    private fun requestMacOSFocusOnAccessible(accessible: Accessible?) {
+        val focusManager = KeyboardFocusManager.getCurrentKeyboardFocusManager()
+        val listeners = focusManager.getPropertyChangeListeners("focusOwner")
+        val event = PropertyChangeEvent(focusManager, "focusOwner", null, accessible)
+        listeners.forEach { it.propertyChange(event) }
+    }
+
+    fun dispose() {
+        resetFocusAccessibleJob?.cancel()
+    }
+}

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SkiaSwingLayer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SkiaSwingLayer.kt
@@ -3,9 +3,11 @@ package org.jetbrains.skiko.swing
 import org.jetbrains.skia.Canvas
 import org.jetbrains.skiko.*
 import org.jetbrains.skiko.redrawer.RedrawerManager
+import java.awt.Component
 import java.awt.Graphics2D
 import java.awt.GraphicsConfiguration
 import javax.accessibility.Accessible
+import javax.accessibility.AccessibleContext
 import javax.swing.JComponent
 import javax.swing.JPanel
 import javax.swing.SwingUtilities.isEventDispatchThread
@@ -25,6 +27,7 @@ import javax.swing.SwingUtilities.isEventDispatchThread
 open class SkiaSwingLayer(
     renderDelegate: SkikoRenderDelegate,
     analytics: SkiaLayerAnalytics = SkiaLayerAnalytics.Empty,
+    externalAccessibleFactory: ((Component) -> Accessible)? = null,
 ) : JPanel() {
     internal companion object {
         init {
@@ -119,7 +122,17 @@ open class SkiaSwingLayer(
         }
     }
 
+    @Suppress("LeakingThis")
+    private val nativeAccessibleFocusHelper = NativeAccessibleFocusHelper(
+        component = this,
+        externalAccessible = externalAccessibleFactory?.invoke(this)
+    )
+
+    override fun getAccessibleContext(): AccessibleContext {
+        return nativeAccessibleFocusHelper.accessibleContext ?: super.getAccessibleContext()
+    }
+
     fun requestNativeFocusOnAccessible(accessible: Accessible?) {
-        // TODO: support accessibility
+        nativeAccessibleFocusHelper.requestNativeFocusOnAccessible(accessible)
     }
 }

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SkiaSwingLayer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SkiaSwingLayer.kt
@@ -7,6 +7,7 @@ import java.awt.Graphics2D
 import java.awt.GraphicsConfiguration
 import javax.accessibility.Accessible
 import javax.swing.JComponent
+import javax.swing.JPanel
 import javax.swing.SwingUtilities.isEventDispatchThread
 
 /**
@@ -24,7 +25,7 @@ import javax.swing.SwingUtilities.isEventDispatchThread
 open class SkiaSwingLayer(
     renderDelegate: SkikoRenderDelegate,
     analytics: SkiaLayerAnalytics = SkiaLayerAnalytics.Empty,
-) : JComponent() {
+) : JPanel() {
     internal companion object {
         init {
             Library.load()


### PR DESCRIPTION
To properly support accessibility, SkiaSwingLayer needs to subclass `JPanel`, not `JComponent`.
Also, it needs to implement `requestNativeFocusOnAccessible`.

Fixes https://github.com/JetBrains/compose-multiplatform/issues/4731

Note that this doesn't yet fully fix a11y in `ComposePanel`. It still doesn't work well when Swing and Compose are mixed. `ComposePanel` appears to be highlighted as a whole, rather than individual widgets in it, by VoiceOver. It is, however, possible to go "inside" by focus traversal.