### PR TITLE
Build Skiko with Clang-CL

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,14 +9,15 @@
   * `Windows`
     1. Download [Visual Studio Build Tools 2019](https://learn.microsoft.com/en-us/visualstudio/releases/2019/history) (search "BuildTools" on the page).
     2. During the installation, select "Desktop development with C++"
-    3. Add an environment variable SKIKO_VSBT_PATH=C:/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools
-    ```
-    Control Panel|All Control Panel Items|System|Advanced system settings|Environment variables
-    ```
-    or by running `cmd` as administrator:
-    ```
-    setx /M SKIKO_VSBT_PATH "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools"
-    ```
+    3. Add an environment variable SKIKO_VSBT_PATH=C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools
+       ```
+       Control Panel|All Control Panel Items|System|Advanced system settings|Environment variables
+       ```
+       or by running `cmd` as administrator:
+       ```
+       setx /M SKIKO_VSBT_PATH "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools"
+       ```
+    4. Skiko is built using Clang-cl. Clang-cl is a part of LLVM and can be downloaded from the [LLVM project's website](https://releases.llvm.org/). Please also make sure that Clang-cl.exe is available in %PATH%.
 
 * Install Emscripten
 * Set `JAVA_HOME` to location of JDK, at least version 11

--- a/skiko/buildSrc/src/main/kotlin/CompileSkikoCppTask.kt
+++ b/skiko/buildSrc/src/main/kotlin/CompileSkikoCppTask.kt
@@ -148,7 +148,12 @@ abstract class CompileSkikoCppTask() : AbstractSkikoNativeToolTask() {
                 arg("-o", outputFile.absolutePath.replace("\\", "/"))
                 arg(value = sourceFile.absolutePath.replace("\\", "/"))
                 if (compiler.get().startsWith("clang")) {
-                    arg("-MJ", outputFile.absolutePath + ".json")
+                    // We use Clang-CL on Windows which doesn't directly support the -MJ flag.
+                    // We have to use the /clang:-MJ"path" form instead.
+                    when {
+                        buildTargetOS.get().isWindows -> rawArg("/clang:-MJ\"" + outputFile.absolutePath + ".json\"")
+                        else -> arg("-MJ", outputFile.absolutePath + ".json")
+                    }
                 }
             }
 

--- a/skiko/buildSrc/src/main/kotlin/properties.kt
+++ b/skiko/buildSrc/src/main/kotlin/properties.kt
@@ -43,13 +43,13 @@ fun compilerForTarget(os: OS, arch: Arch): String =
             Arch.Wasm -> "Unexpected combination: $os & $arch"
         }
         OS.Android -> "clang++"
-        OS.Windows -> "cl.exe"
+        OS.Windows -> "clang-cl.exe"
         OS.MacOS, OS.IOS, OS.TVOS -> "clang++"
         OS.Wasm -> "emcc"
     }
 
 fun linkerForTarget(os: OS, arch: Arch): String =
