### PR TITLE
Reuse the BufferedImage in SwingOffscreenRenderer

### DIFF
--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SwingOffscreenDrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SwingOffscreenDrawer.kt
@@ -59,11 +59,13 @@ internal class SwingOffscreenDrawer(
     ): BufferedImage {
         val src = ByteBuffer.wrap(bytes)
         if (bufferedImage == null || bufferedImage?.width != width || bufferedImage?.height != height) {
+            bufferedImage?.flush()
             bufferedImage = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB_PRE)
             bufferedImageGraphics = bufferedImage?.createGraphics()
+        } else {
+            bufferedImageGraphics?.clearRect(0,0, width, height)
         }
         val image = bufferedImage!!
-        bufferedImageGraphics?.clearRect(0,0, width, height)
 
         val dstData = (image.raster.dataBuffer as DataBufferInt).data
         val srcData: IntBuffer = src.order(ByteOrder.LITTLE_ENDIAN).asIntBuffer()

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SwingOffscreenDrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SwingOffscreenDrawer.kt
@@ -15,6 +15,8 @@ internal class SwingOffscreenDrawer(
 ) {
     @Volatile
     private var volatileImage: VolatileImage? = null
+    private var bufferedImage: BufferedImage? = null
+    private var bufferedImageGraphics: Graphics2D? = null
 
     /**
      * Draws rendered image that is represented by [bytes] on [g].
@@ -56,7 +58,13 @@ internal class SwingOffscreenDrawer(
         dirtyRectangles: List<Rectangle>
     ): BufferedImage {
         val src = ByteBuffer.wrap(bytes)
-        val image = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB_PRE)
+        if (bufferedImage == null || bufferedImage?.width != width || bufferedImage?.height != height) {
+            bufferedImage = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB_PRE)
+            bufferedImageGraphics = bufferedImage?.createGraphics()
+        }
+        val image = bufferedImage!!
+        bufferedImageGraphics?.clearRect(0,0, width, height)
+
         val dstData = (image.raster.dataBuffer as DataBufferInt).data
         val srcData: IntBuffer = src.order(ByteOrder.LITTLE_ENDIAN).asIntBuffer()
         for (rect in dirtyRectangles) {


### PR DESCRIPTION
Fix for https://youtrack.jetbrains.com/issue/CMP-6722/Excessive-garbage-generation-from-redrawing

Previously, the `draw` method would allocate a `BufferedImage` on every redraw, which is wasteful. This fix changed `SwingOffscreenRenderer` to reuse the same instance of `BufferedImage` and only clear it on redraws. Only changing the draw size would allocate a new `BufferedImage`.