### PR TITLE
Set -mios-simulator-version-min=12.0 for skiko build

### DIFF
--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/NativeTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/NativeTasksConfiguration.kt
@@ -74,7 +74,7 @@ fun SkikoProjectContext.compileNativeBridgesTask(
                     Arch.Arm64 -> arrayOf(
                         "-target", if (isUikitSim) "arm64-apple-ios-simulator" else "arm64-apple-ios",
                         "-isysroot", if (isUikitSim) iphoneSimSdk else iphoneOsSdk,
-                        if (isUikitSim) "-mios-simulator-version-min=12.0" else "-miphoneos-version-min=12.0"
+                        if (isUikitSim) "-mios-simulator-version-min=12.0" else "-mios-version-min=12.0"
                     )
                     Arch.X64 -> arrayOf(
                         "-target", "x86_64-apple-ios-simulator",

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/NativeTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/NativeTasksConfiguration.kt
@@ -74,7 +74,7 @@ fun SkikoProjectContext.compileNativeBridgesTask(
                     Arch.Arm64 -> arrayOf(
                         "-target", if (isUikitSim) "arm64-apple-ios-simulator" else "arm64-apple-ios",
                         "-isysroot", if (isUikitSim) iphoneSimSdk else iphoneOsSdk,
-                        "-miphoneos-version-min=12.0"
+                        if (isUikitSim) "-mios-simulator-version-min=12.0" else "-miphoneos-version-min=12.0"
                     )
                     Arch.X64 -> arrayOf(
                         "-target", "x86_64-apple-ios-simulator",


### PR DESCRIPTION
This is an alternative (better) fix for https://youtrack.jetbrains.com/issue/CMP-6721 

Similar change is skia is required too: https://github.com/JetBrains/skia-pack/pull/60