### PR TITLE
Adding an implementation for skiaLayer.detach()

### DIFF
--- a/skiko/src/jsWasmMain/kotlin/org/jetbrains/skiko/CanvasRenderer.kt
+++ b/skiko/src/jsWasmMain/kotlin/org/jetbrains/skiko/CanvasRenderer.kt
@@ -4,7 +4,6 @@ import org.jetbrains.skia.*
 import org.jetbrains.skia.impl.NativePointer
 import org.jetbrains.skiko.w3c.HTMLCanvasElement
 import org.jetbrains.skiko.w3c.window
-import org.jetbrains.skiko.wasm.createWebGLContext
 
 /**
  * CanvasRenderer takes an [HTMLCanvasElement] instance and initializes
@@ -36,8 +35,6 @@ internal abstract class CanvasRenderer(
     }
 
     fun initCanvas() {
-        disposeCanvas()
-
         renderTarget = BackendRenderTarget.makeGL(width, height, 1, 8, 0, 0x8058)
         surface = Surface.makeFromBackendRenderTarget(
             context,
@@ -50,11 +47,13 @@ internal abstract class CanvasRenderer(
         canvas = surface!!.canvas
     }
 
-    private fun disposeCanvas() {
+    fun disposeCanvas() {
         surface?.close()
         surface = null
         renderTarget?.close()
         renderTarget = null
+        canvas = null
+        context.abandon()
     }
 
     /**

--- a/skiko/src/jsWasmMain/kotlin/org/jetbrains/skiko/SkiaLayer.js.kt
+++ b/skiko/src/jsWasmMain/kotlin/org/jetbrains/skiko/SkiaLayer.js.kt
@@ -66,7 +66,8 @@ actual open class SkiaLayer {
     }
 
     actual fun detach() {
-        // TODO: when switch to the frame dispatcher - stop it here.
+        state?.disposeCanvas()
+        state = null
     }
 
     actual val component: Any?
@@ -85,7 +86,10 @@ actual open class SkiaLayer {
             override fun drawFrame(currentTimestamp: Double) {
                 // currentTimestamp is in milliseconds.
                 val currentNanos = currentTimestamp * 1_000_000
-                renderDelegate?.onRender(canvas!!, width, height, currentNanos.toLong())
+                val canvasCapture = canvas
+                canvasCapture?.run {
+                    renderDelegate?.onRender(canvasCapture, width, height, currentNanos.toLong())
+                }
             }
         }
     }


### PR DESCRIPTION
Once SkiaLayer was created, it wasn't possible to reinstantiate it gracefully (e.g. when changing the geometry of the underlying canvas). It wasn't releasing the GL context so it wasn't possible to reuse the same HTML canvas when the window was resized etc.

I'm not sure if this is enough though, but it fixed my issues at least.