### PR TITLE
Fix high CPU usage when window is occluded on macOS Native

### DIFF
--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
@@ -140,11 +140,9 @@ internal class MetalRedrawer(
 
         // When window is not visible - it doesn't make sense to redraw fast to avoid battery drain.
         if (isWindowOccluded) {
-            withTimeoutOrNull(300) {
-                // If the window becomes non-occluded, stop waiting immediately
-                @Suppress("ControlFlowWithEmptyBody")
-                while (windowOcclusionStateChannel.receive()) { }
-            }
+            // If the window becomes non-occluded, stop waiting immediately
+            @Suppress("ControlFlowWithEmptyBody")
+            while (windowOcclusionStateChannel.receive()) { }
         }
     }
 

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
@@ -140,9 +140,11 @@ internal class MetalRedrawer(
 
         // When window is not visible - it doesn't make sense to redraw fast to avoid battery drain.
         if (isWindowOccluded) {
-            // If the window becomes non-occluded, stop waiting immediately
-            @Suppress("ControlFlowWithEmptyBody")
-            while (windowOcclusionStateChannel.receive()) { }
+            withTimeoutOrNull(300) {
+                // If the window becomes non-occluded, stop waiting immediately
+                @Suppress("ControlFlowWithEmptyBody")
+                while (windowOcclusionStateChannel.receive()) { }
+            }
         }
     }
 

--- a/skiko/src/macosMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.macos.kt
+++ b/skiko/src/macosMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.macos.kt
@@ -6,6 +6,7 @@ import kotlinx.cinterop.objcPtr
 import kotlinx.cinterop.usePinned
 import kotlinx.cinterop.useContents
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.withTimeoutOrNull
 import org.jetbrains.skia.BackendRenderTarget
 import org.jetbrains.skia.DirectContext
 import org.jetbrains.skiko.FrameDispatcher
@@ -157,9 +158,11 @@ internal class MacOsMetalRedrawer(
 
         // When window is not visible - it doesn't make sense to redraw fast to avoid battery drain.
         if (isWindowOccluded) {
-            // If the window becomes non-occluded, stop waiting immediately
-            @Suppress("ControlFlowWithEmptyBody")
-            while (windowOcclusionStateChannel.receive()) { }
+            withTimeoutOrNull(300) {
+                // If the window becomes non-occluded, stop waiting immediately
+                @Suppress("ControlFlowWithEmptyBody")
+                while (windowOcclusionStateChannel.receive()) { }
+            }
         }
     }
 

--- a/skiko/src/macosMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.macos.kt
+++ b/skiko/src/macosMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.macos.kt
@@ -6,7 +6,6 @@ import kotlinx.cinterop.objcPtr
 import kotlinx.cinterop.usePinned
 import kotlinx.cinterop.useContents
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.withTimeoutOrNull
 import org.jetbrains.skia.BackendRenderTarget
 import org.jetbrains.skia.DirectContext
 import org.jetbrains.skiko.FrameDispatcher
@@ -158,11 +157,9 @@ internal class MacOsMetalRedrawer(
 
         // When window is not visible - it doesn't make sense to redraw fast to avoid battery drain.
         if (isWindowOccluded) {
-            withTimeoutOrNull(300) {
-                // If the window becomes non-occluded, stop waiting immediately
-                @Suppress("ControlFlowWithEmptyBody")
-                while (windowOcclusionStateChannel.receive()) { }
-            }
+            // If the window becomes non-occluded, stop waiting immediately
+            @Suppress("ControlFlowWithEmptyBody")
+            while (windowOcclusionStateChannel.receive()) { }
         }
     }
 


### PR DESCRIPTION
My app is used a lot in the background, and I noticed high CPU usage in the native macOS version. With this PR, CPU usage is reduced when window is invisible by disabling drawing. This was already implemented for the JVM, and that behaviour is now copied to native macOS. So the code is similar to JVM parts in:
- https://github.com/JetBrains/skiko/blob/master/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
- https://github.com/JetBrains/skiko/blob/master/skiko/src/awtMain/objectiveC/macos/MetalRedrawer.mm

The draw function is now suspend, which required moving some other functions around. I tried to keep the implementation similar to the JVM version.

# Testing
Tested using `./gradlew runNative` in `samples/SkiaMultiplatformSample`. Now the CPU usage is reduced a lot when moving another (non transparent) app over the window.

# Old behaviour

https://github.com/user-attachments/assets/60ad3398-3f44-4e2f-aca7-44a4607d0840

# New behaviour with 300ms timeout
See reduction in CPU usage when window is invisible

https://github.com/user-attachments/assets/106efdeb-0044-4411-9b26-5a6b8886ff04


# New behaviour without 300ms timeout


https://github.com/user-attachments/assets/b986548b-d7ab-497b-9ddb-5b46ca016f83