### PR TITLE
Remove BreakIterator.clone() method

### DIFF
--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/BreakIterator.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/BreakIterator.kt
@@ -306,14 +306,6 @@ class BreakIterator internal constructor(ptr: NativePointer) : Managed(ptr, _Fin
     }
 
     /**
-     * Create a copy of this iterator
-     */
-    fun clone(): BreakIterator {
-        Stats.onNativeCall()
-        return BreakIterator(withErrorGuard("Failed to clone") { _nClone(_ptr, it) })
-    }
-
-    /**
      * Returns character index of the text boundary that was most recently
      * returned by [], [], [],
      * [], [], [] or
@@ -551,10 +543,6 @@ private external fun BreakIterator_nGetFinalizer(): NativePointer
 @ExternalSymbolName("org_jetbrains_skia_BreakIterator__1nMake")
 @ModuleImport("./skiko.mjs", "org_jetbrains_skia_BreakIterator__1nMake")
 private external fun _nMake(type: Int, locale: InteropPointer, errorCode: InteropPointer): NativePointer
-
-@ExternalSymbolName("org_jetbrains_skia_BreakIterator__1nClone")
-@ModuleImport("./skiko.mjs", "org_jetbrains_skia_BreakIterator__1nClone")
-private external fun _nClone(ptr: NativePointer, errorCode: InteropPointer): NativePointer
 
 @ExternalSymbolName("org_jetbrains_skia_BreakIterator__1nCurrent")
 @ModuleImport("./skiko.mjs", "org_jetbrains_skia_BreakIterator__1nCurrent")

--- a/skiko/src/commonTest/kotlin/org/jetbrains/skia/BreakIteratorTests.kt
+++ b/skiko/src/commonTest/kotlin/org/jetbrains/skia/BreakIteratorTests.kt
@@ -34,31 +34,6 @@ class BreakIteratorTests {
     }
 
     @Test
-    @SkipJsTarget
-    @SkipWasmTarget
-    fun breakIteratorCloneTest() {
-        // Wasm, iOS, and tvOS builds of Skia do not include required data to implement those iterators,
-        // see `third_party/externals/icu/flutter/README.md`.
-        if (hostOs == OS.Ios || hostOs == OS.Tvos)
-            return
-
-        if (isDebugModeOnJvm)
-            throw Error("This test is usually crashes in DEBUG mode")
-
-        val boundary = BreakIterator.makeWordInstance()
-
-        val boundaryCloned = boundary.clone()
-
-        boundaryCloned.setText("家捷克的软件开发公司 ,software development company")
-        val boundariesList = listOf(1, 3, 4, 6, 8, 10, 11, 12, 20, 21, 32, 33, 40)
-        assertContentEquals(boundariesList, boundaryCloned.asSequence().toList())
-
-        assertEquals(0, boundaryCloned.first())
-        assertEquals(40, boundaryCloned.last())
-        reachabilityBarrier(boundary)
-    }
-
-    @Test
     @SkipNativeTarget
     @SkipJvmTarget
     fun breakIteratorSentenceFailsOnJsTest() {

--- a/skiko/src/jvmMain/cpp/common/BreakIterator.cc
+++ b/skiko/src/jvmMain/cpp/common/BreakIterator.cc
@@ -29,18 +29,6 @@ extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_BreakIteratorKt__1nMa
       return reinterpret_cast<jlong>(instance);
 }
 
-extern "C" JNIEXPORT jint JNICALL Java_org_jetbrains_skia_BreakIteratorKt__1nClone
-  (JNIEnv* env, jclass jclass, jlong ptr, jintArray errorCode) {
-    UBreakIterator* instance = reinterpret_cast<UBreakIterator*>(static_cast<uintptr_t>(ptr));
-    UErrorCode status = U_ZERO_ERROR;
-    UBreakIterator* clone = ubrk_clone(instance, &status);
-    if (U_FAILURE(status)) {
-      env->ThrowNew(java::lang::RuntimeException::cls, u_errorName(status));
-      return 0;
-    } else
-      return reinterpret_cast<jlong>(clone);
-}
-
 extern "C" JNIEXPORT jint JNICALL Java_org_jetbrains_skia_BreakIteratorKt__1nCurrent
   (JNIEnv* env, jclass jclass, jlong ptr) {
     UBreakIterator* instance = reinterpret_cast<UBreakIterator*>(static_cast<uintptr_t>(ptr));

--- a/skiko/src/nativeJsMain/cpp/BreakIterator.cc
+++ b/skiko/src/nativeJsMain/cpp/BreakIterator.cc
@@ -29,20 +29,6 @@ SKIKO_EXPORT KNativePointer org_jetbrains_skia_BreakIterator__1nMake
 }
 
 
-SKIKO_EXPORT KNativePointer org_jetbrains_skia_BreakIterator__1nClone
-  (KNativePointer ptr, KInt* errorCode) {
-    UBreakIterator* instance = reinterpret_cast<UBreakIterator*>(ptr);
-    UErrorCode status = U_ZERO_ERROR;
-    UBreakIterator* clone = ubrk_clone(instance, &status);
-
-    errorCode[0] = status;
-    if (U_FAILURE(status)) {
-      return 0;
-    } else
-      return reinterpret_cast<KNativePointer>(clone);
-}
-
-
 SKIKO_EXPORT KInt org_jetbrains_skia_BreakIterator__1nCurrent
   (KNativePointer ptr) {
     UBreakIterator* instance = reinterpret_cast<UBreakIterator*>(ptr);


### PR DESCRIPTION
This PR is split-off from and is a prerequisite of Clang-cl PR: #1020

BreakIterator.clone() is broken on JVM and seemingly leads to a use-after-free behaviour. Clang-cl makes this issue more visible, likely due to address sanitisation.

Explanation why it is deleted in an internal channel: https://jetbrains.slack.com/archives/C02DDNREC77/p1738678000232729
* `breakIteratorCloneTest` is failing with an access violation in Debug mode with additional checks, so using it wasn't safe
* it is not used anywhere

This is a breaking change and will require bumping Skiko version to 0.9.0.
