### PR TITLE
All build targets have common skiaVersion which, however, can be overridden

### DIFF
--- a/skiko/buildSrc/src/main/kotlin/SkikoProjectContext.kt
+++ b/skiko/buildSrc/src/main/kotlin/SkikoProjectContext.kt
@@ -34,7 +34,8 @@ fun SkikoProjectContext.declareSkiaTasks() {
         (if (config == "wasm") listOf("wasm") else listOf("arm64", "x64")).forEach { arch ->
             val taskNameSuffix = joinToTitleCamelCase(config, arch)
             val target = "$config-$arch"
-            val skiaReleaseTag = project.property("dependencies.skia.$target") as String
+
+            val skiaReleaseTag = project.skiaVersion(target)
 
             val skiaBaseUrl = "https://github.com/JetBrains/skia-pack/releases/download/$skiaReleaseTag"
 
@@ -152,3 +153,13 @@ val Project.supportWasm: Boolean
 
 val Project.supportJs: Boolean
     get() = findProperty("skiko.js.enabled") == "true" || supportWasm || isInIdea
+
+fun Project.skiaVersion(target: String): String {
+    val platformSpecificVersion = "dependencies.skia.$target"
+
+    return if (hasProperty(platformSpecificVersion)) {
+        property(platformSpecificVersion) as String
+    } else {
+        property("dependencies.skia") as String
+    }
+}

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/CommonTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/CommonTasksConfiguration.kt
@@ -14,6 +14,7 @@ import supportAndroid
 import supportWasm
 import toTitleCase
 import java.io.File
+import skiaVersion
 
 fun skiaHeadersDirs(skiaDir: File): List<File> =
     listOf(
@@ -177,7 +178,8 @@ fun KotlinTarget.generateVersion(
             val out = "$outDir/Version.kt"
 
             val target = "${targetOs.id}-${targetArch.id}"
-            val skiaTag = project.property("dependencies.skia.$target") as String
+            val skiaTag = project.skiaVersion(target)
+
             File(out).writeText(
                 """
                 package org.jetbrains.skiko

--- a/skiko/gradle.properties
+++ b/skiko/gradle.properties
@@ -1,23 +1,27 @@
 kotlin.code.style=official
 deploy.version=0.0.0
 
-dependencies.skia.windows-x64=m116-47d3027-1
-dependencies.skia.linux-x64=m116-47d3027-1
-dependencies.skia.macos-x64=m116-47d3027-1
-dependencies.skia.windows-arm64=m116-47d3027-1
-dependencies.skia.linux-arm64=m116-47d3027-1
-dependencies.skia.macos-arm64=m116-47d3027-1
-dependencies.skia.wasm-wasm=m116-47d3027-1
-dependencies.skia.ios-x64=m116-47d3027-1
-dependencies.skia.ios-arm64=m116-47d3027-1
-dependencies.skia.iosSim-arm64=m116-47d3027-1
-dependencies.skia.iosSim-x64=m116-47d3027-1
-dependencies.skia.android-x64=m116-47d3027-1
-dependencies.skia.android-arm64=m116-47d3027-1
-dependencies.skia.tvos-x64=m116-47d3027-1
-dependencies.skia.tvos-arm64=m116-47d3027-1
-dependencies.skia.tvosSim-arm64=m116-47d3027-1
-dependencies.skia.tvosSim-x64=m116-47d3027-1
+
+dependencies.skia=m116-47d3027-1
+
+# you can override general skia dependencies by passing platform-specific property: 
+# dependencies.skia.android-arm64
+# dependencies.skia.android-x64
+# dependencies.skia.ios-arm64
+# dependencies.skia.ios-x64
+# dependencies.skia.iosSim-arm64
+# dependencies.skia.iosSim-x64
+# dependencies.skia.linux-arm64
+# dependencies.skia.linux-x64
+# dependencies.skia.macos-arm64
+# dependencies.skia.macos-x64
+# dependencies.skia.tvos-arm64
+# dependencies.skia.tvos-x64
+# dependencies.skia.tvosSim-arm64
+# dependencies.skia.tvosSim-x64
+# dependencies.skia.wasm-wasm
+# dependencies.skia.windows-arm64
+# dependencies.skia.windows-x64
 
 org.gradle.jvmargs=-Xmx3G -XX:MaxMetaspaceSize=512m
 


### PR DESCRIPTION
One still can use optional platfrom-specific skia dependencies using exactly the property which was used before, however, by default all build targets are using the same version of skia prebuilt artefacts.