### PR TITLE
Update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           ./gradlew --stacktrace --info -Pskiko.native.enabled=true :skiko:publishToMavenLocal -Pskiko.debug=true
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         name: 'Save test results as artifact'
         if: always()
         with:
@@ -96,11 +96,11 @@ jobs:
         name: 'Publish to Maven Local'
         run: ./gradlew --stacktrace --info -Pskiko.native.enabled=true :skiko:publishToMavenLocal
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         name: 'Save test results as artifact'
         if: always()
         with:
-          name: test-reports-macos
+          name: test-reports-ios
           path: ./skiko/build/reports/tests
           retention-days: 5
 
@@ -123,7 +123,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-reports-macos
+          name: test-reports-tvos
           path: ./skiko/build/reports/tests
           retention-days: 5
 
@@ -189,7 +189,7 @@ jobs:
           ./gradlew --no-daemon --stacktrace --info :SkiaAwtSample:installDist
           ./gradlew --no-daemon -Pskiko.android.enabled=true :skiko:publishSkikoJvmRuntimeAndroidX64PublicationToMavenLocal :skiko:publishSkikoJvmRuntimeAndroidArm64PublicationToMavenLocal :skiko:publishAndroidPublicationToMavenLocal
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         name: 'Save test results as artifact'
         if: always()
         with:
@@ -224,7 +224,7 @@ jobs:
           ./gradlew --stacktrace --info :skiko:publishToMavenLocal
           ./gradlew --stacktrace --info :SkiaAwtSample:installDist
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         name: 'Save test results as artifact'
         if: always()
         with:

--- a/skiko/build.gradle.kts
+++ b/skiko/build.gradle.kts
@@ -585,17 +585,6 @@ tasks.withType<AbstractTestTask> {
     }
 }
 
-rootProject.plugins.withType<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin> {
-    val nodeExtension = rootProject.the<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension>()
-    nodeExtension.nodeVersion = "16.0.0"
-    // Kotlin/JS has a bug preventing compilation on non-x86 Linux machines,
-    // see https://youtrack.jetbrains.com/issue/KT-48631
-    // It always downloads and uses x86 version, so on those architectures
-    if (hostOs == OS.Linux && hostArch != Arch.X64) {
-        nodeExtension.download = false
-    }
-}
-
 tasks.withType<JavaCompile> {
     // Workaround to configure Java sources on Android (src/androidMain/java)
     targetCompatibility = "1.8"


### PR DESCRIPTION
Currently fails with
```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```