### PR TITLE
Fix paint nullability for `updateForegroundPaint`/`updateBackgroundPaint`

### DIFF
--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/paragraph/Paragraph.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/paragraph/Paragraph.kt
@@ -229,7 +229,7 @@ class Paragraph internal constructor(ptr: NativePointer, text: ManagedString?) :
      * `from` and `to` are ignored by skia
      * and change applies to the whole paragraph text
      */
-    fun updateForegroundPaint(from: Int, to: Int, paint: Paint?): Paragraph {
+    fun updateForegroundPaint(from: Int, to: Int, paint: Paint): Paragraph {
         return try {
             if (_text != null) {
                 Stats.onNativeCall()
@@ -253,7 +253,7 @@ class Paragraph internal constructor(ptr: NativePointer, text: ManagedString?) :
      * `from` and `to` are ignored by skia
      * and change applies to the whole paragraph text
      */
-    fun updateBackgroundPaint(from: Int, to: Int, paint: Paint?): Paragraph {
+    fun updateBackgroundPaint(from: Int, to: Int, paint: Paint): Paragraph {
         return try {
             if (_text != null) {
                 Stats.onNativeCall()


### PR DESCRIPTION
It's unconditionally de-ref the pointer that causes crash in case of nulls

https://github.com/JetBrains/skiko/blob/c66eebc2c23a8b41eb618c715296c2a7dd135f43/skiko/src/jvmMain/cpp/common/paragraph/Paragraph.cc#L206