### PR TITLE
Use actual openURL method on iOS

### DIFF
--- a/skiko/src/uikitMain/kotlin/org/jetbrains/skiko/Actuals.uikit.kt
+++ b/skiko/src/uikitMain/kotlin/org/jetbrains/skiko/Actuals.uikit.kt
@@ -4,7 +4,11 @@ import platform.Foundation.NSURL.Companion.URLWithString
 import platform.UIKit.UIApplication
 
 internal actual fun URIHandler_openUri(uri: String) {
-    UIApplication.sharedApplication.openURL(URLWithString(uri)!!)
+    UIApplication.sharedApplication.openURL(
+        url = URLWithString(uri)!!,
+        options = emptyMap<Any?, Any>(),
+        completionHandler = null
+    )
 }
 
 // TODO: not sure if correct.


### PR DESCRIPTION
Fixes the following error when calling `URIHandler_openUri` on iOS 18:

```
The caller of UIApplication.openURL(_:) needs to migrate to the non-deprecated UIApplication.open(_:options:completionHandler:). Force returning false (NO).
```

Fixes: https://youtrack.jetbrains.com/issue/CMP-6699