### PR TITLE
[WIP] Add MingwX64 (Windows) support

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -7,15 +7,10 @@
     sudo apt-get install ninja-build fontconfig libfontconfig1-dev libglu1-mesa-dev libxrandr-dev libdbus-1-dev zip libx11-dev
     ```
   * `Windows`
-    1. Download [Visual Studio Build Tools 2019](https://learn.microsoft.com/en-us/visualstudio/releases/2019/history) (search "BuildTools" on the page).
-    2. During the installation, select "Desktop development with C++"
-    3. Add an environment variable SKIKO_VSBT_PATH=C:/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools
+    1. Download [LLVM](https://github.com/llvm/llvm-project/releases/tag/llvmorg-17.0.1) (search "LLVM-version-x64.exe" on the page).
+    2. Add the "bin" folder into your PATH
     ```
     Control Panel|All Control Panel Items|System|Advanced system settings|Environment variables
-    ```
-    or by running `cmd` as administrator:
-    ```
-    setx /M SKIKO_VSBT_PATH "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools"
     ```
 
 * Install Emscripten

--- a/samples/SkiaMultiplatformSample/build.gradle.kts
+++ b/samples/SkiaMultiplatformSample/build.gradle.kts
@@ -92,6 +92,16 @@ kotlin {
         }
     }
 
+    if(hostOs == "windows") {
+        mingwX64 {
+            binaries {
+                executable {
+                    entryPoint = "org.jetbrains.skiko.sample.main"
+                }
+            }
+        }
+    }
+
     jvm("awt") {
         compilations.all {
             kotlinOptions.jvmTarget = "11"
@@ -158,6 +168,10 @@ kotlin {
             dependsOn(darwinMain)
         }
 
+        val mingwMain by creating {
+            dependsOn(nativeMain)
+        }
+
         if (hostOs == "macos") {
             val macosX64Main by getting {
                 dependsOn(macosMain)
@@ -170,6 +184,11 @@ kotlin {
             }
             val iosSimulatorArm64Main by getting {
                 dependsOn(iosMain)
+            }
+        }
+        if(hostOs == "windows") {
+            val mingwX64Main by getting {
+                dependsOn(mingwMain)
             }
         }
     }

--- a/samples/SkiaMultiplatformSample/gradle.properties
+++ b/samples/SkiaMultiplatformSample/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx3G -XX:MaxMetaspaceSize=512m
 kotlin.version=1.9.21
-#skiko.composite.build=1
+skiko.composite.build=1

--- a/samples/SkiaMultiplatformSample/src/mingwMain/kotlin/org/jetbrains/skiko/sample/Main.mingw.kt
+++ b/samples/SkiaMultiplatformSample/src/mingwMain/kotlin/org/jetbrains/skiko/sample/Main.mingw.kt
@@ -1,0 +1,5 @@
+package org.jetbrains.skiko.sample
+
+fun main() {
+
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,4 @@
 rootProject.name = "skiko-all"
 includeBuild("samples/SkiaAwtSample")
+includeBuild("samples/SkiaMultiplatformSample")
 includeBuild("skiko")

--- a/skiko/build.gradle.kts
+++ b/skiko/build.gradle.kts
@@ -140,6 +140,9 @@ kotlin {
     if (supportNativeIosX64) {
         skikoProjectContext.configureNativeTarget(OS.IOS, Arch.X64, iosX64())
     }
+    if(supportNativeMingwX64) {
+        skikoProjectContext.configureNativeTarget(OS.Windows, Arch.X64, mingwX64())
+    }
 
     sourceSets {
         val commonMain by getting {
@@ -270,6 +273,20 @@ kotlin {
                     }
                     val linuxX64Test by getting {
                         dependsOn(linuxTest)
+                    }
+                }
+                if(supportNativeMingwX64) {
+                    val mingwMain by creating {
+                        dependsOn(nativeMain)
+                    }
+                    val mingwTest by creating {
+                        dependsOn(nativeTest)
+                    }
+                    val mingwX64Main by getting {
+                        dependsOn(mingwMain)
+                    }
+                    val mingwX64Test by getting {
+                        dependsOn(mingwTest)
                     }
                 }
                 if (supportAnyNativeIos || supportNativeMac) {

--- a/skiko/buildSrc/src/main/kotlin/CompileSkikoCppTask.kt
+++ b/skiko/buildSrc/src/main/kotlin/CompileSkikoCppTask.kt
@@ -105,7 +105,7 @@ abstract class CompileSkikoCppTask() : AbstractSkikoNativeToolTask() {
     private val compilerArgsRootDir = taskStateDir.map { it.dir("args") }
 
     override fun createArgBuilder(): ArgBuilder =
-        if (buildTargetOS.get().isWindows) VisualCppCompilerArgBuilder()
+        if (buildTargetOS.get().isWindows) WindowsClangArgBuilder()
         else super.createArgBuilder()
 
     override fun execute(mode: ToolMode, args: ArgBuilder) {
@@ -148,7 +148,7 @@ abstract class CompileSkikoCppTask() : AbstractSkikoNativeToolTask() {
                 arg("-o", outputFile.absolutePath.replace("\\", "/"))
                 arg(value = sourceFile.absolutePath.replace("\\", "/"))
                 if (compiler.get().startsWith("clang")) {
-                    arg("-MJ", outputFile.absolutePath + ".json")
+                    arg("-MJ", outputFile.absolutePath.replace("\\", "/") + ".json")
                 }
             }
 

--- a/skiko/buildSrc/src/main/kotlin/SkikoProjectContext.kt
+++ b/skiko/buildSrc/src/main/kotlin/SkikoProjectContext.kt
@@ -95,8 +95,11 @@ val Project.supportNativeMac: Boolean
 val Project.supportNativeLinux: Boolean
     get() = supportAllNative || findProperty("skiko.native.linux.enabled") == "true" || isInIdea
 
+val Project.supportNativeMingwX64: Boolean
+    get() = supportAllNative || findProperty("skiko.native.mingw.x64.enabled") == "true" || isInIdea
+
 val Project.supportAnyNative: Boolean
-    get() = supportAllNative || supportAnyNativeIos || supportNativeMac || supportNativeLinux
+    get() = supportAllNative || supportAnyNativeIos || supportNativeMac || supportNativeLinux || supportNativeMingwX64
 
 val Project.supportWasm: Boolean
     get() = findProperty("skiko.wasm.enabled") == "true" || isInIdea

--- a/skiko/buildSrc/src/main/kotlin/internal/utils/ArgBuilder.kt
+++ b/skiko/buildSrc/src/main/kotlin/internal/utils/ArgBuilder.kt
@@ -88,6 +88,11 @@ internal class DefaultArgBuilder() : AbstractArgBuilder() {
     override fun newSelfInstance(): ArgBuilder = DefaultArgBuilder()
 }
 
+internal class WindowsClangArgBuilder: BaseVisualStudioBuildToolsArgBuilder() {
+    override fun newSelfInstance(): ArgBuilder = WindowsClangArgBuilder()
+
+}
+
 internal class VisualCppCompilerArgBuilder : BaseVisualStudioBuildToolsArgBuilder() {
     private val objectOutputArg = "/Fo"
     private val includeDirArg = "/I"

--- a/skiko/buildSrc/src/main/kotlin/properties.kt
+++ b/skiko/buildSrc/src/main/kotlin/properties.kt
@@ -41,7 +41,7 @@ fun compilerForTarget(os: OS, arch: Arch): String =
             Arch.Wasm -> "Unexpected combination: $os & $arch"
         }
         OS.Android -> "clang++"
-        OS.Windows -> "cl.exe"
+        OS.Windows -> "clang++.exe"
         OS.MacOS, OS.IOS -> "clang++"
         OS.Wasm -> "emcc"
     }

--- a/skiko/buildSrc/src/main/kotlin/properties.kt
+++ b/skiko/buildSrc/src/main/kotlin/properties.kt
@@ -19,6 +19,12 @@ enum class OS(
     val isMacOs
         get() = this == MacOS
 
+    val libExtension
+        get() = when(this) {
+            Windows -> "lib"
+            else -> "a"
+        }
+
     fun idWithSuffix(isIosSim: Boolean = false): String {
         return id + if (isIosSim) "Sim" else ""
     }

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/NativeTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/NativeTasksConfiguration.kt
@@ -216,10 +216,13 @@ fun SkikoProjectContext.configureNativeTarget(os: OS, arch: Arch, target: Kotlin
             "$skiaBinDir/libskunicode.a",
             "$skiaBinDir/libskia.a"
         )
-        OS.Windows -> {
-            configureCinterop("skiko", os, arch, target, targetString, emptyList())
-            mutableListOfLinkerOptions()
-        }
+        OS.Windows -> mutableListOfLinkerOptions(
+            *windowsSdkPaths.libDirs.map { "-L${it.absolutePath}" }.toTypedArray(),
+            "$skiaBinDir/sksg.lib",
+            "$skiaBinDir/skshaper.lib",
+            "$skiaBinDir/skunicode.lib",
+            "$skiaBinDir/skia.lib"
+        )
         else -> mutableListOf()
     }
     if (skiko.includeTestHelpers) {
@@ -267,8 +270,8 @@ fun SkikoProjectContext.configureNativeTarget(os: OS, arch: Arch, target: Kotlin
                 argumentProviders.add { listOf("-static", "-o", staticLib) }
             }
             OS.Windows -> {
-                executable = "llvm-lib"
-                argumentProviders.add { listOf("/out:$staticLib") }
+                executable = "llvm-ar"
+                argumentProviders.add { listOf("-crs", staticLib) }
             }
             else -> error("Unexpected OS for native bridges linking: $os")
         }

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/NativeTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/NativeTasksConfiguration.kt
@@ -216,13 +216,13 @@ fun SkikoProjectContext.configureNativeTarget(os: OS, arch: Arch, target: Kotlin
             "$skiaBinDir/libskunicode.a",
             "$skiaBinDir/libskia.a"
         )
-        OS.Windows -> mutableListOfLinkerOptions(
-            *windowsSdkPaths.libDirs.map { "-L${it.absolutePath}" }.toTypedArray(),
-            "$skiaBinDir/sksg.lib",
-            "$skiaBinDir/skshaper.lib",
-            "$skiaBinDir/skunicode.lib",
-            "$skiaBinDir/skia.lib"
-        )
+        OS.Windows -> {
+            val windowsLibs = listOf(
+                *windowsSdkPaths.libDirs.map { "-L\"${it.absolutePath.replace("\\", "/")}\"" }.toTypedArray()
+            )
+            configureCinterop("skiko", os, arch, target, targetString, windowsLibs)
+            mutableListOfLinkerOptions(windowsLibs)
+        }
         else -> mutableListOf()
     }
     if (skiko.includeTestHelpers) {

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/NativeTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/NativeTasksConfiguration.kt
@@ -97,6 +97,12 @@ fun SkikoProjectContext.compileNativeBridgesTask(
                     *skiaPreprocessorFlags(OS.Linux, buildType)
                 ))
             }
+            OS.Windows -> {
+                flags.set(listOf(
+                    *buildType.clangFlags,
+                    *skiaPreprocessorFlags(OS.Windows, buildType)
+                ))
+            }
             else -> throw GradleException("$os not yet supported")
         }
 
@@ -248,6 +254,10 @@ fun SkikoProjectContext.configureNativeTarget(os: OS, arch: Arch, target: Kotlin
             OS.MacOS, OS.IOS -> {
                 executable = "libtool"
                 argumentProviders.add { listOf("-static", "-o", staticLib) }
+            }
+            OS.Windows -> {
+                executable = "llvm-lib"
+                argumentProviders.add { listOf("/out:$staticLib") }
             }
             else -> error("Unexpected OS for native bridges linking: $os")
         }

--- a/skiko/gradle.properties
+++ b/skiko/gradle.properties
@@ -31,3 +31,5 @@ skiko.native.ios.arm64.enabled=false
 skiko.native.ios.simulatorArm64.enabled=false
 skiko.native.ios.x64.enabled=false
 skiko.native.mingw.x64.enabled=false
+
+skiko.link.ignore.libs.windows=dng_sdk,piex

--- a/skiko/gradle.properties
+++ b/skiko/gradle.properties
@@ -30,3 +30,4 @@ skiko.native.ios.enabled=false
 skiko.native.ios.arm64.enabled=false
 skiko.native.ios.simulatorArm64.enabled=false
 skiko.native.ios.x64.enabled=false
+skiko.native.mingw.x64.enabled=false

--- a/skiko/src/mingwMain/kotlin/org/jetbrains/skiko/Actuals.mingw.kt
+++ b/skiko/src/mingwMain/kotlin/org/jetbrains/skiko/Actuals.mingw.kt
@@ -1,0 +1,36 @@
+package org.jetbrains.skiko
+
+import kotlinx.cinterop.*
+import platform.windows.SW_SHOWNORMAL
+import platform.windows.ShellExecute
+
+actual typealias Cursor = Any
+
+internal actual fun getCursorById(id: PredefinedCursorsId) : Cursor {
+    return Any()
+}
+
+@OptIn(ExperimentalForeignApi::class)
+internal actual fun URIHandler_openUri(uri: String) {
+    memScoped {
+        ShellExecute?.let { it(null, "open".wcstr.ptr, uri.wcstr.ptr, null, null, SW_SHOWNORMAL) }
+    }
+}
+
+internal actual fun ClipboardManager_setText(text: String) {
+    //TODO: Not implemented yet
+}
+internal actual fun ClipboardManager_getText(): String? {
+    return null
+}
+internal actual fun ClipboardManager_hasText(): Boolean {
+    return false
+}
+
+internal actual fun CursorManager_setCursor(component: Any, cursor: Cursor) {
+    //TODO: Not implemented yet
+}
+
+internal actual fun CursorManager_getCursor(component: Any): Cursor? {
+    return null
+}

--- a/skiko/src/mingwMain/kotlin/org/jetbrains/skiko/SkiaLayer.mingw.kt
+++ b/skiko/src/mingwMain/kotlin/org/jetbrains/skiko/SkiaLayer.mingw.kt
@@ -1,0 +1,83 @@
+package org.jetbrains.skiko
+
+import org.jetbrains.skia.Canvas
+import org.jetbrains.skia.PixelGeometry
+
+/**
+ * Generic layer for Skiko rendering.
+ */
+actual open class SkiaLayer {
+    /**
+     * Current graphics API used for rendering.
+     */
+    actual var renderApi: GraphicsApi
+        get() = TODO("Not yet implemented")
+        set(value) {}
+
+    /**
+     * Current content scale.
+     */
+    actual val contentScale: Float
+        get() = TODO("Not yet implemented")
+
+    /**
+     * Pixel geometry corresponding to graphics device which renders this layer
+     */
+    actual val pixelGeometry: PixelGeometry
+        get() = TODO("Not yet implemented")
+
+    /**
+     * If rendering is full screen.
+     */
+    actual var fullscreen: Boolean
+        get() = TODO("Not yet implemented")
+        set(value) {}
+
+    /**
+     * If transparency is enabled.
+     */
+    actual var transparency: Boolean
+        get() = TODO("Not yet implemented")
+        set(value) {}
+
+    /**
+     * Underlying platform component.
+     */
+    actual val component: Any?
+        get() = TODO("Not yet implemented")
+
+    /**
+     * Current view used for rendering.
+     */
+    actual var renderDelegate: SkikoRenderDelegate?
+        get() = TODO("Not yet implemented")
+        set(value) {}
+
+    /**
+     * Attach this [SkikoRenderDelegate] to platform container.
+     * Actual type of attach container is platform-specific.
+     */
+    actual fun attachTo(container: Any) {
+    }
+
+    /**
+     * Detach this [SkikoRenderDelegate] from platform container.
+     */
+    actual fun detach() {
+    }
+
+    /**
+     * Force redraw.
+     */
+    actual fun needRedraw() {
+    }
+
+    /**
+     * Drawing function.
+     */
+    internal actual fun draw(canvas: Canvas) {
+    }
+
+}
+
+actual val currentSystemTheme: SystemTheme = SystemTheme.UNKNOWN

--- a/skiko/src/nativeMain/kotlin/org/jetbrains/skiko/Resources.native.kt
+++ b/skiko/src/nativeMain/kotlin/org/jetbrains/skiko/Resources.native.kt
@@ -1,10 +1,12 @@
 package org.jetbrains.skiko
 
+import kotlinx.cinterop.UnsafeNumber
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.toKString
 import kotlinx.cinterop.usePinned
 import platform.posix.*
 
+@OptIn(UnsafeNumber::class)
 actual suspend fun loadBytesFromPath(path: String): ByteArray {
     val file = fopen(path, "r") ?: run {
         val error = strerror(errno)?.toKString() ?: "Unknown error"
@@ -28,7 +30,7 @@ actual suspend fun loadBytesFromPath(path: String): ByteArray {
         throw Error("File '$path' is too long")
     }
 
-    if (size == 0L) {
+    if (size.toLong() == 0L) {
         fclose(file)
         return byteArrayOf()
     }


### PR DESCRIPTION
This PR adds support for Windows (MingwX64).
It uses LLVM (Clang) for compiling Skia rather than MSVC. To successfully build the mingwX64 target, you need to have LLVM installed and the "bin" folder in your PATH.

This is a work in progress. At this writing time, it successfully builds native bridge and link it to a static `.lib` library

If you have any comments or ideas to make it stable, please feel free to leave them here :)

I know there is an other opened PR for this goal, but it seems to be out-of-date and not maintained anymore

**UPDATE**: the `compileKotlinMingwX64 `task now completes successfully