### PR TITLE
Take ownership over NSWindow raw pointer when passing it from and to JNI

### DIFF
--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/HardwareLayer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/HardwareLayer.kt
@@ -40,6 +40,10 @@ internal open class HardwareLayer(
     val contentHandle: Long
         get() = useDrawingSurfacePlatformInfo(::getContentHandle)
 
+    /**
+     * On macOS accessing this property returns an owning raw pointer to the NSWindow.
+     * Failure to pass this pointer to consuming APIs will result in a memory leak.
+     */
     val windowHandle: Long
         get() = useDrawingSurfacePlatformInfo(::getWindowHandle)
 

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt
@@ -212,6 +212,8 @@ actual open class SkiaLayer internal constructor(
     /**
      * Returns the pointer to an OS specific window handle (native resource)
      * which the current [SkiaLayer] is attached.
+     * On macOS accessing this property returns an owning raw pointer to the NSWindow.
+     * Failure to pass this pointer to consuming APIs will result in a memory leak.
      */
     val windowHandle: Long
         get() = backedLayer.windowHandle

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/DisplayLinkThrottler.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/DisplayLinkThrottler.kt
@@ -7,9 +7,10 @@ internal class DisplayLinkThrottler {
 
     internal fun dispose() = dispose(implPtr)
 
-    /*
+    /**
      * Creates a DisplayLink if needed with refresh rate matching NSScreen of NSWindow passed in [windowPtr].
      * If DisplayLink is already active, blocks until next vsync for physical screen of NSWindow passed in [windowPtr].
+     * This API consumes [windowPtr], calling it transfers the ownership to the function.
      */
     internal fun waitVSync(windowPtr: Long) = waitVSync(implPtr, windowPtr)
 

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
@@ -185,6 +185,9 @@ internal class MetalRedrawer(
         setLayerVisible(device.ptr, isVisible)
     }
 
+    /**
+     * This API consumes [window], calling it transfers the ownership to the function.
+     */
     private external fun createMetalDevice(window: Long, transparency: Boolean, adapter: Long, platformInfo: Long): Long
     private external fun disposeDevice(device: Long)
     private external fun resizeLayers(device: Long, x: Int, y: Int, width: Int, height: Int)

--- a/skiko/src/awtMain/objectiveC/macos/DisplayLinkThrottler.mm
+++ b/skiko/src/awtMain/objectiveC/macos/DisplayLinkThrottler.mm
@@ -162,13 +162,20 @@ JNIEXPORT void JNICALL Java_org_jetbrains_skiko_redrawer_DisplayLinkThrottler_di
 }
 
 JNIEXPORT void JNICALL Java_org_jetbrains_skiko_redrawer_DisplayLinkThrottler_waitVSync(JNIEnv *env, jobject obj, jlong throttlerPtr, jlong windowPtr) {
-    DisplayLinkThrottler *throttler = (__bridge DisplayLinkThrottler *) (void *) throttlerPtr;
-    NSWindow *window = (__bridge NSWindow *) (void *) windowPtr;
+    @autoreleasepool {
+        DisplayLinkThrottler *throttler = (__bridge DisplayLinkThrottler *) (void *) throttlerPtr;
 
-    // CVDisplayLink is conditionally set up on each draw request to track window.screen change to match throttling
-    // with the refresh rate of the actual screen the window is shown on.
-    [throttler setupDisplayLinkForWindow:window];
-    [throttler waitVSync];
+        NSWindow *window = nil;
+
+        if (windowPtr != 0) {
+            window = (__bridge_transfer NSWindow *) (void *) windowPtr;
+        }
+
+        // CVDisplayLink is conditionally set up on each draw request to track window.screen change to match throttling
+        // with the refresh rate of the actual screen the window is shown on.
+        [throttler setupDisplayLinkForWindow:window];
+        [throttler waitVSync];
+    }
 }
 
 }

--- a/skiko/src/awtMain/objectiveC/macos/Drawlayer.mm
+++ b/skiko/src/awtMain/objectiveC/macos/Drawlayer.mm
@@ -362,7 +362,14 @@ JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_HardwareLayer_getWindowHandle(J
 {
     @autoreleasepool {
         LayerHandler *layer = findByObject(env, component);
-        return (jlong) (__bridge void*) layer.window;
+
+        NSWindow *window = layer.window;
+
+        if (window) {
+            return (jlong) (__bridge_retained void*) window;
+        } else {
+            return 0;
+        }
     }
 }
 

--- a/skiko/src/awtMain/objectiveC/macos/MetalRedrawer.mm
+++ b/skiko/src/awtMain/objectiveC/macos/MetalRedrawer.mm
@@ -121,6 +121,12 @@ JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_redrawer_MetalRedrawer_createMe
     JNIEnv *env, jobject redrawer, jlong windowPtr, jboolean transparency, jlong adapterPtr, jlong platformInfoPtr)
 {
     @autoreleasepool {
+        NSWindow *window = nil;
+
+        if (windowPtr != 0) {
+            window = (__bridge_transfer NSWindow *) (void *) windowPtr;
+        }
+
         id<MTLDevice> adapter = (__bridge id<MTLDevice>) (void *) adapterPtr;
 
         MetalDevice *device = [MetalDevice new];
@@ -154,8 +160,6 @@ JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_redrawer_MetalRedrawer_createMe
 
         /// max inflight command buffers count matches swapchain size to avoid overcommitment
         device.inflightSemaphore = dispatch_semaphore_create(device.layer.maximumDrawableCount);
-
-        NSWindow* window = (__bridge NSWindow*) (void *) windowPtr;
 
         if (transparency) {
             window.hasShadow = NO;


### PR DESCRIPTION
Speculative fix for https://youtrack.jetbrains.com/issue/FL-27529/Native-crash-on-macOS-while-being-idle

Speculative scenario:
```
// before

void bar(NSObject *object) {
    NSLog(@"%@", object);
}

void foo(void* ptr) {
    NSObject *object = (__bridge NSObject *)ptr;
    bar(object);
}

int main(int argc, const char * argv[]) {
    @autoreleasepool {
        NSObject *strongRef = [NSObject new];
        __weak NSObject *weakRef = strongRef;
        void *ptr = (__bridge void *)weakRef;
        strongRef = nil;
        foo(ptr); //crash
        
        NSLog(@"Hello");
    }
    return 0;
}
```

```
// after
void bar(NSObject *object) {
    NSLog(@"%@", object);
}

void foo(void* ptr) {
    NSObject *object = (__bridge_transfer NSObject *)ptr;
    bar(object);
}

int main(int argc, const char * argv[]) {
    @autoreleasepool {
        NSObject *strongRef = [NSObject new];
        __weak NSObject *weakRef = strongRef;
        void *ptr = (__bridge_retained void *)weakRef;
        strongRef = nil;
        foo(ptr); // no crash
        
        NSLog(@"Hello");
    }
    return 0;
}

```
