### PR TITLE
Update macos runner to 13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   macos:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
         name: 'Check out code'


### PR DESCRIPTION
Reason: macos-12 is deprecated and not available anymore https://github.com/actions/runner-images/issues/10721 
(Several previous CI runs were incomplete bacause of this: https://github.com/JetBrains/skiko/actions, including a commit merged to master - https://github.com/JetBrains/skiko/commit/bccb17a47610b17ee5e297d3665b4fc0625da9e1)  