### PR TITLE
Fix Font linear metrics binding

### DIFF
--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Font.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Font.kt
@@ -148,16 +148,25 @@ class Font : Managed {
         }
 
     /**
-     * @return  true if font and glyph metrics are requested to be linearly scalable
+     * Returns true if font and glyph metrics are requested to be linearly scalable.
+     *
+     * @return  true if font and glyph metrics are requested to be linearly scalable.
      */
-    fun areMetricsLinear(): Boolean {
-        return try {
+    var isMetricsLinear: Boolean
+        get() = try {
             Stats.onNativeCall()
             _nAreMetricsLinear(_ptr)
         } finally {
             reachabilityBarrier(this)
         }
-    }
+        set(value) {
+            try {
+                Stats.onNativeCall()
+                _nSetMetricsLinear(_ptr, value)
+            } finally {
+                reachabilityBarrier(this)
+            }
+        }
 
     /**
      * Returns true if bold is approximated by increasing the stroke width when creating glyph

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Font.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Font.kt
@@ -152,17 +152,17 @@ class Font : Managed {
      *
      * @return  true if font and glyph metrics are requested to be linearly scalable.
      */
-    var isMetricsLinear: Boolean
+    var isLinearMetrics: Boolean
         get() = try {
             Stats.onNativeCall()
-            _nAreMetricsLinear(_ptr)
+            _nIsLinearMetrics(_ptr)
         } finally {
             reachabilityBarrier(this)
         }
         set(value) {
             try {
                 Stats.onNativeCall()
-                _nSetMetricsLinear(_ptr, value)
+                _nSetLinearMetrics(_ptr, value)
             } finally {
                 reachabilityBarrier(this)
             }
@@ -649,9 +649,9 @@ private external fun _nAreBitmapsEmbedded(ptr: NativePointer): Boolean
 @ModuleImport("./skiko.mjs", "org_jetbrains_skia_Font__1nIsSubpixel")
 private external fun _nIsSubpixel(ptr: NativePointer): Boolean
 
-@ExternalSymbolName("org_jetbrains_skia_Font__1nAreMetricsLinear")
-@ModuleImport("./skiko.mjs", "org_jetbrains_skia_Font__1nAreMetricsLinear")
-private external fun _nAreMetricsLinear(ptr: NativePointer): Boolean
+@ExternalSymbolName("org_jetbrains_skia_Font__1nIsLinearMetrics")
+@ModuleImport("./skiko.mjs", "org_jetbrains_skia_Font__1nIsLinearMetrics")
+private external fun _nIsLinearMetrics(ptr: NativePointer): Boolean
 
 @ExternalSymbolName("org_jetbrains_skia_Font__1nIsEmboldened")
 @ModuleImport("./skiko.mjs", "org_jetbrains_skia_Font__1nIsEmboldened")
@@ -673,9 +673,9 @@ private external fun _nSetBitmapsEmbedded(ptr: NativePointer, value: Boolean)
 @ModuleImport("./skiko.mjs", "org_jetbrains_skia_Font__1nSetSubpixel")
 private external fun _nSetSubpixel(ptr: NativePointer, value: Boolean)
 
-@ExternalSymbolName("org_jetbrains_skia_Font__1nSetMetricsLinear")
-@ModuleImport("./skiko.mjs", "org_jetbrains_skia_Font__1nSetMetricsLinear")
-private external fun _nSetMetricsLinear(ptr: NativePointer, value: Boolean)
+@ExternalSymbolName("org_jetbrains_skia_Font__1nSetLinearMetrics")
+@ModuleImport("./skiko.mjs", "org_jetbrains_skia_Font__1nSetLinearMetrics")
+private external fun _nSetLinearMetrics(ptr: NativePointer, value: Boolean)
 
 @ExternalSymbolName("org_jetbrains_skia_Font__1nSetEmboldened")
 @ModuleImport("./skiko.mjs", "org_jetbrains_skia_Font__1nSetEmboldened")

--- a/skiko/src/commonTest/kotlin/org/jetbrains/skia/FontTests.kt
+++ b/skiko/src/commonTest/kotlin/org/jetbrains/skia/FontTests.kt
@@ -9,10 +9,7 @@ import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.hostOs
 import org.jetbrains.skiko.kotlinBackend
 import org.jetbrains.skiko.tests.runTest
-import kotlin.test.Test
-import kotlin.test.assertContentEquals
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
+import kotlin.test.*
 
 private fun isMac() = (hostOs == OS.MacOS)
 private fun isIos() = (hostOs == OS.Ios)
@@ -20,11 +17,12 @@ private fun isLinux() = (hostOs == OS.Linux)
 private fun isWindows() = (hostOs == OS.Windows)
 private fun isJs() = (kotlinBackend == KotlinBackend.JS)
 private val COARSE_EPSILON = 2.4f
+private const val jbMonoPath = "./fonts/JetBrainsMono-Regular.ttf"
 
 class FontTests {
     @Test
     fun fontTest() = runTest {
-        val jbMono = Typeface.makeFromResource("./fonts/JetBrainsMono-Regular.ttf")
+        val jbMono = Typeface.makeFromResource(jbMonoPath)
         Font(jbMono).use { font ->
             assertEquals(12f, font.size)
             // TODO: we have to use bigger epsilon because of MacOS and definitely need to investigate what would be a better solution
@@ -118,6 +116,16 @@ class FontTests {
 
 //            assertEquals(Rect(1f, -12f, 21f, 0f), font.measureText("ЕЁЫ"))
 
+        }
+    }
+
+    @Test
+    fun fontLinearMetricsTest() = runTest {
+        val jbMono = Typeface.makeFromResource(jbMonoPath)
+        Font(jbMono).use { font ->
+            assertFalse(font.isLinearMetrics)
+            font.isLinearMetrics = true
+            assertTrue(font.isLinearMetrics)
         }
     }
 

--- a/skiko/src/jvmMain/cpp/common/Font.cc
+++ b/skiko/src/jvmMain/cpp/common/Font.cc
@@ -73,7 +73,7 @@ extern "C" JNIEXPORT jboolean JNICALL Java_org_jetbrains_skia_FontKt__1nIsSubpix
     return instance->isSubpixel();
 }
 
-extern "C" JNIEXPORT jboolean JNICALL Java_org_jetbrains_skia_FontKt__1nAreMetricsLinear
+extern "C" JNIEXPORT jboolean JNICALL Java_org_jetbrains_skia_FontKt__1nIsLinearMetrics
   (JNIEnv* env, jclass jclass, jlong ptr) {
     SkFont* instance = reinterpret_cast<SkFont*>(static_cast<uintptr_t>(ptr));
     return instance->isLinearMetrics();
@@ -109,7 +109,7 @@ extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_FontKt__1nSetSubpixel
     instance->setSubpixel(value);
 }
 
-extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_FontKt__1nSetMetricsLinear
+extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_FontKt__1nSetLinearMetrics
   (JNIEnv* env, jclass jclass, jlong ptr, jboolean value) {
     SkFont* instance = reinterpret_cast<SkFont*>(static_cast<uintptr_t>(ptr));
     instance->setLinearMetrics(value);

--- a/skiko/src/nativeJsMain/cpp/Font.cc
+++ b/skiko/src/nativeJsMain/cpp/Font.cc
@@ -72,7 +72,7 @@ SKIKO_EXPORT KBoolean org_jetbrains_skia_Font__1nIsSubpixel
     return instance->isSubpixel();
 }
 
-SKIKO_EXPORT KBoolean org_jetbrains_skia_Font__1nAreMetricsLinear
+SKIKO_EXPORT KBoolean org_jetbrains_skia_Font__1nIsLinearMetrics
   (KNativePointer ptr) {
     SkFont* instance = reinterpret_cast<SkFont*>(ptr);
     return instance->isLinearMetrics();
@@ -108,7 +108,7 @@ SKIKO_EXPORT void org_jetbrains_skia_Font__1nSetSubpixel
     instance->setSubpixel(value);
 }
 
-SKIKO_EXPORT void org_jetbrains_skia_Font__1nSetMetricsLinear
+SKIKO_EXPORT void org_jetbrains_skia_Font__1nSetLinearMetrics
   (KNativePointer ptr, KBoolean value) {
     SkFont* instance = reinterpret_cast<SkFont*>(ptr);
     instance->setLinearMetrics(value);


### PR DESCRIPTION
Add forgotten setter for linear metrics. Changed it to property.

Original functions have names [`isLinearMetrics`](https://github.com/JetBrains/skia/blob/6726cd3e1ac4f30d6874c278008cdf24dfc9b470/include/core/SkFont.h#L115-L119C12) and [`setLinearMetrics`](https://github.com/JetBrains/skia/blob/6726cd3e1ac4f30d6874c278008cdf24dfc9b470/include/core/SkFont.h#L156-L163)
