### PR TITLE
Pre-cache SkPicture snapshots for RenderNode

### DIFF
--- a/skiko/src/commonMain/cpp/common/include/node/RenderNode.h
+++ b/skiko/src/commonMain/cpp/common/include/node/RenderNode.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <optional>
+#include <set>
 #include <SkBBHFactory.h>
 #include <SkCamera.h>
 #include <SkCanvas.h>
@@ -68,6 +69,8 @@ public:
 
     void drawInto(SkCanvas *canvas);
 
+    SkFlattenable::Type getFlattenableType() const override;
+
 protected:
     // SkDrawable
     SkRect onGetBounds() override;
@@ -76,7 +79,34 @@ protected:
     sk_sp<SkPicture> onMakePictureSnapshot() override;
 
 private:
+    // What changed about a node, as far as snapshot bookkeeping is concerned.
+    enum SnapshotChange : uint32_t {
+        // Drawing applied around the snapshot: transform, clip, layer, alpha. This
+        // node's own snapshot stays valid; the snapshots that inlined it do not.
+        kAppearance = 1 << 0,
+        // The recorded content, or the cull rect it is recorded with.
+        kContent = 1 << 1,
+        // The set of drawn nodes, or what they draw, may differ, so re-derive from
+        // the current dependencies whether this content can be snapshotted.
+        kDependencies = 1 << 2,
+    };
+
+    SkCanvas *beginRecordingInto(SkPictureRecorder& target);
+    // Whether the content may cover more than the node's own bounds, and so has to be
+    // measured while recording instead of being culled to them.
+    bool mayDrawOutOfBounds() const;
+    // Whether this node's own drawing only replays correctly at the transform it was
+    // recorded under, which bars every node that inlines it from snapshotting too.
+    bool drawsTransformDependentContent() const;
+    // Whether an observer that inlines this node cannot snapshot the result: true when this
+    // node draws a shadow, or when anything in its own content does. This is the single bit
+    // an observer reads from each of its dependencies.
+    bool preventsObserverSnapshot() const;
     void updateMatrix();
+    void updateDependencies();
+    void releaseDependencies();
+    void updateSnapshot();
+    void invalidateSnapshot(uint32_t changes);
     void drawShadow(SkCanvas *canvas, const LightGeometry& lightGeometry, const LightInfo& lightInfo);
     void setCameraLocation(float x, float y, float z);
 
@@ -85,6 +115,20 @@ private:
     SkBBHFactory *bbhFactory;
     SkPictureRecorder recorder;
     sk_sp<SkDrawable> contentCache;
+    sk_sp<SkPicture> contentSnapshot;
+    // Whether the recorded content replays correctly under any transform, and so may be
+    // snapshotted at all. Cleared by drawing whose result depends on the transform it is
+    // replayed under -- today only a shadow, whose spot geometry follows the occluder's
+    // position relative to a light fixed in device space, so replaying the recording
+    // anywhere else yields a different shadow.
+    bool contentTransformInvariant;
+    // Whether the observers have already been told, since this node was last drawn, that
+    // their inlined copy of it is stale. Lets a node reached through several observer paths
+    // propagate once instead of once per path. Cleared when the node is drawn (they inline
+    // it afresh) and when preventsObserverSnapshot() flips (they must re-derive).
+    bool observersNotified;
+
+    std::set<RenderNode *> dependencies, observers;
 
     std::optional<SkPaint> layerPaint;
     SkRect bounds;

--- a/skiko/src/commonMain/cpp/common/include/node/RenderNode.h
+++ b/skiko/src/commonMain/cpp/common/include/node/RenderNode.h
@@ -68,11 +68,11 @@ public:
 
     void drawInto(SkCanvas *canvas);
 
-    // SkDrawable
-    void onDraw(SkCanvas* canvas) override;
-    SkRect onGetBounds() override;
-
 protected:
+    // SkDrawable
+    SkRect onGetBounds() override;
+    size_t onApproximateBytesUsed() override;
+    void onDraw(SkCanvas* canvas) override;
     sk_sp<SkPicture> onMakePictureSnapshot() override;
 
 private:

--- a/skiko/src/commonMain/cpp/common/include/node/RenderNode.h
+++ b/skiko/src/commonMain/cpp/common/include/node/RenderNode.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <optional>
-#include <set>
+#include <unordered_set>
 #include <SkBBHFactory.h>
 #include <SkCamera.h>
 #include <SkCanvas.h>
@@ -128,7 +128,7 @@ private:
     // it afresh) and when preventsObserverSnapshot() flips (they must re-derive).
     bool observersNotified;
 
-    std::set<RenderNode *> dependencies, observers;
+    std::unordered_set<RenderNode *> dependencies, observers;
 
     std::optional<SkPaint> layerPaint;
     SkRect bounds;

--- a/skiko/src/commonMain/cpp/common/include/node/RenderNodeContext.h
+++ b/skiko/src/commonMain/cpp/common/include/node/RenderNodeContext.h
@@ -9,9 +9,13 @@ class RenderNode;
 
 class RenderNodeContext : public SkRefCnt {
 public:
-    RenderNodeContext(bool measureDrawBounds);
+    RenderNodeContext(bool measureDrawBounds, bool snapshotCache);
 
     bool shouldMeasureDrawBounds() const { return this->measureDrawBounds; }
+    // Whether the nodes created with this context keep an SkPicture snapshot of their
+    // recorded content. A snapshot inlines the drawing of the nodes below it, so this
+    // holds for the whole tree rather than for a single node.
+    bool shouldUseSnapshotCache() const { return this->snapshotCache; }
 
     const LightGeometry& getLightGeometry() const { return this->lightGeometry; }
     const LightInfo& getLightInfo() const { return this->lightInfo; }
@@ -24,6 +28,7 @@ private:
     LightGeometry lightGeometry;
     LightInfo lightInfo;
     bool measureDrawBounds;
+    bool snapshotCache;
 };
 
 } // namespace node

