### PR TITLE
Raise the macOs build agent from macos-11 to macos-12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   macos:
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
         name: 'Check out code'


### PR DESCRIPTION
https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/