### PR TITLE
Add support for `SkImages::AdoptFromTexture`

### DIFF
--- a/skiko/build.gradle.kts
+++ b/skiko/build.gradle.kts
@@ -474,6 +474,17 @@ publishing {
             }
         }
         maven {
+            name = "Vexor"
+            url = uri("https://maven.vexor.dev/releases")
+            credentials(PasswordCredentials::class) {
+                username = properties["user"].toString()
+                password = properties["passkey"].toString()
+            }
+            authentication {
+                create<BasicAuthentication>("basic")
+            }
+        }
+        maven {
             name = "BuildRepo"
             url = uri("${rootProject.buildDir}/repo")
         }

--- a/skiko/buildSrc/src/main/kotlin/SkikoProjectContext.kt
+++ b/skiko/buildSrc/src/main/kotlin/SkikoProjectContext.kt
@@ -101,13 +101,13 @@ internal val Project.isInIdea: Boolean
     }
 
 val Project.supportAndroid: Boolean
-    get() = findProperty("skiko.android.enabled") == "true" // || isInIdea
+    get() = false // || isInIdea
 
 val Project.supportAwt: Boolean
     get() = findProperty("skiko.awt.enabled") == "true" || isInIdea
 
 val Project.supportAllNative: Boolean
-    get() = findProperty("skiko.native.enabled") == "true" || isInIdea
+    get() = false
 
 val Project.supportAllNativeIos: Boolean
     get() = supportAllNative || findProperty("skiko.native.ios.enabled") == "true" || isInIdea
@@ -149,10 +149,10 @@ val Project.supportAnyNative: Boolean
     get() = supportAllNative || supportAnyNativeIos || supportNativeMac || supportNativeLinux
 
 val Project.supportWasm: Boolean
-    get() = findProperty("skiko.wasm.enabled") == "true" || isInIdea
+    get() = false
 
 val Project.supportJs: Boolean
-    get() = findProperty("skiko.js.enabled") == "true" || supportWasm || isInIdea
+    get() = false
 
 fun Project.skiaVersion(target: String): String {
     val platformSpecificVersion = "dependencies.skia.$target"

--- a/skiko/buildSrc/src/main/kotlin/properties.kt
+++ b/skiko/buildSrc/src/main/kotlin/properties.kt
@@ -190,7 +190,7 @@ class SkikoProperties(private val myProject: Project) {
 }
 
 object SkikoArtifacts {
-    val groupId = "org.jetbrains.skiko"
+    val groupId = "dev.vexor.skiko"
     // names are also used in samples, e.g. samples/SkijaInjectSample/build.gradle
     val commonArtifactId = "skiko"
     val jvmArtifactId = "skiko-awt"

--- a/skiko/gradle.properties
+++ b/skiko/gradle.properties
@@ -1,5 +1,5 @@
 kotlin.code.style=official
-deploy.version=0.0.0
+deploy.version=1.0.0
 
 
 dependencies.skia=m126-6bfb13368b

--- a/skiko/gradle.properties
+++ b/skiko/gradle.properties
@@ -1,5 +1,5 @@
 kotlin.code.style=official
-deploy.version=1.0.0
+deploy.version=1.0.1
 
 
 dependencies.skia=m126-6bfb13368b

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Image.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Image.kt
@@ -138,6 +138,36 @@ class Image internal constructor(ptr: NativePointer) : RefCnt(ptr), IHasImageInf
             return Image(ptr)
         }
 
+        fun adoptFromTexture(
+            context: DirectContext,
+            textureId: Int,
+            target: Int,
+            width: Int,
+            height: Int,
+            format: Int,
+            origin: SurfaceOrigin,
+            colorType: ColorType,
+            alphaType: ColorAlphaType,
+            colorSpace: ColorSpace?
+        ): Image {
+            Stats.onNativeCall()
+            val ptr = _nAdoptFromTexture(
+                context._ptr,
+                textureId,
+                target,
+                width,
+                height,
+                format,
+                origin.ordinal,
+                colorType.ordinal,
+                alphaType.ordinal,
+                colorSpace?._ptr ?: NullPointer
+            )
+            require(ptr != NullPointer) { "Failed to Image::makeFromTexture" }
+            return Image(ptr)
+        }
+
+
         init {
             staticLoad()
         }
@@ -425,6 +455,21 @@ private external fun _nMakeFromBitmap(bitmapPtr: NativePointer): NativePointer
 @ExternalSymbolName("org_jetbrains_skia_Image__1nMakeFromPixmap")
 @ModuleImport("./skiko.mjs", "org_jetbrains_skia_Image__1nMakeFromPixmap")
 private external fun _nMakeFromPixmap(pixmapPtr: NativePointer): NativePointer
+
+@ExternalSymbolName("org_jetbrains_skia_Image__1nAdoptFromTexture")
+@ModuleImport("./skiko.mjs", "org_jetbrains_skia_Image__1nAdoptFromTexture")
+private external fun _nAdoptFromTexture(
+    contextPtr: NativePointer,
+    textureId: Int,
+    target: Int,
+    width: Int,
+    height: Int,
+    format: Int,
+    surfaceOrigin: Int,
+    colorType: Int,
+    alphaType: Int,
+    colorSpacePtr: NativePointer
+): NativePointer
 
 @ExternalSymbolName("org_jetbrains_skia_Image__1nMakeFromEncoded")
 @ModuleImport("./skiko.mjs", "org_jetbrains_skia_Image__1nMakeFromEncoded")

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Image.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Image.kt
@@ -138,6 +138,19 @@ class Image internal constructor(ptr: NativePointer) : RefCnt(ptr), IHasImageInf
             return Image(ptr)
         }
 