-    if (os.isWindows) "link.exe" else compilerForTarget(os, arch)
+    if (os.isWindows) "lld-link.exe" else compilerForTarget(os, arch)
 
 val OS.dynamicLibExt: String
     get() = when (this) {
@@ -74,22 +74,22 @@ enum class SkiaBuildType(
     val id: String,
     val flags: Array<String>,
     val clangFlags: Array<String>,
-    val msvcCompilerFlags: Array<String>,
-    val msvcLinkerFlags: Array<String>
+    val winCompilerFlags: Array<String>,
+    val winLinkerFlags: Array<String>
 ) {
     DEBUG(
-        "Debug",
+        id = "Debug",
         flags = arrayOf("-DSK_DEBUG"),
         clangFlags = arrayOf("-std=c++17", "-g", "-DSK_TRIVIAL_ABI=[[clang::trivial_abi]]"),
-        msvcCompilerFlags = arrayOf("/Zi /std:c++17"),
-        msvcLinkerFlags = arrayOf("/DEBUG"),
+        winCompilerFlags = arrayOf("/Zi", "/std:c++17"),
+        winLinkerFlags = arrayOf("/DEBUG"),
     ),
     RELEASE(
         id = "Release",
         flags = arrayOf("-DNDEBUG"),
         clangFlags = arrayOf("-std=c++17", "-O3"),
-        msvcCompilerFlags = arrayOf("/O2 /std:c++17"),
-        msvcLinkerFlags = arrayOf("/DEBUG"),
+        winCompilerFlags = arrayOf("/O2", "/std:c++17"),
+        winLinkerFlags = arrayOf("/DEBUG"),
     );
     override fun toString() = id
 }

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/JvmTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/JvmTasksConfiguration.kt
@@ -62,6 +62,7 @@ fun SkikoProjectContext.createCompileJvmBindingsTask(
     includeHeadersNonRecursive(skiaHeadersDirs(skiaJvmBindingsDir.get()))
     val projectDir = project.projectDir
     includeHeadersNonRecursive(projectDir.resolve("src/awtMain/cpp/include"))
+    includeHeadersNonRecursive(projectDir.resolve("src/jvmMain/cpp/common"))
     includeHeadersNonRecursive(projectDir.resolve("src/jvmMain/cpp/include"))
     includeHeadersNonRecursive(projectDir.resolve("src/commonMain/cpp/common/include"))
 
@@ -95,16 +96,17 @@ fun SkikoProjectContext.createCompileJvmBindingsTask(
             )
         }
         OS.Windows -> {
-            compiler.set(windowsSdkPaths.compiler.absolutePath)
             includeHeadersNonRecursive(windowsSdkPaths.includeDirs)
             includeHeadersNonRecursive(jdkHome.resolve("include/win32"))
+            val targetArgs = if (targetArch == Arch.Arm64) arrayOf("/clang:--target=arm64-windows") else arrayOf()
             osFlags = arrayOf(
                 "/nologo",
-                *buildType.msvcCompilerFlags,
+                *buildType.winCompilerFlags,
                 "/utf-8",
                 "/GR-", // no-RTTI.
                 "/FS", // Due to an error when building in Teamcity. https://docs.microsoft.com/en-us/cpp/build/reference/fs-force-synchronous-pdb-writes
-                // LATER. Ange rendering arguments:
+                *targetArgs,
+                // LATER. Angle rendering arguments:
                 // "-I$skiaDir/third_party/externals/angle2/include",
                 // "-I$skiaDir/src/gpu",
                 // "-DSK_ANGLE",
@@ -287,10 +289,9 @@ fun SkikoProjectContext.createLinkJvmBindings(
             )
         }
         OS.Windows -> {
-            linker.set(windowsSdkPaths.linker.absolutePath)
             libDirs.set(windowsSdkPaths.libDirs)
             osFlags = mutableListOf<String>().apply {
-                addAll(buildType.msvcLinkerFlags)
+                addAll(buildType.winLinkerFlags)
                 addAll(
                     arrayOf(
                         // ignore https://learn.microsoft.com/en-us/cpp/error-messages/tool-errors/linker-tools-warning-lnk4217
@@ -298,16 +299,6 @@ fun SkikoProjectContext.createLinkJvmBindings(
                         "/ignore:4217"
                     )
                 )
-                // workaround for VS Build Tools 2022 (17.2+) change
-                // https://developercommunity.visualstudio.com/t/-imp-std-init-once-complete-unresolved-external-sy/1684365#T-N10041864
-                if (windowsSdkPaths.toolchainVersion >= VersionNumber.parse("14.32")) {
-                    addAll(
-                        arrayOf(
-                            "/ALTERNATENAME:__imp___std_init_once_begin_initialize=__imp_InitOnceBeginInitialize",
-                            "/ALTERNATENAME:__imp___std_init_once_complete=__imp_InitOnceComplete"
-                        )
-                    )
-                }
                 addAll(
                     arrayOf(
                         "/NOLOGO",

--- a/skiko/gradle.properties
+++ b/skiko/gradle.properties
@@ -2,7 +2,7 @@ kotlin.code.style=official
 deploy.version=0.0.0
 
 
-dependencies.skia=m132-9b3c42e2f9-1
+dependencies.skia=m132-9b3c42e2f9-2
 
 # you can override general skia dependencies by passing platform-specific property: 
 # dependencies.skia.android-arm64

--- a/skiko/src/awtMain/cpp/windows/InternalDirectXApi.cc
+++ b/skiko/src/awtMain/cpp/windows/InternalDirectXApi.cc
@@ -15,7 +15,6 @@
 #include "ganesh/GrBackendSurface.h"
 #include "ganesh/GrDirectContext.h"
 #include "SkSurface.h"
-#include "../common/interop.hh"
 
 #include "ganesh/d3d/GrD3DTypes.h"
 #include "ganesh/d3d/GrD3DBackendContext.h"
@@ -351,7 +350,7 @@ extern "C"
         dst.PlacedFootprint.Footprint.Depth = 1;
         dst.PlacedFootprint.Footprint.RowPitch = calculateRowPitch(texture->width);
 
-        D3D12_BOX srcBox = {0, 0, 0, texture->width, texture->height, 1};
+        D3D12_BOX srcBox = {0, 0, 0, static_cast<UINT>(texture->width), static_cast<UINT>(texture->height), 1};
 
         commandList->CopyTextureRegion(&dst, 0, 0, 0, &src, &srcBox);
 
@@ -381,7 +380,7 @@ extern "C"
         DirectXOffScreenTexture *texture = fromJavaPointer<DirectXOffScreenTexture *>(texturePtr);
 
         auto rangeLength = texture->readbackBufferWidth();
-        D3D12_RANGE readbackBufferRange{ 0, rangeLength };
+        D3D12_RANGE readbackBufferRange{ 0, static_cast<SIZE_T>(rangeLength) };
 
         /*
          * TODO: memcpy from unaligned texture is not supported, line by line copy is very slow,

--- a/skiko/src/awtMain/cpp/windows/SoftwareRedrawer.cc
+++ b/skiko/src/awtMain/cpp/windows/SoftwareRedrawer.cc
@@ -7,7 +7,7 @@
 #include "SkColorSpace.h"
 #include "SkSurface.h"
 #include "src/base/SkAutoMalloc.h"
-#include "../common/interop.hh"
+#include "interop.hh"
 
 class SoftwareDevice
 {

--- a/skiko/src/awtMain/cpp/windows/directXRedrawer.cc
+++ b/skiko/src/awtMain/cpp/windows/directXRedrawer.cc
@@ -11,7 +11,7 @@
 #include "ganesh/GrDirectContext.h"
 #include "SkSurface.h"
 #include "include/gpu/ganesh/SkSurfaceGanesh.h"
-#include "../common/interop.hh"
+#include "interop.hh"
 #include "DCompLibrary.h"
 
 #include "ganesh/d3d/GrD3DTypes.h"

--- a/skiko/src/awtMain/cpp/windows/exceptions_handler.cc
+++ b/skiko/src/awtMain/cpp/windows/exceptions_handler.cc
@@ -1,5 +1,4 @@
 #include "exceptions_handler.h"
-#include "../common/interop.hh"
 
 const char *getDescription(DWORD code) {
     switch (code) {


### PR DESCRIPTION
Official Skia documentation suggests that it's [_highly recommended_](https://skia.org/docs/user/build/#highly-recommended-build-with-clang-cl) to build Skia with Clang-CL on Windows, and that this dramatically improves Skia performance with Software rendering and in other areas. This corresponds with my experience, so here it is.

Related Skia-pack PR: https://github.com/JetBrains/skia-pack/pull/64

Prerequisite: #1024 