--- a/skiko/src/commonMain/cpp/common/node/RenderNode.cpp
+++ b/skiko/src/commonMain/cpp/common/node/RenderNode.cpp
@@ -87,14 +87,14 @@ private:
 // The set is expected to be empty on entry.
 class DependencyTrackerCanvas : public SkNoDrawCanvas {
 public:
-    DependencyTrackerCanvas(std::set<RenderNode *> *dependencies)
+    DependencyTrackerCanvas(std::unordered_set<RenderNode *>& dependencies)
         : SkNoDrawCanvas(INT_MAX, INT_MAX), dependencies(dependencies) {}
 
 protected:
     void onDrawDrawable(SkDrawable* drawable, const SkMatrix* matrix) override {
         if (drawable->getFlattenableType() == kRenderNode_Type) {
             auto renderNode = static_cast<RenderNode *>(drawable);
-            if (dependencies->insert(renderNode).second) {
+            if (dependencies.insert(renderNode).second) {
                 renderNode->ref();
             }
         } else {
@@ -103,7 +103,7 @@ protected:
     }
 
 private:
-    std::set<RenderNode *> *dependencies;
+    std::unordered_set<RenderNode *>& dependencies;
 };
 
 RenderNode::RenderNode(const sk_sp<RenderNodeContext>& context)
@@ -473,7 +473,7 @@ void RenderNode::updateDependencies() {
     }
     this->releaseDependencies();
     if (this->contentCache) {
-        DependencyTrackerCanvas dependencyTracker(&this->dependencies);
+        DependencyTrackerCanvas dependencyTracker(this->dependencies);
         this->contentCache->draw(&dependencyTracker);
 
         for (auto renderNode : this->dependencies) {

--- a/skiko/src/commonMain/cpp/common/node/RenderNode.cpp
+++ b/skiko/src/commonMain/cpp/common/node/RenderNode.cpp
@@ -18,13 +18,13 @@ namespace node {
 // 2^30 was chosen because it's big enough, leaves quite a lot of room between it
 // and Float.MAX_VALUE, and also lets the width and height fit into int32 (just in
 // case).
-static const float PICTURE_MIN_VALUE = static_cast<float>(-(1L << 30));
-static const float PICTURE_MAX_VALUE = static_cast<float>((1L << 30) - 1);
-static SkRect PICTURE_BOUNDS {
-    PICTURE_MIN_VALUE,
-    PICTURE_MIN_VALUE,
-    PICTURE_MAX_VALUE,
-    PICTURE_MAX_VALUE
+static const float UNKNOWN_BOUNDS_MIN_VALUE = static_cast<float>(-(1L << 30));
+static const float UNKNOWN_BOUNDS_MAX_VALUE = static_cast<float>((1L << 30) - 1);
+static SkRect UNKNOWN_BOUNDS {
+    UNKNOWN_BOUNDS_MIN_VALUE,
+    UNKNOWN_BOUNDS_MIN_VALUE,
+    UNKNOWN_BOUNDS_MAX_VALUE,
+    UNKNOWN_BOUNDS_MAX_VALUE
 };
 
 static const float DEFAULT_CAMERA_DISTANCE = 8.0f;
@@ -224,7 +224,7 @@ const SkMatrix& RenderNode::getMatrix() {
 
 SkCanvas *RenderNode::beginRecording() {
     bool measureDrawBounds = !clip || shadowElevation > 0.0f;
-    const SkRect& bounds = measureDrawBounds ? PICTURE_BOUNDS : SkRect::MakeWH(this->bounds.width(), this->bounds.height());
+    const SkRect& bounds = measureDrawBounds ? UNKNOWN_BOUNDS : SkRect::MakeWH(this->bounds.width(), this->bounds.height());
     SkBBHFactory* bbhFactory = measureDrawBounds ? this->bbhFactory : nullptr;
     return this->recorder.beginRecording(bounds, bbhFactory);
 }
@@ -235,6 +235,32 @@ void RenderNode::endRecording() {
 
 void RenderNode::drawInto(SkCanvas* canvas) {
     canvas->drawDrawable(this);
+}
+
+SkRect RenderNode::onGetBounds() {
+    this->updateMatrix();
+    SkRect result;
+    if (this->contentCache) {
+        result = this->contentCache->getBounds().makeOffset(this->bounds.left(), this->bounds.top());
+    } else {
+        bool measureDrawBounds = !clip || shadowElevation > 0.0f;
+        result = measureDrawBounds ? UNKNOWN_BOUNDS : this->bounds;
+    }
+    if (!this->matrixIdentity) {
+        this->transformMatrix.mapRect(&result);
+    }
+    return result;
+}
+
+size_t RenderNode::onApproximateBytesUsed() {
+    size_t contentSize = 0;
+    if (this->contentCache) {
+        contentSize += this->contentCache->approximateBytesUsed();
+    }
+    if (this->clipPath) {
+        contentSize += this->clipPath->approximateBytesUsed();
+    }
+    return sizeof(*this) + contentSize;
 }
 
 void RenderNode::onDraw(SkCanvas* canvas) {
@@ -280,9 +306,6 @@ void RenderNode::onDraw(SkCanvas* canvas) {
     }
 }
 
-SkRect RenderNode::onGetBounds() {
-    return this->bounds;
-}
 
 sk_sp<SkPicture> RenderNode::onMakePictureSnapshot() {
     SkCanvas* canvas = this->beginRecording();

--- a/skiko/src/commonMain/cpp/common/node/RenderNode.cpp
+++ b/skiko/src/commonMain/cpp/common/node/RenderNode.cpp
@@ -30,6 +30,14 @@ static SkRect UNKNOWN_BOUNDS {
 static const float DEFAULT_CAMERA_DISTANCE = 8.0f;
 static const float NON_ZERO_EPSILON = 0.001f;
 
+// Since "kSkDrawable_Type" isn't really used anywhere outside of serialization, we can use it
+// to identify RenderNode objects without RTTI, like SkRuntimeEffect does (even without adding to original enum).
+static const SkFlattenable::Type kRenderNode_Type = static_cast<SkFlattenable::Type>(0x2d2595b6);
+// The value has to stay outside the range Skia assigns, or a node is mistaken for a
+// flattenable of that type. kSkShader_Type is the largest Skia declares.
+static_assert(static_cast<uint32_t>(kRenderNode_Type) > static_cast<uint32_t>(SkFlattenable::kSkShader_Type),
+              "kRenderNode_Type must stay above the SkFlattenable::Type values Skia declares");
+
 /**
  * Check for floats that are close enough to zero.
  */
@@ -42,7 +50,6 @@ inline static bool isZero(float value) {
 static SkColor multiplyAlpha(SkColor color, float alpha) {
     return SkColorSetA(color, alpha * SkColorGetA(color));
 }
-
 
 class UnrollDrawableCanvas : public SkNWayCanvas {
 public:
@@ -76,11 +83,39 @@ private:
     float alpha;
 };
 
+// Collects the render nodes drawn by a recording, taking a reference to each.
+// The set is expected to be empty on entry.
+class DependencyTrackerCanvas : public SkNoDrawCanvas {
+public:
+    DependencyTrackerCanvas(std::set<RenderNode *> *dependencies)
+        : SkNoDrawCanvas(INT_MAX, INT_MAX), dependencies(dependencies) {}
+
+protected:
+    void onDrawDrawable(SkDrawable* drawable, const SkMatrix* matrix) override {
+        if (drawable->getFlattenableType() == kRenderNode_Type) {
+            auto renderNode = static_cast<RenderNode *>(drawable);
+            if (dependencies->insert(renderNode).second) {
+                renderNode->ref();
+            }
+        } else {
+            drawable->draw(this, matrix);
+        }
+    }
+
+private:
+    std::set<RenderNode *> *dependencies;
+};
+
 RenderNode::RenderNode(const sk_sp<RenderNodeContext>& context)
     : context(context),
       bbhFactory(context->shouldMeasureDrawBounds() ? new SkRTreeFactory() : nullptr),
       recorder(),
       contentCache(),
+      contentSnapshot(),
+      contentTransformInvariant(true),
+      observersNotified(false),
+      dependencies(),
+      observers(),
       layerPaint(),
       bounds { 0.0f, 0.0f, 0.0f, 0.0f },
       pivot { SK_FloatNaN, SK_FloatNaN },
@@ -113,71 +148,97 @@ RenderNode::~RenderNode() {
         delete this->bbhFactory;
         this->bbhFactory = nullptr;
     }
+    // The observers set is necessarily empty: an observer holds a reference to this
+    // node through its own dependencies, so it cannot outlive it.
+    this->releaseDependencies();
 }
 
 void RenderNode::setLayerPaint(const std::optional<SkPaint>& layerPaint) {
     this->layerPaint = layerPaint;
+    this->invalidateSnapshot(kAppearance);
 }
 
 void RenderNode::setBounds(const SkRect& bounds) {
     this->bounds = bounds;
     this->matrixDirty = true;
+    // The bounds size is the cull rect of a clipping node's recording.
+    this->invalidateSnapshot(kContent);
 }
 
 void RenderNode::setPivot(const SkPoint& pivot) {
     this->pivot = pivot;
     this->matrixDirty = true;
+    this->invalidateSnapshot(kAppearance);
 }
 
 void RenderNode::setAlpha(float alpha) {
     this->alpha = alpha;
+    this->invalidateSnapshot(kAppearance);
 }
 
 void RenderNode::setScaleX(float scaleX) {
     this->scaleX = scaleX;
     this->matrixDirty = true;
+    this->invalidateSnapshot(kAppearance);
 }
 
 void RenderNode::setScaleY(float scaleY) {
     this->scaleY = scaleY;
     this->matrixDirty = true;
+    this->invalidateSnapshot(kAppearance);
 }
 
 void RenderNode::setTranslationX(float translationX) {
     this->translationX = translationX;
     this->matrixDirty = true;
+    this->invalidateSnapshot(kAppearance);
 }
 
 void RenderNode::setTranslationY(float translationY) {
     this->translationY = translationY;
     this->matrixDirty = true;
+    this->invalidateSnapshot(kAppearance);
 }
 
 void RenderNode::setShadowElevation(float shadowElevation) {
+    bool wasPreventingObserverSnapshot = this->preventsObserverSnapshot();
     this->shadowElevation = shadowElevation;
+    // A shadow makes this node's drawing transform-dependent, which its observers read
+    // when deciding whether they may snapshot, so a change to it has to reach them even
+    // if they were already told stale this frame.
+    if (this->preventsObserverSnapshot() != wasPreventingObserverSnapshot) {
+        this->observersNotified = false;
+    }
+    // A shadow also lets the node draw outside its bounds, widening the cull rect.
+    this->invalidateSnapshot(kContent);
 }
 
 void RenderNode::setAmbientShadowColor(SkColor ambientShadowColor) {
     this->ambientShadowColor = ambientShadowColor;
+    this->invalidateSnapshot(kAppearance);
 }
 
 void RenderNode::setSpotShadowColor(SkColor spotShadowColor) {
     this->spotShadowColor = spotShadowColor;
+    this->invalidateSnapshot(kAppearance);
 }
 
 void RenderNode::setRotationX(float rotationX) {
     this->rotationX = rotationX;
     this->matrixDirty = true;
+    this->invalidateSnapshot(kAppearance);
 }
 
 void RenderNode::setRotationY(float rotationY) {
     this->rotationY = rotationY;
     this->matrixDirty = true;
+    this->invalidateSnapshot(kAppearance);
 }
 
 void RenderNode::setRotationZ(float rotationZ) {
     this->rotationZ = rotationZ;
     this->matrixDirty = true;
+    this->invalidateSnapshot(kAppearance);
 }
 
 float RenderNode::getCameraDistance() const {
@@ -187,6 +248,7 @@ float RenderNode::getCameraDistance() const {
 void RenderNode::setCameraDistance(float cameraDistance) {
     this->setCameraLocation(0.0f, 0.0f, cameraDistance);
     this->matrixDirty = true;
+    this->invalidateSnapshot(kAppearance);
 }
 
 void RenderNode::setClipRect(const std::optional<SkRect>& clipRect, SkClipOp op, bool doAntiAlias) {
@@ -195,6 +257,7 @@ void RenderNode::setClipRect(const std::optional<SkRect>& clipRect, SkClipOp op,
     this->clipPath.reset();
     this->clipOp = op;
     this->clipAntiAlias = doAntiAlias;
+    this->invalidateSnapshot(kAppearance);
 }
 
 void RenderNode::setClipRRect(const std::optional<SkRRect>& clipRRect, SkClipOp op, bool doAntiAlias) {
@@ -203,6 +266,7 @@ void RenderNode::setClipRRect(const std::optional<SkRRect>& clipRRect, SkClipOp 
     this->clipPath.reset();
     this->clipOp = op;
     this->clipAntiAlias = doAntiAlias;
+    this->invalidateSnapshot(kAppearance);
 }
 
 void RenderNode::setClipPath(const std::optional<SkPath>& clipPath, SkClipOp op, bool doAntiAlias) {
@@ -211,10 +275,13 @@ void RenderNode::setClipPath(const std::optional<SkPath>& clipPath, SkClipOp op,
     this->clipPath = clipPath;
     this->clipOp = op;
     this->clipAntiAlias = doAntiAlias;
+    this->invalidateSnapshot(kAppearance);
 }
 
 void RenderNode::setClip(bool clip) {
     this->clip = clip;
+    // Clipping bounds the recording's cull rect to the node's own bounds.
+    this->invalidateSnapshot(kContent);
 }
 
 const SkMatrix& RenderNode::getMatrix() {
@@ -222,19 +289,37 @@ const SkMatrix& RenderNode::getMatrix() {
     return this->transformMatrix;
 }
 
-SkCanvas *RenderNode::beginRecording() {
-    bool measureDrawBounds = !clip || shadowElevation > 0.0f;
+bool RenderNode::mayDrawOutOfBounds() const {
+    return !this->clip || this->shadowElevation > 0.0f;
+}
+
+// The content cache and the snapshot recorded from it have to agree on the cull rect
+// and the bounding hierarchy, or the two cull differently and report different bounds.
+// They cannot share a recorder: the snapshot is taken while the member one may be
+// mid-recording.
+SkCanvas *RenderNode::beginRecordingInto(SkPictureRecorder& target) {
+    bool measureDrawBounds = this->mayDrawOutOfBounds();
     const SkRect& bounds = measureDrawBounds ? UNKNOWN_BOUNDS : SkRect::MakeWH(this->bounds.width(), this->bounds.height());
     SkBBHFactory* bbhFactory = measureDrawBounds ? this->bbhFactory : nullptr;
-    return this->recorder.beginRecording(bounds, bbhFactory);
+    return target.beginRecording(bounds, bbhFactory);
+}
+
+SkCanvas *RenderNode::beginRecording() {
+    return this->beginRecordingInto(this->recorder);
 }
 
 void RenderNode::endRecording() {
     this->contentCache = this->recorder.finishRecordingAsDrawable();
+    this->updateDependencies();
+    this->invalidateSnapshot(kContent | kDependencies);
 }
 
 void RenderNode::drawInto(SkCanvas* canvas) {
     canvas->drawDrawable(this);
+}
+
+SkFlattenable::Type RenderNode::getFlattenableType() const {
+    return kRenderNode_Type;
 }
 
 SkRect RenderNode::onGetBounds() {
@@ -243,8 +328,7 @@ SkRect RenderNode::onGetBounds() {
     if (this->contentCache) {
         result = this->contentCache->getBounds().makeOffset(this->bounds.left(), this->bounds.top());
     } else {
-        bool measureDrawBounds = !clip || shadowElevation > 0.0f;
-        result = measureDrawBounds ? UNKNOWN_BOUNDS : this->bounds;
+        result = this->mayDrawOutOfBounds() ? UNKNOWN_BOUNDS : this->bounds;
     }
     if (!this->matrixIdentity) {
         this->transformMatrix.mapRect(&result);
@@ -257,6 +341,12 @@ size_t RenderNode::onApproximateBytesUsed() {
     if (this->contentCache) {
         contentSize += this->contentCache->approximateBytesUsed();
     }
+    if (this->contentSnapshot) {
+        // A snapshot references the snapshots nested in it rather than copying them, and
+        // SkPicture already counts those, so the figure reported here covers the subtree
+        // and must not be summed with the figures its dependencies report.
+        contentSize += this->contentSnapshot->approximateBytesUsed();
+    }
     if (this->clipPath) {
         contentSize += this->clipPath->approximateBytesUsed();
     }
@@ -265,6 +355,9 @@ size_t RenderNode::onApproximateBytesUsed() {
 
 void RenderNode::onDraw(SkCanvas* canvas) {
     this->updateMatrix();
+    // Whatever records this draw inlines the node afresh, so its next change must be
+    // relayed to the observers again.
+    this->observersNotified = false;
 
     canvas->translate(this->bounds.left(), this->bounds.top());
     if (!this->matrixIdentity) {
@@ -299,14 +392,23 @@ void RenderNode::onDraw(SkCanvas* canvas) {
     }
 
     if (this->alpha < 1.0f && !this->layerPaint) {
+        // Modulating alpha at replay time has to reach every recorded paint, which
+        // means unrolling the content. A snapshot is only cheap while it is replayed
+        // whole, so this path neither records nor uses one.
         AlphaModulateFilterCanvas alphaCanvas(canvas, this->alpha);
         alphaCanvas.drawDrawable(this->contentCache.get());
     } else {
-        canvas->drawDrawable(this->contentCache.get());
+        this->updateSnapshot();
+        if (this->contentSnapshot) {
+            canvas->drawPicture(this->contentSnapshot.get());
+        } else {
+            canvas->drawDrawable(this->contentCache.get());
+        }
     }
 }
 
-
+// The shadow is drawn against the context's light geometry, which is expressed in the
+// coordinate space the resulting picture is replayed in.
 sk_sp<SkPicture> RenderNode::onMakePictureSnapshot() {
     SkCanvas* canvas = this->beginRecording();
     UnrollDrawableCanvas unrollCanvas(canvas);
@@ -350,6 +452,87 @@ void RenderNode::updateMatrix() {
     }
     this->matrixDirty = false;
     this->matrixIdentity = this->transformMatrix.isIdentity();
+}
+
+// Maintains the invariant `node in dep->observers` iff `dep in node->dependencies`.
+// Only dependencies holds references: an observer registration is a bare back
+// pointer, so that a parent drawing a child does not form a reference cycle.
+void RenderNode::releaseDependencies() {
+    for (auto renderNode : this->dependencies) {
+        renderNode->observers.erase(this);
+        renderNode->unref();
+    }
+    this->dependencies.clear();
+}
+
+void RenderNode::updateDependencies() {
+    this->releaseDependencies();
+
+    DependencyTrackerCanvas dependencyTracker(&this->dependencies);
+    this->contentCache->draw(&dependencyTracker);
+
+    for (auto renderNode : this->dependencies) {
+        renderNode->observers.insert(this);
+    }
+}
+
+void RenderNode::updateSnapshot() {
+    if (!this->contentTransformInvariant || !this->contentCache || this->contentSnapshot) {
+        return;
+    }
+
+    SkPictureRecorder snapshotRecorder;
+    SkCanvas* recordingCanvas = this->beginRecordingInto(snapshotRecorder);
+    // Force unrolling all drawables to avoid nested snapshotting.
+    UnrollDrawableCanvas unrollCanvas(recordingCanvas);
+    this->contentCache->draw(&unrollCanvas);
+    this->contentSnapshot = snapshotRecorder.finishRecordingAsPicture();
+}
+
+bool RenderNode::drawsTransformDependentContent() const {
+    return this->shadowElevation > 0.0f;
+}
+
+bool RenderNode::preventsObserverSnapshot() const {
+    return this->drawsTransformDependentContent() || !this->contentTransformInvariant;
+}
+
+// Snapshots hold the recorded content only: the transform, clip, layer, alpha and
+// shadow are applied around them in onDraw, so which of those changed decides whether
+// this node's own snapshot survives. None of them leaves the snapshots that inlined
+// this node's drawing valid, so those are dropped whatever the change was.
+void RenderNode::invalidateSnapshot(uint32_t changes) {
+    this->notifyDrawingChanged();
+
+    if (changes & kDependencies) {
+        bool wasPreventingObserverSnapshot = this->preventsObserverSnapshot();
+        this->contentTransformInvariant = true;
+        for (auto renderNode : this->dependencies) {
+            if (renderNode->preventsObserverSnapshot()) {
+                this->contentTransformInvariant = false;
+                break;
+            }
+        }
+        // Observers derive their own snapshottability from this bit, so a change to it has
+        // to reach them even if they were already told stale this frame.
+        if (this->preventsObserverSnapshot() != wasPreventingObserverSnapshot) {
+            this->observersNotified = false;
+        }
+    }
+    if (changes & kContent) {
+        this->contentSnapshot.reset();
+    }
+
+    // Observers inlined this node's drawing when they recorded, so they hold a stale copy
+    // until they record again -- which redraws this node and clears the flag below. One
+    // notification per draw is enough to invalidate them, and telling them once instead of
+    // once per observer path bounds the walk when a node is drawn through several of them.
+    if (!this->observersNotified) {
+        this->observersNotified = true;
+        for (auto renderNode : this->observers) {
+            renderNode->invalidateSnapshot(kContent | kDependencies);
+        }
+    }
 }
 
 void RenderNode::drawShadow(SkCanvas *canvas, const LightGeometry& lightGeometry, const LightInfo& lightInfo) {

--- a/skiko/src/commonMain/cpp/common/node/RenderNode.cpp
+++ b/skiko/src/commonMain/cpp/common/node/RenderNode.cpp
@@ -466,18 +466,25 @@ void RenderNode::releaseDependencies() {
 }
 
 void RenderNode::updateDependencies() {
+    // Tracking exists to invalidate the snapshots that inline this node, so it is only
+    // worth its replay of the recording where snapshots are taken at all.
+    if (!this->context->shouldUseSnapshotCache()) {
+        return;
+    }
     this->releaseDependencies();
+    if (this->contentCache) {
+        DependencyTrackerCanvas dependencyTracker(&this->dependencies);
+        this->contentCache->draw(&dependencyTracker);
 
-    DependencyTrackerCanvas dependencyTracker(&this->dependencies);
-    this->contentCache->draw(&dependencyTracker);
-
-    for (auto renderNode : this->dependencies) {
-        renderNode->observers.insert(this);
+        for (auto renderNode : this->dependencies) {
+            renderNode->observers.insert(this);
+        }
     }
 }
 
 void RenderNode::updateSnapshot() {
-    if (!this->contentTransformInvariant || !this->contentCache || this->contentSnapshot) {
+    if (!this->context->shouldUseSnapshotCache() || !this->contentTransformInvariant ||
+        !this->contentCache || this->contentSnapshot) {
         return;
     }
 

--- a/skiko/src/commonMain/cpp/common/node/RenderNodeContext.cpp
+++ b/skiko/src/commonMain/cpp/common/node/RenderNodeContext.cpp
@@ -3,8 +3,8 @@
 namespace skiko {
 namespace node {
 
-RenderNodeContext::RenderNodeContext(bool measureDrawBounds)
-    : measureDrawBounds(measureDrawBounds) {
+RenderNodeContext::RenderNodeContext(bool measureDrawBounds, bool snapshotCache)
+    : measureDrawBounds(measureDrawBounds), snapshotCache(snapshotCache) {
 }
 
 void RenderNodeContext::setLightingInfo(

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skiko/node/RenderNode.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skiko/node/RenderNode.kt
@@ -16,6 +16,11 @@ import org.jetbrains.skia.impl.Library.Companion.staticLoad
  * everything from scratch. A RenderNode only needs its display list re-recorded when its content
  * alone should be changed. RenderNodes can also be transformed without re-recording the display
  * list through the transform properties.</p>
+ *
+ * <p>A tree of RenderNodes is owned by a single thread. Recording, changing a property and drawing
+ * all mutate the node they are called on, and changing a property of one node may also mutate the
+ * nodes drawing it, so none of them may run concurrently with each other. A picture recorded from
+ * a node is immutable and can be replayed on any thread.</p>
  */
 class RenderNode internal constructor(ptr: NativePointer, managed: Boolean = true) : RefCnt(ptr, managed) {
     private companion object {

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skiko/node/RenderNodeContext.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skiko/node/RenderNodeContext.kt
@@ -30,7 +30,7 @@ class RenderNodeContext internal constructor(ptr: NativePointer, managed: Boolea
      */
     constructor(
         measureDrawBounds: Boolean = false,
-        snapshotCache: Boolean = false,
+        snapshotCache: Boolean = true,
     ) : this(RenderNodeContext_nMake(measureDrawBounds, snapshotCache)) {
         Stats.onNativeCall()
     }

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skiko/node/RenderNodeContext.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skiko/node/RenderNodeContext.kt
@@ -11,9 +11,27 @@ class RenderNodeContext internal constructor(ptr: NativePointer, managed: Boolea
         }
     }
 
+    /**
+     * @param measureDrawBounds whether the nodes created with this context measure the area their
+     * content actually covers as they record it. Without it a node whose content is not confined to
+     * its own bounds -- one that does not clip, or that casts a shadow -- reports a conservative
+     * area instead, and whatever records that node widens its cull rect to match. It costs a
+     * bounding hierarchy built over every recording.
+     * @param snapshotCache whether the nodes created with this context record their content into an
+     * immutable picture once and replay it until the content changes, instead of re-recording it for
+     * every frame. It trades memory for recording time, so it pays off for trees that are drawn far
+     * more often than they change, and costs for trees that are re-recorded every frame. A node that
+     * casts a shadow, and every node drawing it, replays its content directly either way, because
+     * the shadow it draws depends on where it is replayed.
+     *
+     * Snapshotting is a property of the whole tree rather than of a single node: a snapshot inlines
+     * the drawing of the nodes below it, so those nodes have to report their changes upwards for it
+     * to be dropped in time.
+     */
     constructor(
         measureDrawBounds: Boolean = false,
-    ) : this(RenderNodeContext_nMake(measureDrawBounds)) {
+        snapshotCache: Boolean = false,
+    ) : this(RenderNodeContext_nMake(measureDrawBounds, snapshotCache)) {
         Stats.onNativeCall()
     }
 
@@ -43,7 +61,7 @@ class RenderNodeContext internal constructor(ptr: NativePointer, managed: Boolea
 }
 
 @ExternalSymbolName("org_jetbrains_skiko_node_RenderNodeContextKt_RenderNodeContext_1nMake")
-private external fun RenderNodeContext_nMake(measureDrawBounds: Boolean): NativePointer
+private external fun RenderNodeContext_nMake(measureDrawBounds: Boolean, snapshotCache: Boolean): NativePointer
 
 @ExternalSymbolName("org_jetbrains_skiko_node_RenderNodeContextKt_RenderNodeContext_1nSetLightingInfo")
 private external fun RenderNodeContext_nSetLightingInfo(ptr: NativePointer, centerX: Float, centerY: Float, centerZ: Float, radius: Float, ambientShadowAlpha: Float, spotShadowAlpha: Float)

--- a/skiko/src/commonTest/kotlin/org/jetbrains/skiko/node/RenderNodeTest.kt
+++ b/skiko/src/commonTest/kotlin/org/jetbrains/skiko/node/RenderNodeTest.kt
@@ -3,6 +3,7 @@ package org.jetbrains.skiko.node
 import org.jetbrains.skia.*
 import org.jetbrains.skia.tests.assertCloseEnough
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -77,6 +78,99 @@ class RenderNodeTest {
         surface.close()
         node.close()
         context.close()
+    }
+
+    @Test
+    fun drawingANodeDoesNotReferenceTheDrawingNodeBack() {
+        val context = RenderNodeContext()
+        val parent = RenderNode(context)
+        val child = RenderNode(context)
+
+        child.bounds = Rect(0f, 0f, 10f, 10f)
+        child.beginRecording().drawRect(0f, 0f, 10f, 10f, Paint())
+        child.endRecording()
+
+        parent.bounds = Rect(0f, 0f, 10f, 10f)
+        child.drawInto(parent.beginRecording())
+        parent.endRecording()
+
+        // The parent holds the child alive, through both its recorded content and
+        // its dependencies set. The child must not hold the parent back: a cycle
+        // would leak both for the lifetime of the process.
+        assertEquals(1, parent.refCount)
+        assertTrue(child.refCount > 1)
+
+        // Releasing the parent releases everything it held on the child.
+        parent.close()
+        assertEquals(1, child.refCount)
+
+        child.close()
+        context.close()
+    }
+
+    @Test
+    fun mutatedTreeRendersLikeAFreshOne() {
+        // A node keeps its snapshot across property changes and rebuilds it when the
+        // content it inlined changes. Either way the result has to match a tree built
+        // with those values from the start.
+        fun render(mutate: Boolean): ByteArray {
+            val context = RenderNodeContext()
+            val parent = RenderNode(context)
+            val child = RenderNode(context)
+            val surface = Surface.makeRasterN32Premul(16, 16)
+
+            child.bounds = Rect(0f, 0f, 8f, 8f)
+            child.beginRecording().drawRect(0f, 0f, 8f, 8f, Paint().apply { color = Color.RED })
+            child.endRecording()
+            parent.bounds = Rect(0f, 0f, 16f, 16f)
+            val parentCanvas = parent.beginRecording()
+            parentCanvas.drawRect(0f, 0f, 16f, 16f, Paint().apply { color = Color.GREEN })
+            child.drawInto(parentCanvas)
+            parent.endRecording()
+
+            if (mutate) {
+                // Draw once so both nodes snapshot, then move the child and re-record it.
+                parent.drawInto(surface.canvas)
+                surface.canvas.clear(Color.TRANSPARENT)
+            }
+            child.translationX = 4f
+            child.beginRecording().drawRect(0f, 0f, 8f, 8f, Paint().apply { color = Color.BLUE })
+            child.endRecording()
+            parent.drawInto(surface.canvas)
+
+            val bytes = Bitmap.makeFromImage(surface.makeImageSnapshot()).readPixels()!!
+            surface.close(); parent.close(); child.close(); context.close()
+            return bytes
+        }
+
+        assertContentEquals(render(mutate = false), render(mutate = true))
+    }
+
+    @Test
+    fun nodeRecordedIntoPictureBeforeItHasDrawn() {
+        // Recording the node into a picture replays it, which builds the snapshot on the
+        // way. That recording must not go through the recorder the replay is using.
+        val context = RenderNodeContext()
+        val node = RenderNode(context)
+        node.bounds = Rect(0f, 0f, 100f, 100f)
+        node.beginRecording().drawRect(Rect(20f, 20f, 40f, 40f), Paint().apply { color = Color.RED })
+        node.endRecording()
+
+        val recorder = PictureRecorder()
+        node.drawInto(recorder.beginRecording(Rect(0f, 0f, 100f, 100f)))
+        val picture = recorder.finishRecordingAsPicture()
+
+        val viaPicture = Surface.makeRasterN32Premul(100, 100)
+        viaPicture.canvas.drawPicture(picture)
+        val direct = Surface.makeRasterN32Premul(100, 100)
+        node.drawInto(direct.canvas)
+
+        assertContentEquals(
+            Bitmap.makeFromImage(direct.makeImageSnapshot()).readPixels()!!,
+            Bitmap.makeFromImage(viaPicture.makeImageSnapshot()).readPixels()!!
+        )
+
+        picture.close(); viaPicture.close(); direct.close(); node.close(); context.close()
     }
 
     @Test

--- a/skiko/src/commonTest/kotlin/org/jetbrains/skiko/node/RenderNodeTest.kt
+++ b/skiko/src/commonTest/kotlin/org/jetbrains/skiko/node/RenderNodeTest.kt
@@ -82,7 +82,7 @@ class RenderNodeTest {
 
     @Test
     fun drawingANodeDoesNotReferenceTheDrawingNodeBack() {
-        val context = RenderNodeContext()
+        val context = RenderNodeContext(snapshotCache = true)
         val parent = RenderNode(context)
         val child = RenderNode(context)
 
@@ -113,16 +113,10 @@ class RenderNodeTest {
         // A node keeps its snapshot across property changes and rebuilds it when the
         // content it inlined changes. Either way the result has to match a tree built
         // with those values from the start.
-        fun render(mutate: Boolean): ByteArray {
-            val context = RenderNodeContext()
-            val parent = RenderNode(context)
-            val child = RenderNode(context)
-            val surface = Surface.makeRasterN32Premul(16, 16)
-
-            child.bounds = Rect(0f, 0f, 8f, 8f)
-            child.beginRecording().drawRect(0f, 0f, 8f, 8f, Paint().apply { color = Color.RED })
-            child.endRecording()
-            parent.bounds = Rect(0f, 0f, 16f, 16f)
+        fun rendered(mutate: Boolean) = render { canvas ->
+            val child = node(Rect(0f, 0f, 8f, 8f))
+            fill(child, Color.RED, 8f, 8f)
+            val parent = node(Rect(0f, 0f, 16f, 16f))
             val parentCanvas = parent.beginRecording()
             parentCanvas.drawRect(0f, 0f, 16f, 16f, Paint().apply { color = Color.GREEN })
             child.drawInto(parentCanvas)
@@ -130,27 +124,46 @@ class RenderNodeTest {
 
             if (mutate) {
                 // Draw once so both nodes snapshot, then move the child and re-record it.
-                parent.drawInto(surface.canvas)
-                surface.canvas.clear(Color.TRANSPARENT)
+                parent.drawInto(canvas)
+                canvas.clear(Color.TRANSPARENT)
             }
             child.translationX = 4f
-            child.beginRecording().drawRect(0f, 0f, 8f, 8f, Paint().apply { color = Color.BLUE })
-            child.endRecording()
-            parent.drawInto(surface.canvas)
-
-            val bytes = Bitmap.makeFromImage(surface.makeImageSnapshot()).readPixels()!!
-            surface.close(); parent.close(); child.close(); context.close()
-            return bytes
+            fill(child, Color.BLUE, 8f, 8f)
+            parent.drawInto(canvas)
         }
 
-        assertContentEquals(render(mutate = false), render(mutate = true))
+        assertContentEquals(rendered(mutate = false), rendered(mutate = true))
+    }
+
+    @Test
+    fun snapshotCacheRendersTheSameAsDirectDrawing() {
+        // Renders a parent/child pair twice, changing only properties that are
+        // applied around the recorded content, which the snapshot has to survive.
+        fun rendered(snapshotCache: Boolean) = render(snapshotCache = snapshotCache) { canvas ->
+            val child = node(Rect(0f, 0f, 8f, 8f))
+            fill(child, Color.RED, 8f, 8f)
+            val parent = node(Rect(0f, 0f, 16f, 16f))
+            val parentCanvas = parent.beginRecording()
+            parentCanvas.drawRect(0f, 0f, 16f, 16f, Paint().apply { color = Color.GREEN })
+            child.drawInto(parentCanvas)
+            parent.endRecording()
+
+            parent.drawInto(canvas)
+
+            child.alpha = 0.5f
+            child.translationX = 4f
+            parent.alpha = 0.75f
+            parent.drawInto(canvas)
+        }
+
+        assertContentEquals(rendered(snapshotCache = false), rendered(snapshotCache = true))
     }
 
     @Test
     fun nodeRecordedIntoPictureBeforeItHasDrawn() {
         // Recording the node into a picture replays it, which builds the snapshot on the
         // way. That recording must not go through the recorder the replay is using.
-        val context = RenderNodeContext()
+        val context = RenderNodeContext(snapshotCache = true)
         val node = RenderNode(context)
         node.bounds = Rect(0f, 0f, 100f, 100f)
         node.beginRecording().drawRect(Rect(20f, 20f, 40f, 40f), Paint().apply { color = Color.RED })
@@ -174,6 +187,154 @@ class RenderNodeTest {
     }
 
     @Test
+    fun nestedContentInvalidatesTheSnapshotsThatInlinedIt() {
+        // A node under alpha is unrolled rather than snapshotted, so it holds no snapshot
+        // of its own while still being inlined into the one above it. It has to keep
+        // relaying changes from below, or that outer snapshot replays stale content.
+        fun rendered(middleAlpha: Float, mutate: Boolean) = render { canvas ->
+            val inner = node(Rect(0f, 0f, 8f, 8f))
+            fill(inner, if (mutate) Color.RED else Color.BLUE, 8f, 8f)
+            val middle = node(Rect(0f, 0f, 16f, 16f))
+            middle.alpha = middleAlpha
+            inner.drawInto(middle.beginRecording())
+            middle.endRecording()
+            val outer = node(Rect(0f, 0f, 16f, 16f))
+            middle.drawInto(outer.beginRecording())
+            outer.endRecording()
+
+            if (mutate) {
+                // Draw once so the whole chain snapshots, then re-record the innermost node.
+                outer.drawInto(canvas)
+                canvas.clear(Color.TRANSPARENT)
+                fill(inner, Color.BLUE, 8f, 8f)
+            }
+            outer.drawInto(canvas)
+        }
+
+        for (middleAlpha in listOf(1.0f, 0.5f)) {
+            assertContentEquals(
+                rendered(middleAlpha, mutate = false),
+                rendered(middleAlpha, mutate = true),
+                "stale content at middleAlpha=$middleAlpha"
+            )
+        }
+    }
+
+    @Test
+    fun changesBetweenTwoDrawsReachTheSnapshots() {
+        // The observers are notified once per draw, so of several changes made between two
+        // draws only the first is relayed. Each sequence below starts from content the
+        // snapshot would still be showing if a later change went unnoticed.
+        fun rendered(
+            before: RenderScope.(RenderNode) -> Unit,
+            change: RenderScope.(middle: RenderNode, inner: RenderNode) -> Unit
+        ) = render { canvas ->
+            val inner = node(Rect(0f, 0f, 8f, 8f))
+            before(inner)
+            val middle = node(Rect(0f, 0f, 16f, 16f))
+            inner.drawInto(middle.beginRecording())
+            middle.endRecording()
+            val outer = node(Rect(0f, 0f, 16f, 16f))
+            middle.drawInto(outer.beginRecording())
+            outer.endRecording()
+
+            outer.drawInto(canvas)
+            canvas.clear(Color.TRANSPARENT)
+            change(middle, inner)
+            outer.drawInto(canvas)
+        }
+
+        val expected = rendered({ fill(it, Color.BLUE, 8f, 8f) }, { _, _ -> })
+
+        assertContentEquals(expected, rendered({ fill(it, Color.RED, 8f, 8f) }, { _, inner ->
+            fill(inner, Color.GREEN, 8f, 8f)
+            fill(inner, Color.BLUE, 8f, 8f)
+        }), "the second of two re-recordings was not relayed")
+
+        assertContentEquals(expected, rendered({ fill(it, Color.RED, 8f, 8f) }, { middle, inner ->
+            inner.drawInto(middle.beginRecording())
+            middle.endRecording()
+            fill(inner, Color.BLUE, 8f, 8f)
+        }), "a change below a re-recorded node was not relayed")
+
+        assertContentEquals(expected, rendered({ it.translationX = 8f; fill(it, Color.BLUE, 8f, 8f) }, { _, inner ->
+            fill(inner, Color.BLUE, 8f, 8f)
+            inner.translationX = 0f
+        }), "a position change after a re-recording was not relayed")
+    }
+
+    @Test
+    fun aChangeReachesEveryObserverOfTheChangedNode() {
+        // The shared node is drawn by both branches, so one notification has to invalidate
+        // the snapshots of both.
+        fun rendered(mutate: Boolean) = render { canvas ->
+            val shared = node(Rect(0f, 0f, 8f, 8f))
+            fill(shared, if (mutate) Color.RED else Color.BLUE, 8f, 8f)
+            val left = node(Rect(0f, 0f, 8f, 8f))
+            shared.drawInto(left.beginRecording())
+            left.endRecording()
+            val right = node(Rect(8f, 0f, 16f, 8f))
+            shared.drawInto(right.beginRecording())
+            right.endRecording()
+            val outer = node(Rect(0f, 0f, 16f, 16f))
+            val outerCanvas = outer.beginRecording()
+            left.drawInto(outerCanvas)
+            right.drawInto(outerCanvas)
+            outer.endRecording()
+
+            if (mutate) {
+                outer.drawInto(canvas)
+                canvas.clear(Color.TRANSPARENT)
+                fill(shared, Color.BLUE, 8f, 8f)
+            }
+            outer.drawInto(canvas)
+        }
+
+        assertContentEquals(rendered(mutate = false), rendered(mutate = true))
+    }
+
+    @Test
+    fun aShadowAppearingAfterAnotherChangeReachesTheSnapshots() {
+        // A shadow is only correct at the transform it was recorded under, so nothing
+        // inlining it may be snapshotted. That answer has to reach the nodes above even
+        // when they were already told about an earlier change and would otherwise be
+        // left alone until the next draw.
+        fun rendered(shadowAddedAfterADraw: Boolean) = render(width = 80, height = 80) { canvas ->
+            context.setLightingInfo(
+                centerX = 40f, centerY = 40f, centerZ = 100f, radius = 200f,
+                ambientShadowAlpha = 0.6f, spotShadowAlpha = 0.6f
+            )
+
+            val inner = node(Rect(0f, 0f, 20f, 20f))
+            inner.setClipRect(Rect(0f, 0f, 20f, 20f))
+            if (!shadowAddedAfterADraw) inner.shadowElevation = 8f
+            fill(inner, if (shadowAddedAfterADraw) Color.RED else Color.BLUE, 20f, 20f)
+            val middle = node(Rect(0f, 0f, 60f, 60f))
+            inner.drawInto(middle.beginRecording())
+            middle.endRecording()
+            val outer = node(Rect(0f, 0f, 60f, 60f))
+            middle.drawInto(outer.beginRecording())
+            outer.endRecording()
+
+            if (shadowAddedAfterADraw) {
+                outer.drawInto(canvas)
+                canvas.clear(Color.TRANSPARENT)
+                fill(inner, Color.BLUE, 20f, 20f)
+                inner.shadowElevation = 8f
+            }
+
+            // Replay somewhere other than where the content was recorded: a shadow that
+            // was snapshotted keeps the geometry it was recorded with and shows up here.
+            canvas.save()
+            canvas.translate(20f, 20f)
+            outer.drawInto(canvas)
+            canvas.restore()
+        }
+
+        assertContentEquals(rendered(shadowAddedAfterADraw = false), rendered(shadowAddedAfterADraw = true))
+    }
+
+    @Test
     fun pictureCullRect() {
         val context = RenderNodeContext(measureDrawBounds = true)
         val node = RenderNode(context)
@@ -194,5 +355,46 @@ class RenderNodeTest {
         picture.close()
         node.close()
         context.close()
+    }
+
+    // The nodes a test builds, the surface they draw into and the pixels that come out.
+    // Everything created here is closed even when an assertion fails partway through.
+    private class RenderScope(val context: RenderNodeContext, val surface: Surface) {
+        private val nodes = mutableListOf<RenderNode>()
+
+        fun node(bounds: Rect): RenderNode =
+            RenderNode(context).also {
+                it.bounds = bounds
+                nodes += it
+            }
+
+        fun fill(node: RenderNode, color: Int, width: Float, height: Float) {
+            node.beginRecording().drawRect(0f, 0f, width, height, Paint().apply { this.color = color })
+            node.endRecording()
+        }
+
+        fun close() {
+            nodes.forEach(RenderNode::close)
+            surface.close()
+            context.close()
+        }
+    }
+
+    private fun render(
+        width: Int = 16,
+        height: Int = 16,
+        snapshotCache: Boolean = true,
+        body: RenderScope.(canvas: Canvas) -> Unit
+    ): ByteArray {
+        val scope = RenderScope(
+            RenderNodeContext(snapshotCache = snapshotCache),
+            Surface.makeRasterN32Premul(width, height)
+        )
+        try {
+            scope.body(scope.surface.canvas)
+            return Bitmap.makeFromImage(scope.surface.makeImageSnapshot()).readPixels()!!
+        } finally {
+            scope.close()
+        }
     }
 }

--- a/skiko/src/jvmMain/cpp/common/node/RenderNodeContext.jvm.cpp
+++ b/skiko/src/jvmMain/cpp/common/node/RenderNodeContext.jvm.cpp
@@ -3,8 +3,8 @@
 #include "node/RenderNodeContext.h"
 
 extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_node_RenderNodeContextKt_RenderNodeContext_1nMake
-  (JNIEnv *env, jclass jclass, jboolean measureDrawBounds) {
-    auto instance = sk_make_sp<skiko::node::RenderNodeContext>(measureDrawBounds);
+  (JNIEnv *env, jclass jclass, jboolean measureDrawBounds, jboolean snapshotCache) {
+    auto instance = sk_make_sp<skiko::node::RenderNodeContext>(measureDrawBounds, snapshotCache);
     return reinterpret_cast<jlong>(instance.release());
 }
 

--- a/skiko/src/nativeJsMain/cpp/node/RenderNodeContext.native.cpp
+++ b/skiko/src/nativeJsMain/cpp/node/RenderNodeContext.native.cpp
@@ -2,8 +2,8 @@
 #include "node/RenderNodeContext.h"
 
 SKIKO_EXPORT KNativePointer org_jetbrains_skiko_node_RenderNodeContextKt_RenderNodeContext_1nMake
-  (KBoolean measureDrawBounds) {
-    auto instance = sk_make_sp<skiko::node::RenderNodeContext>(measureDrawBounds);
+  (KBoolean measureDrawBounds, KBoolean snapshotCache) {
+    auto instance = sk_make_sp<skiko::node::RenderNodeContext>(measureDrawBounds, snapshotCache);
     return reinterpret_cast<KNativePointer>(instance.release());
 }
 


### PR DESCRIPTION
[SKIKO-1000](https://youtrack.jetbrains.com/issue/SKIKO-1000) Pre-cache SkPicture snapshots for RenderNode