+
+        /** Creates GPU-backed [org.jetbrains.skia.Image] from backendTexture associated with context.
+        Skia will assume ownership of the resource and will release it when no longer needed.
+        A non-null SkImage is returned if format of backendTexture is recognized and supported.
+        Recognized formats vary by GPU backend.
+        @param context         GPU context
+        @param backendTexture  texture residing on GPU
+        @param textureOrigin   origin of backendTexture
+        @param colorType       color type of the resulting image
+        @param alphaType       alpha type of the resulting image
+        @param colorSpace      range of colors; may be nullptr
+        @return                created SkImage, or nullptr
+         */
         fun adoptFromTexture(
             context: DirectContext,
             textureId: Int,
@@ -147,8 +160,6 @@ class Image internal constructor(ptr: NativePointer) : RefCnt(ptr), IHasImageInf
             format: Int,
             origin: SurfaceOrigin,
             colorType: ColorType,
-            alphaType: ColorAlphaType,
-            colorSpace: ColorSpace?
         ): Image {
             Stats.onNativeCall()
             val ptr = _nAdoptFromTexture(
@@ -160,8 +171,6 @@ class Image internal constructor(ptr: NativePointer) : RefCnt(ptr), IHasImageInf
                 format,
                 origin.ordinal,
                 colorType.ordinal,
-                alphaType.ordinal,
-                colorSpace?._ptr ?: NullPointer
             )
             require(ptr != NullPointer) { "Failed to Image::makeFromTexture" }
             return Image(ptr)
@@ -467,8 +476,6 @@ private external fun _nAdoptFromTexture(
     format: Int,
     surfaceOrigin: Int,
     colorType: Int,
-    alphaType: Int,
-    colorSpacePtr: NativePointer
 ): NativePointer
 
 @ExternalSymbolName("org_jetbrains_skia_Image__1nMakeFromEncoded")

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Image.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Image.kt
@@ -143,13 +143,6 @@ class Image internal constructor(ptr: NativePointer) : RefCnt(ptr), IHasImageInf
         Skia will assume ownership of the resource and will release it when no longer needed.
         A non-null SkImage is returned if format of backendTexture is recognized and supported.
         Recognized formats vary by GPU backend.
-        @param context         GPU context
-        @param backendTexture  texture residing on GPU
-        @param textureOrigin   origin of backendTexture
-        @param colorType       color type of the resulting image
-        @param alphaType       alpha type of the resulting image
-        @param colorSpace      range of colors; may be nullptr
-        @return                created SkImage, or nullptr
          */
         fun adoptFromTexture(
             context: DirectContext,
@@ -158,8 +151,8 @@ class Image internal constructor(ptr: NativePointer) : RefCnt(ptr), IHasImageInf
             width: Int,
             height: Int,
             format: Int,
-            origin: SurfaceOrigin,
-            colorType: ColorType,
+            origin: SurfaceOrigin = SurfaceOrigin.TOP_LEFT,
+            colorType: ColorType = ColorType.RGBA_8888,
         ): Image {
             Stats.onNativeCall()
             val ptr = _nAdoptFromTexture(
@@ -172,7 +165,7 @@ class Image internal constructor(ptr: NativePointer) : RefCnt(ptr), IHasImageInf
                 origin.ordinal,
                 colorType.ordinal,
             )
-            require(ptr != NullPointer) { "Failed to Image::makeFromTexture" }
+            require(ptr != NullPointer) { "Failed to Image::adoptFromTexture" }
             return Image(ptr)
         }
 

--- a/skiko/src/jvmMain/cpp/common/Image.cc
+++ b/skiko/src/jvmMain/cpp/common/Image.cc
@@ -2,13 +2,50 @@
 #include <jni.h>
 #include "SkData.h"
 #include "SkImage.h"
+#include "GrDirectContext.h"
+
+#include "ganesh/gl/GrGLBackendSurface.h"
+#include "include/gpu/ganesh/SkImageGanesh.h"
 #include "SkBitmap.h"
 #include "SkShader.h"
+#include "include/gpu/gl/GrGLTypes.h"
+#include "GrBackendSurface.h"
+#include "GrDirectContext.h"
 #include "SkEncodedImageFormat.h"
 #include "encode/SkPngEncoder.h"
 #include "encode/SkJpegEncoder.h"
 #include "encode/SkWebpEncoder.h"
 #include "interop.hh"
+
+extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_ImageKt__1nAdoptFromTexture
+  (JNIEnv* env, jclass jclass, jlong contextPtr, jint textureId, jint target, jint width, jint height, jint format, jint surfaceOrigin, jint colorType, jint alphaType, jlong colorSpacePtr) {
+    GrDirectContext* context = reinterpret_cast<GrDirectContext*>(static_cast<uintptr_t>(contextPtr));
+    SkColorSpace* colorSpace = reinterpret_cast<SkColorSpace*>(static_cast<uintptr_t>(colorSpacePtr));
+
+    GrGLTextureInfo textureInfo;
+    textureInfo.fID = static_cast<GrGLuint>(textureId);
+    textureInfo.fTarget = static_cast<GrGLenum>(target);
+    textureInfo.fFormat = static_cast<GrGLenum>(format);
+
+    GrBackendTexture backendTexture = GrBackendTextures::MakeGL(
+        width, height, skgpu::Mipmapped::kNo, textureInfo
+    );
+
+    sk_sp<SkImage> image = SkImages::AdoptTextureFrom(
+        context,
+        backendTexture,
+        static_cast<GrSurfaceOrigin>(surfaceOrigin),
+        static_cast<SkColorType>(colorType),
+        static_cast<SkAlphaType>(alphaType),
+        sk_ref_sp(colorSpace)
+    );
+
+    if (!image) {
+        env->ThrowNew(java::lang::RuntimeException::cls, "Failed to create image from OpenGL texture");
+        return 0;
+    }
+    return reinterpret_cast<jlong>(image.release());
+}
 
 extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_ImageKt__1nMakeRaster
   (JNIEnv* env, jclass jclass, jint width, jint height, jint colorType, jint alphaType, jlong colorSpacePtr, jbyteArray bytesArr, jint rowBytes) {

--- a/skiko/src/jvmMain/cpp/common/Image.cc
+++ b/skiko/src/jvmMain/cpp/common/Image.cc
@@ -18,9 +18,8 @@
 #include "interop.hh"
 
 extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_ImageKt__1nAdoptFromTexture
-  (JNIEnv* env, jclass jclass, jlong contextPtr, jint textureId, jint target, jint width, jint height, jint format, jint surfaceOrigin, jint colorType, jint alphaType, jlong colorSpacePtr) {
+  (JNIEnv* env, jclass jclass, jlong contextPtr, jint textureId, jint target, jint width, jint height, jint format, jint surfaceOrigin, jint colorType) {
     GrDirectContext* context = reinterpret_cast<GrDirectContext*>(static_cast<uintptr_t>(contextPtr));
-    SkColorSpace* colorSpace = reinterpret_cast<SkColorSpace*>(static_cast<uintptr_t>(colorSpacePtr));
 
     GrGLTextureInfo textureInfo;
     textureInfo.fID = static_cast<GrGLuint>(textureId);
@@ -28,7 +27,7 @@ extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_ImageKt__1nAdoptFromT
     textureInfo.fFormat = static_cast<GrGLenum>(format);
 
     GrBackendTexture backendTexture = GrBackendTextures::MakeGL(
-        width, height, skgpu::Mipmapped::kNo, textureInfo
+        width, height, skgpu::Mipmapped::kYes, textureInfo
     );
 
     sk_sp<SkImage> image = SkImages::AdoptTextureFrom(
@@ -36,14 +35,8 @@ extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_ImageKt__1nAdoptFromT
         backendTexture,
         static_cast<GrSurfaceOrigin>(surfaceOrigin),
         static_cast<SkColorType>(colorType),
-        static_cast<SkAlphaType>(alphaType),
-        sk_ref_sp(colorSpace)
     );
 
-    if (!image) {
-        env->ThrowNew(java::lang::RuntimeException::cls, "Failed to create image from OpenGL texture");
-        return 0;
-    }
     return reinterpret_cast<jlong>(image.release());
 }
 

--- a/skiko/src/jvmMain/cpp/common/Image.cc
+++ b/skiko/src/jvmMain/cpp/common/Image.cc
@@ -34,7 +34,7 @@ extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_ImageKt__1nAdoptFromT
         context,
         backendTexture,
         static_cast<GrSurfaceOrigin>(surfaceOrigin),
-        static_cast<SkColorType>(colorType),
+        static_cast<SkColorType>(colorType)
     );
 
     return reinterpret_cast<jlong>(image.release());


### PR DESCRIPTION
I have added bindings for the `AdoptFromTexture` method as I require it for rendering certain models inside Compose. 

I've tested it and it appears to be working fine.