### PR TITLE
Preserve profiling information in skiko.wasm with an extra build flag

### DIFF
--- a/skiko/build.gradle.kts
+++ b/skiko/build.gradle.kts
@@ -610,6 +610,8 @@ project.tasks.withType<org.jetbrains.kotlin.gradle.dsl.KotlinJsCompile>().config
 
 tasks.findByName("publishSkikoWasmRuntimePublicationToComposeRepoRepository")
     ?.dependsOn("publishWasmJsPublicationToComposeRepoRepository")
+tasks.findByName("publishSkikoWasmRuntimePublicationToMavenLocal")
+    ?.dependsOn("publishWasmJsPublicationToMavenLocal")
 
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile>().configureEach {

--- a/skiko/buildSrc/src/main/kotlin/properties.kt
+++ b/skiko/buildSrc/src/main/kotlin/properties.kt
@@ -126,7 +126,8 @@ class SkikoProperties(private val myProject: Project) {
     val deployVersion: String
         get() {
             val main = if (isRelease) planeDeployVersion else "$planeDeployVersion-SNAPSHOT"
-            val metadata = if (buildType == SkiaBuildType.DEBUG) "+debug" else ""
+            var metadata = if (buildType == SkiaBuildType.DEBUG) "+debug" else ""
+            metadata += if (isWasmBuildWithProfiling) "+profiling" else ""
             return main + metadata
         }
 
@@ -135,6 +136,9 @@ class SkikoProperties(private val myProject: Project) {
 
     val buildType: SkiaBuildType
         get() = if (myProject.findProperty("skiko.debug") == "true") SkiaBuildType.DEBUG else SkiaBuildType.RELEASE
+
+    val isWasmBuildWithProfiling: Boolean
+        get() = myProject.findProperty("skiko.wasm.withProfiling") == "true"
 
     val targetArch: Arch
         get() = myProject.findProperty("skiko.arch")?.toString()?.let(Arch::byName) ?: hostArch

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/CommonTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/CommonTasksConfiguration.kt
@@ -98,7 +98,7 @@ fun skiaPreprocessorFlags(os: OS, buildType: SkiaBuildType): Array<String> {
         )
         OS.Wasm -> buildList {
             add("-DSKIKO_WASM")
-            if (buildType == SkiaBuildType.DEBUG) add("-g")
+            // add("-sSUPPORT_LONGJMP=wasm") // TODO(o.karpovich): enable when skia is built with this flag
         }
         OS.Android -> listOf(
             "-DSK_BUILD_FOR_ANDROID"

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/CommonTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/CommonTasksConfiguration.kt
@@ -96,9 +96,10 @@ fun skiaPreprocessorFlags(os: OS, buildType: SkiaBuildType): Array<String> {
             "-DSK_BUILD_FOR_LINUX",
             "-D_GLIBCXX_USE_CXX11_ABI=0"
         )
-        OS.Wasm -> listOf(
-            "-DSKIKO_WASM"
-        )
+        OS.Wasm -> buildList {
+            add("-DSKIKO_WASM")
+            if (buildType == SkiaBuildType.DEBUG) add("-g")
+        }
         OS.Android -> listOf(
             "-DSK_BUILD_FOR_ANDROID"
         )

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/CommonTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/CommonTasksConfiguration.kt
@@ -96,9 +96,9 @@ fun skiaPreprocessorFlags(os: OS, buildType: SkiaBuildType): Array<String> {
             "-DSK_BUILD_FOR_LINUX",
             "-D_GLIBCXX_USE_CXX11_ABI=0"
         )
-        OS.Wasm -> buildList {
+        OS.Wasm -> mutableListOf<String>().apply {
             add("-DSKIKO_WASM")
-            // add("-sSUPPORT_LONGJMP=wasm") // TODO(o.karpovich): enable when skia is built with this flag
+            // add("-sSUPPORT_LONGJMP=wasm") // TODO(o.karpovich): enable when skia is built with this flag (CMP-6628)
         }
         OS.Android -> listOf(
             "-DSK_BUILD_FOR_ANDROID"

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/WasmTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/WasmTasksConfiguration.kt
@@ -56,12 +56,13 @@ fun SkikoProjectContext.createWasmLinkTasks(): LinkWasmTasks = with(this.project
         includeHeadersNonRecursive(skiaHeadersDirs(skiaWasmDir.get()))
 
         flags.set(
-            listOf(
-                *skiaPreprocessorFlags(OS.Wasm, buildType),
-                *buildType.clangFlags,
-                "-fno-rtti",
-                "-fno-exceptions",
-            )
+            buildList {
+                addAll(skiaPreprocessorFlags(OS.Wasm, buildType))
+                addAll(buildType.clangFlags)
+                add("-fno-rtti")
+                add("-fno-exceptions")
+                if (skiko.isWasmBuildWithProfiling) add("--profiling")
+            }
         )
     }
 
@@ -117,6 +118,7 @@ fun SkikoProjectContext.createWasmLinkTasks(): LinkWasmTasks = with(this.project
                     "-O2"
                 )
             )
+            // addAll(listOf("-s", "SUPPORT_LONGJMP=wasm")) // TODO(o.karpovich): enable when skia is built with this flag
             if (outputES6) {
                 addAll(
                     listOf(
@@ -129,7 +131,7 @@ fun SkikoProjectContext.createWasmLinkTasks(): LinkWasmTasks = with(this.project
                 )
             }
 
-            if (buildType == SkiaBuildType.DEBUG) add("-g")
+            if (skiko.isWasmBuildWithProfiling) add("--profiling")
         })
 
         doLast {
@@ -138,11 +140,16 @@ fun SkikoProjectContext.createWasmLinkTasks(): LinkWasmTasks = with(this.project
             val jsFiles = outDir.asFile.get().walk()
                 .filter { it.isFile && (it.name.endsWith(".js") || it.name.endsWith(".mjs")) }
 
+            val isEnvironmentNodeCheckRegex = Regex(
+                // spaces are different in release and debug builds
+                """if\s*\(ENVIRONMENT_IS_NODE\)\s*\{"""
+            )
+
             for (jsFile in jsFiles) {
                 val originalContent = jsFile.readText()
                 val newContent = originalContent.replace("_org_jetbrains", "org_jetbrains")
                     .replace("skikomjs.wasm", "skiko.wasm")
-                    .replace("if(ENVIRONMENT_IS_NODE){", "if (false) {") // to make webpack erase this part
+                    .replace(isEnvironmentNodeCheckRegex, "if (false) {") // to make webpack erase this part
                 jsFile.writeText(newContent)
 
                 if (outputES6) {

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/WasmTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/WasmTasksConfiguration.kt
@@ -128,6 +128,8 @@ fun SkikoProjectContext.createWasmLinkTasks(): LinkWasmTasks = with(this.project
                     )
                 )
             }
+
+            if (buildType == SkiaBuildType.DEBUG) add("-g")
         })
 
         doLast {

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/WasmTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/WasmTasksConfiguration.kt
@@ -56,7 +56,7 @@ fun SkikoProjectContext.createWasmLinkTasks(): LinkWasmTasks = with(this.project
         includeHeadersNonRecursive(skiaHeadersDirs(skiaWasmDir.get()))
 
         flags.set(
-            buildList {
+            mutableListOf<String?>().apply {
                 addAll(skiaPreprocessorFlags(OS.Wasm, buildType))
                 addAll(buildType.clangFlags)
                 add("-fno-rtti")
@@ -104,7 +104,7 @@ fun SkikoProjectContext.createWasmLinkTasks(): LinkWasmTasks = with(this.project
         )
 
         @OptIn(kotlin.ExperimentalStdlibApi::class)
-        flags.set(buildList {
+        flags.set(mutableListOf<String?>().apply {
             addAll(
                 listOf(
                     "-l", "GL",
@@ -118,7 +118,7 @@ fun SkikoProjectContext.createWasmLinkTasks(): LinkWasmTasks = with(this.project
                     "-O2"
                 )
             )
-            // addAll(listOf("-s", "SUPPORT_LONGJMP=wasm")) // TODO(o.karpovich): enable when skia is built with this flag
+            // addAll(listOf("-s", "SUPPORT_LONGJMP=wasm")) // TODO(o.karpovich): enable when skia is built with this flag (CMP-6628)
             if (outputES6) {
                 addAll(
                     listOf(


### PR DESCRIPTION
Adding a new flag `-Pskiko.wasm.withProfiling=true` which adds `--profiling` flag to emcc, so it preserves the function names - makes it easier to use the browser profiler.

By default, it's disabled.  