### PR TITLE
Fix skia download destination directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,11 @@ jobs:
           ./gradlew --stacktrace --info -Pskiko.native.enabled=true :skiko:publishToMavenLocal
           ./gradlew --stacktrace --info :SkiaAwtSample:installDist
 
+      - shell: bash
+        name: 'Publish Debug to Maven Local'
+        run: |
+          ./gradlew --stacktrace --info -Pskiko.native.enabled=true :skiko:publishToMavenLocal -Pskiko.debug=true
+
       - uses: actions/upload-artifact@v3
         name: 'Save test results as artifact'
         if: always()

--- a/skiko/buildSrc/src/main/kotlin/SkikoProjectContext.kt
+++ b/skiko/buildSrc/src/main/kotlin/SkikoProjectContext.kt
@@ -50,7 +50,7 @@ fun SkikoProjectContext.declareSkiaTasks() {
                 onlyIfModified(true)
                 src(skiaUrl)
                 dest(skiko.dependenciesDir.resolve(
-                    "skia/$skiaReleaseTag/Skia-$skiaReleaseTag-$config-Release-${arch}.zip")
+                    "skia/$skiaReleaseTag/Skia-$skiaReleaseTag-$config-$buildType-${arch}.zip")
                 )
             }
 


### PR DESCRIPTION
The download directory path now depends on the buildType: Debug and Release


___
It affected our buildServer CI pipeline where it builds Release first and then Debug. And downloadTask was considered UP-TO-DATE when Debug build was attempted. Therefore the build used "Release" version of skia instead of "Debug. "

Added a Debug build to the githiub workflow too. 