### PR TITLE
Replace half leading to top ratio

### DIFF
--- a/skiko/gradle.properties
+++ b/skiko/gradle.properties
@@ -2,7 +2,7 @@ kotlin.code.style=official
 deploy.version=0.0.0
 
 
-dependencies.skia=m126-1d69d9b-2
+dependencies.skia=m126-d2aaacc35d-1
 
 # you can override general skia dependencies by passing platform-specific property: 
 # dependencies.skia.android-arm64

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/paragraph/StrutStyle.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/paragraph/StrutStyle.kt
@@ -211,6 +211,7 @@ class StrutStyle internal constructor(ptr: NativePointer) : Managed(ptr, _Finali
         return this
     }
 
+    @Deprecated("Replaced by topRatio")
     var isHalfLeading: Boolean
         get() = try {
             Stats.onNativeCall()
@@ -222,10 +223,35 @@ class StrutStyle internal constructor(ptr: NativePointer) : Managed(ptr, _Finali
             setHalfLeading(value)
         }
 
+    // Same as topRatio = halfLeading ? 0.5f : -1.0f
+    @Deprecated("Replaced by topRatio")
     fun setHalfLeading(value: Boolean): StrutStyle {
         try {
             Stats.onNativeCall()
             _nSetHalfLeading(_ptr, value)
+        } finally {
+            reachabilityBarrier(this)
+        }
+        return this
+    }
+
+    // [0..1]: the ratio of ascent to ascent+descent
+    // -1: proportional to the ascent/descent
+    var topRatio: Float
+        get() = try {
+            Stats.onNativeCall()
+            StrutStyle_nGetTopRatio(_ptr)
+        } finally {
+            reachabilityBarrier(this)
+        }
+        set(value) {
+            setTopRatio(value)
+        }
+
+    fun setTopRatio(topRatio: Float): StrutStyle {
+        try {
+            Stats.onNativeCall()
+            StrutStyle_nSetTopRatio(_ptr, topRatio)
         } finally {
             reachabilityBarrier(this)
         }
@@ -321,3 +347,11 @@ private external fun _nIsHalfLeading(ptr: NativePointer): Boolean
 @ExternalSymbolName("org_jetbrains_skia_paragraph_StrutStyle__1nSetHalfLeading")
 @ModuleImport("./skiko.mjs", "org_jetbrains_skia_paragraph_StrutStyle__1nSetHalfLeading")
 private external fun _nSetHalfLeading(ptr: NativePointer, value: Boolean)
+
+@ExternalSymbolName("org_jetbrains_skia_paragraph_StrutStyle__1nGetTopRatio")
+@ModuleImport("./skiko.mjs", "org_jetbrains_skia_paragraph_StrutStyle__1nGetTopRatio")
+private external fun StrutStyle_nGetTopRatio(ptr: NativePointer): Float
+
+@ExternalSymbolName("org_jetbrains_skia_paragraph_StrutStyle__1nSetTopRatio")
+@ModuleImport("./skiko.mjs", "org_jetbrains_skia_paragraph_StrutStyle__1nSetTopRatio")
+private external fun StrutStyle_nSetTopRatio(ptr: NativePointer, value: Float)

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/paragraph/TextStyle.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/paragraph/TextStyle.kt
@@ -323,6 +323,7 @@ class TextStyle internal constructor(ptr: NativePointer) : Managed(ptr, _Finaliz
         return this
     }
 
+    @Deprecated("Replaced by topRatio")
     var isHalfLeading: Boolean
         get() = try {
             Stats.onNativeCall()
@@ -334,10 +335,35 @@ class TextStyle internal constructor(ptr: NativePointer) : Managed(ptr, _Finaliz
             setHalfLeading(value)
         }
 
+    // Same as topRatio = halfLeading ? 0.5f : -1.0f
+    @Deprecated("Replaced by topRatio")
     fun setHalfLeading(value: Boolean): TextStyle {
         try {
             Stats.onNativeCall()
             TextStyle_nSetHalfLeading(_ptr, value)
+        } finally {
+            reachabilityBarrier(this)
+        }
+        return this
+    }
+
+    // [0..1]: the ratio of ascent to ascent+descent
+    // -1: proportional to the ascent/descent
+    var topRatio: Float
+        get() = try {
+            Stats.onNativeCall()
+            TextStyle_nGetTopRatio(_ptr)
+        } finally {
+            reachabilityBarrier(this)
+        }
+        set(value) {
+            setTopRatio(value)
+        }
+
+    fun setTopRatio(topRatio: Float): TextStyle {
+        try {
+            Stats.onNativeCall()
+            TextStyle_nSetTopRatio(_ptr, topRatio)
         } finally {
             reachabilityBarrier(this)
         }
@@ -559,6 +585,14 @@ private external fun TextStyle_nGetHalfLeading(ptr: NativePointer): Boolean
 @ExternalSymbolName("org_jetbrains_skia_paragraph_TextStyle__1nSetHalfLeading")
 @ModuleImport("./skiko.mjs", "org_jetbrains_skia_paragraph_TextStyle__1nSetHalfLeading")
 private external fun TextStyle_nSetHalfLeading(ptr: NativePointer, value: Boolean)
+
+@ExternalSymbolName("org_jetbrains_skia_paragraph_TextStyle__1nGetTopRatio")
+@ModuleImport("./skiko.mjs", "org_jetbrains_skia_paragraph_TextStyle__1nGetTopRatio")
+private external fun TextStyle_nGetTopRatio(ptr: NativePointer): Float
+
+@ExternalSymbolName("org_jetbrains_skia_paragraph_TextStyle__1nSetTopRatio")
+@ModuleImport("./skiko.mjs", "org_jetbrains_skia_paragraph_TextStyle__1nSetTopRatio")
+private external fun TextStyle_nSetTopRatio(ptr: NativePointer, value: Float)
 
 @ExternalSymbolName("org_jetbrains_skia_paragraph_TextStyle__1nGetBaselineShift")
 @ModuleImport("./skiko.mjs", "org_jetbrains_skia_paragraph_TextStyle__1nGetBaselineShift")

--- a/skiko/src/commonTest/kotlin/org/jetbrains/skiko/paragraph/TextStyleTest.kt
+++ b/skiko/src/commonTest/kotlin/org/jetbrains/skiko/paragraph/TextStyleTest.kt
@@ -144,6 +144,15 @@ class TextStyleTest {
     }
 
     @Test
+    fun textStyleTopRatioTest() {
+        TextStyle().use { textStyle ->
+            assertEquals(-1f, textStyle.topRatio)
+            textStyle.topRatio = 0.42f
+            assertEquals(0.42f, textStyle.topRatio, 0.001f)
+        }
+    }
+
+    @Test
     fun textStyleMetricsContainsMeaningfulValues() = runTest {
         val jbMono = Typeface.makeFromResource(jbMonoPath)
         TextStyle().use { textStyle ->

--- a/skiko/src/jvmMain/cpp/common/paragraph/StrutStyle.cc
+++ b/skiko/src/jvmMain/cpp/common/paragraph/StrutStyle.cc
@@ -145,3 +145,15 @@ extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_paragraph_StrutStyleKt
     StrutStyle* instance = reinterpret_cast<StrutStyle*>(static_cast<uintptr_t>(ptr));
     instance->setHalfLeading(value);
 }
+
+extern "C" JNIEXPORT jfloat JNICALL Java_org_jetbrains_skia_paragraph_StrutStyleKt__1nGetTopRatio
+  (JNIEnv* env, jclass jclass, jlong ptr) {
+    StrutStyle* instance = reinterpret_cast<StrutStyle*>(static_cast<uintptr_t>(ptr));
+    return instance->getTopRatio();
+}
+
+extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_paragraph_StrutStyleKt__1nSetTopRatio
+  (JNIEnv* env, jclass jclass, jlong ptr, jfloat value) {
+    StrutStyle* instance = reinterpret_cast<StrutStyle*>(static_cast<uintptr_t>(ptr));
+    instance->setTopRatio(value);
+}

--- a/skiko/src/jvmMain/cpp/common/paragraph/TextStyle.cc
+++ b/skiko/src/jvmMain/cpp/common/paragraph/TextStyle.cc
@@ -257,6 +257,18 @@ extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_paragraph_TextStyleKt_
     instance->setHalfLeading(value);
 }
 
+extern "C" JNIEXPORT jfloat JNICALL Java_org_jetbrains_skia_paragraph_TextStyleKt_TextStyle_1nGetTopRatio
+  (JNIEnv* env, jclass jclass, jlong ptr) {
+    TextStyle* instance = reinterpret_cast<TextStyle*>(static_cast<uintptr_t>(ptr));
+    return instance->getTopRatio();
+}
+
+extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_paragraph_TextStyleKt_TextStyle_1nSetTopRatio
+  (JNIEnv* env, jclass jclass, jlong ptr, jfloat value) {
+    TextStyle* instance = reinterpret_cast<TextStyle*>(static_cast<uintptr_t>(ptr));
+    instance->setTopRatio(value);
+}
+
 extern "C" JNIEXPORT jfloat JNICALL Java_org_jetbrains_skia_paragraph_TextStyleKt_TextStyle_1nGetBaselineShift
   (JNIEnv* env, jclass jclass, jlong ptr) {
     TextStyle* instance = reinterpret_cast<TextStyle*>(static_cast<uintptr_t>(ptr));

--- a/skiko/src/nativeJsMain/cpp/paragraph/StrutStyle.cc
+++ b/skiko/src/nativeJsMain/cpp/paragraph/StrutStyle.cc
@@ -145,3 +145,15 @@ SKIKO_EXPORT void org_jetbrains_skia_paragraph_StrutStyle__1nSetHalfLeading
     StrutStyle* instance = reinterpret_cast<StrutStyle*>(ptr);
     instance->setHalfLeading(value);
 }
+
+SKIKO_EXPORT KFloat org_jetbrains_skia_paragraph_StrutStyle__1nGetTopRatio
+  (KNativePointer ptr) {
+    StrutStyle* instance = reinterpret_cast<StrutStyle*>(ptr);
+    return instance->getTopRatio();
+}
+
+SKIKO_EXPORT void org_jetbrains_skia_paragraph_StrutStyle__1nSetTopRatio
+  (KNativePointer ptr, KFloat topRatio) {
+    StrutStyle* instance = reinterpret_cast<StrutStyle*>(ptr);
+    instance->setTopRatio(topRatio);
+}

--- a/skiko/src/nativeJsMain/cpp/paragraph/TextStyle.cc
+++ b/skiko/src/nativeJsMain/cpp/paragraph/TextStyle.cc
@@ -255,6 +255,18 @@ SKIKO_EXPORT void org_jetbrains_skia_paragraph_TextStyle__1nSetHalfLeading
     instance->setHalfLeading(halfLeading);
 }
 
+SKIKO_EXPORT KFloat org_jetbrains_skia_paragraph_TextStyle__1nGetTopRatio
+  (KNativePointer ptr) {
+    TextStyle* instance = reinterpret_cast<TextStyle*>(ptr);
+    return instance->getTopRatio();
+}
+
+SKIKO_EXPORT void org_jetbrains_skia_paragraph_TextStyle__1nSetTopRatio
+  (KNativePointer ptr, KFloat topRatio) {
+    TextStyle* instance = reinterpret_cast<TextStyle*>(ptr);
+    instance->setTopRatio(topRatio);
+}
+
 SKIKO_EXPORT KFloat org_jetbrains_skia_paragraph_TextStyle__1nGetBaselineShift
   (KNativePointer ptr) {
     TextStyle* instance = reinterpret_cast<TextStyle*>(ptr);


### PR DESCRIPTION
Support configurable vertical centering for implementing Compose's `LineHeightStyle.Alignment`.

https://youtrack.jetbrains.com/issue/CMP-2602

See also:
- https://github.com/JetBrains/skia/pull/5
- https://github.com/JetBrains/compose-multiplatform-core/pull/1569