### PR TITLE
Use convertToZeroTerminatedString on both wasm and js targets

### DIFF
--- a/skiko/src/commonTest/kotlin/org/jetbrains/skia/ManagedStringTest.kt
+++ b/skiko/src/commonTest/kotlin/org/jetbrains/skia/ManagedStringTest.kt
@@ -24,6 +24,12 @@ class ManagedStringTest {
     }
 
     @Test
+    fun emptyStringTest() {
+        val s = ManagedString("")
+        assertEquals("", s.toString())
+    }
+
+    @Test
     fun canCreateAndReadManagedString() {
         val ms1 = ManagedString("Hello")
         assertEquals("Hello", ms1.toString())

--- a/skiko/src/commonTest/kotlin/org/jetbrains/skia/ManagedStringTest.kt
+++ b/skiko/src/commonTest/kotlin/org/jetbrains/skia/ManagedStringTest.kt
@@ -24,12 +24,6 @@ class ManagedStringTest {
     }
 
     @Test
-    fun emptyStringTest() {
-        val s = ManagedString("")
-        assertEquals("", s.toString())
-    }
-
-    @Test
     fun canCreateAndReadManagedString() {
         val ms1 = ManagedString("Hello")
         assertEquals("Hello", ms1.toString())
@@ -39,6 +33,9 @@ class ManagedStringTest {
 
         val ms3 = ManagedString("你好!")
         assertEquals("你好!", ms3.toString())
+
+        val msEmpty = ManagedString("")
+        assertEquals("", msEmpty.toString())
     }
 
     @Test
@@ -51,6 +48,9 @@ class ManagedStringTest {
 
         val ms3 = ManagedString("你好").append("，世界")
         assertEquals("你好，世界", ms3.toString())
+
+        val msEmpty = ManagedString("Empty string").append("")
+        assertEquals("Empty string", msEmpty.toString())
     }
 
     @Test
@@ -63,6 +63,9 @@ class ManagedStringTest {
 
         val ms3 = ManagedString("世界").insert(0,"你好，")
         assertEquals("你好，世界", ms3.toString())
+
+        val msEmpty = ManagedString("Empty string").insert(1, "").insert(0, "")
+        assertEquals("Empty string", msEmpty.toString())
     }
 
     @Test
@@ -78,5 +81,8 @@ class ManagedStringTest {
 
         val ms4 = ManagedString("你好，世界!").remove(from = 2, length = 3) // '，' is 1 symbol
         assertEquals("你好!", ms4.toString())
+
+        val msEmpty = ManagedString("World!").remove(from = 2, length = 0)
+        assertEquals("World!", msEmpty.toString())
     }
 }

--- a/skiko/src/jsMain/kotlin/org/jetbrains/skia/impl/Native.js.kt
+++ b/skiko/src/jsMain/kotlin/org/jetbrains/skia/impl/Native.js.kt
@@ -63,8 +63,6 @@ internal actual fun fromWasm(src: NativePointer, result: DoubleArray) {
     result.asDynamic().set(HEAPF64.subarray(startIndex, startIndex + result.size))
 }
 
-internal actual external fun stringToUTF8(str: String, outPtr: NativePointer, maxBytesToWrite: Int)
-
 internal actual class InteropScope actual constructor() {
     private val elements = mutableListOf<NativePointer>()
     private var callbacksInitialized = false

--- a/skiko/src/jsMain/kotlin/org/jetbrains/skia/impl/Native.js.kt
+++ b/skiko/src/jsMain/kotlin/org/jetbrains/skia/impl/Native.js.kt
@@ -71,10 +71,7 @@ internal actual class InteropScope actual constructor() {
 
     actual fun toInterop(string: String?): InteropPointer {
         return if (string != null) {
-            val data = _malloc(string.length * 4)
-            stringToUTF8(string, data, string.length * 4)
-            elements.add(data)
-            data
+            toInterop(convertToZeroTerminatedString(string))
         } else {
             0
         }

--- a/skiko/src/jsWasmMain/kotlin/org/jetbrains/skia/impl/Native.js.kt
+++ b/skiko/src/jsWasmMain/kotlin/org/jetbrains/skia/impl/Native.js.kt
@@ -64,12 +64,6 @@ internal external fun _malloc(size: Int): NativePointer
 @ModuleImport("./skiko.mjs", "free")
 internal external fun _free(ptr: NativePointer)
 
-private external fun lengthBytesUTF8(str: String): Int
-
-internal expect fun stringToUTF8(str: String, outPtr: NativePointer, maxBytesToWrite: Int)
-
-private external fun UTF8ToString(ptr: NativePointer): String
-
 // Data copying routines.
 internal expect fun toWasm(dest: NativePointer, src: ByteArray)
 internal expect fun toWasm(dest: NativePointer, src: ShortArray)

--- a/skiko/src/nativeJsMain/kotlin/org/jetbrains/skia/impl/Native.nativejs.kt
+++ b/skiko/src/nativeJsMain/kotlin/org/jetbrains/skia/impl/Native.nativejs.kt
@@ -1,0 +1,12 @@
+package org.jetbrains.skia.impl
+
+/**
+ * Converts String to zero-terminated utf-8 byte array.
+ */
+internal fun convertToZeroTerminatedString(string: String): ByteArray {
+    //  C++ needs char* with zero byte at the end. So we need to copy array with an extra zero byte.
+
+    val utf8 = string.encodeToByteArray() // encodeToByteArray encodes to utf8
+    // TODO Remove array copy, use `skString(data, length)` instead of `skString(data)`
+    return utf8.copyOf(utf8.size + 1)
+}

--- a/skiko/src/nativeMain/kotlin/org/jetbrains/skia/impl/Native.native.kt
+++ b/skiko/src/nativeMain/kotlin/org/jetbrains/skia/impl/Native.native.kt
@@ -281,14 +281,3 @@ private external fun initCallbacks(
     callVoid: COpaquePointer,
     dispose: COpaquePointer
 )
-
-/**
- * Converts String to zero-terminated utf-8 byte array.
- */
-private fun convertToZeroTerminatedString(string: String): ByteArray {
-    //  C++ needs char* with zero byte at the end. So we need to copy array with an extra zero byte.
-
-    val utf8 = string.encodeToByteArray() // encodeToByteArray encodes to utf8
-    // TODO Remove array copy, use `skString(data, length)` instead of `skString(data)`
-    return utf8.copyOf(utf8.size + 1)
-}

--- a/skiko/src/wasmJsMain/kotlin/org/jetbrains/skia/impl/Native.wasm.kt
+++ b/skiko/src/wasmJsMain/kotlin/org/jetbrains/skia/impl/Native.wasm.kt
@@ -124,20 +124,6 @@ internal actual fun fromWasm(src: NativePointer, result: DoubleArray) {
     }
 }
 
-internal actual fun stringToUTF8(str: String, outPtr: NativePointer, maxBytesToWrite: Int) {
-    if (maxBytesToWrite <= 0) return
-
-    val utf8 = str.encodeToByteArray()
-    val lastIndex = minOf(maxBytesToWrite - 1, utf8.size)
-
-    var index = 0
-    while (index < lastIndex) {
-        skia_memSetByte(outPtr + index, utf8[index])
-        index++
-    }
-    skia_memSetByte(outPtr + index, 0)
-}
-
 internal actual class InteropScope actual constructor() {
     private val elements = mutableListOf<NativePointer>()
     private var callbacksInitialized = false

--- a/skiko/src/wasmJsMain/kotlin/org/jetbrains/skia/impl/Native.wasm.kt
+++ b/skiko/src/wasmJsMain/kotlin/org/jetbrains/skia/impl/Native.wasm.kt
@@ -144,10 +144,7 @@ internal actual class InteropScope actual constructor() {
 
     actual fun toInterop(string: String?): InteropPointer {
         return if (string != null) {
-            val data = _malloc(string.length * 4)
-            stringToUTF8(string, data, string.length * 4)
-            elements.add(data)
-            data
+            toInterop(convertToZeroTerminatedString(string))
         } else {
             0
         }


### PR DESCRIPTION
This is supposed to be fix for https://github.com/JetBrains/skiko/issues/967

The idea is pass strings as (utf8) byte arrays directly through the border
just like we do it on native