### PR TITLE
accelerate swing rendering

### DIFF
--- a/samples/SkiaAwtSample/build.gradle.kts
+++ b/samples/SkiaAwtSample/build.gradle.kts
@@ -9,6 +9,7 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
+    maven("https://packages.jetbrains.team/maven/p/ij/intellij-dependencies")
 }
 
 val osName = System.getProperty("os.name")
@@ -41,6 +42,7 @@ dependencies {
     implementation("org.jetbrains.skiko:skiko-awt-runtime-$target:$version")
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit")
+    implementation("com.jetbrains:jbr-api:1.4.0")
 }
 
 application {

--- a/skiko/build.gradle.kts
+++ b/skiko/build.gradle.kts
@@ -45,6 +45,7 @@ allprojects {
 
 repositories {
     mavenCentral()
+    maven("https://packages.jetbrains.team/maven/p/ij/intellij-dependencies")
 }
 
 kotlin {
@@ -159,6 +160,7 @@ kotlin {
             dependencies {
                 implementation(kotlin("stdlib"))
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
+                implementation("com.jetbrains:jbr-api:1.4.0")
             }
         }
         val commonTest by getting {

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/AcceleratedSwingDrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/AcceleratedSwingDrawer.kt
@@ -1,0 +1,32 @@
+package org.jetbrains.skiko.swing
+
+import org.jetbrains.skia.Surface
+import java.awt.Graphics2D
+import com.jetbrains.JBR
+import java.awt.GraphicsConfiguration
+import java.awt.GraphicsEnvironment
+import java.awt.Image
+
+class AcceleratedSwingDrawer : SwingDrawer {
+    private val sharedTextures =
+        if (JBR.isSharedTexturesSupported()) JBR.getSharedTextures()
+        else throw UnsupportedOperationException("Shared textures are not supported")
+
+    private var imageWrapper: Image? = null
+    private var texturePtr: Long = 0L
+    private var gc: GraphicsConfiguration = GraphicsEnvironment.getLocalGraphicsEnvironment()
+        .defaultScreenDevice.defaultConfiguration
+
+    override fun draw(g: Graphics2D, surface: Surface, texture: Long) {
+        if (g.deviceConfiguration != gc || texturePtr != texture || imageWrapper == null) {
+            gc = g.deviceConfiguration
+            texturePtr = texture
+            imageWrapper = sharedTextures.wrapTexture(gc, texturePtr)
+        }
+
+        g.drawImage(imageWrapper, 0, 0, null)
+    }
+
+    override fun dispose() {
+    }
+}

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/Direct3DSwingRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/Direct3DSwingRedrawer.kt
@@ -86,7 +86,7 @@ internal class Direct3DSwingRedrawer(
         surface.flushAndSubmit(syncCpu = false)
         waitForCompletion(device, texturePtr)
 
-        getSwingDrawer().draw(g, surface)
+        getSwingDrawer().draw(g, surface, texture = texturePtr)
     }
 
     private fun makeRenderTarget() = BackendRenderTarget(

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/Direct3DSwingRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/Direct3DSwingRedrawer.kt
@@ -10,7 +10,6 @@ import org.jetbrains.skiko.graphicapi.InternalDirectXApi.disposeDevice
 import org.jetbrains.skiko.graphicapi.InternalDirectXApi.makeDirectXContext
 import org.jetbrains.skiko.graphicapi.InternalDirectXApi.makeDirectXRenderTargetOffScreen
 import org.jetbrains.skiko.graphicapi.InternalDirectXApi.makeDirectXTexture
-import org.jetbrains.skiko.graphicapi.InternalDirectXApi.readPixels
 import org.jetbrains.skiko.graphicapi.InternalDirectXApi.waitForCompletion
 import java.awt.Graphics2D
 
@@ -31,8 +30,6 @@ internal class Direct3DSwingRedrawer(
     }
 
     private val device = createDirectXOffscreenDevice(adapter)
-
-    private val swingOffscreenDrawer = SwingOffscreenDrawer(swingLayerProperties)
 
     private val context = if (device == 0L) {
         throw RenderException("Failed to create DirectX12 device.")
@@ -89,7 +86,7 @@ internal class Direct3DSwingRedrawer(
         surface.flushAndSubmit(syncCpu = false)
         waitForCompletion(device, texturePtr)
 
-        swingOffscreenDrawer.draw(g, surface)
+        getSwingDrawer().draw(g, surface)
     }
 
     private fun makeRenderTarget() = BackendRenderTarget(

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/Direct3DSwingRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/Direct3DSwingRedrawer.kt
@@ -87,18 +87,9 @@ internal class Direct3DSwingRedrawer(
 
     fun flush(surface: Surface, g: Graphics2D) {
         surface.flushAndSubmit(syncCpu = false)
-
-        val bytesArraySize = surface.width * surface.height * 4
-        if (bytesToDraw.size != bytesArraySize) {
-            bytesToDraw = ByteArray(bytesArraySize)
-        }
-
         waitForCompletion(device, texturePtr)
-        if(!readPixels(texturePtr, bytesToDraw)) {
-            throw RenderException("Couldn't read pixels")
-        }
 
-        swingOffscreenDrawer.draw(g, bytesToDraw, surface.width, surface.height)
+        swingOffscreenDrawer.draw(g, surface)
     }
 
     private fun makeRenderTarget() = BackendRenderTarget(

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/LinuxOpenGLSwingRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/LinuxOpenGLSwingRedrawer.kt
@@ -87,22 +87,7 @@ internal class LinuxOpenGLSwingRedrawer(
 
     private fun flush(surface: Surface, g: Graphics2D) {
         surface.flushAndSubmit(syncCpu = true)
-
-        val width = surface.width
-        val height = surface.height
-
-        val dstRowBytes = width * 4
-        if (storage.width != width || storage.height != height) {
-            storage.allocPixelsFlags(ImageInfo.makeS32(width, height, ColorAlphaType.PREMUL), false)
-            bytesToDraw = ByteArray(storage.getReadPixelsArraySize(dstRowBytes = dstRowBytes))
-        }
-        // TODO: it copies pixels from GPU to CPU, so it is really slow
-        surface.readPixels(storage, 0, 0)
-
-        val successfulRead = storage.readPixels(bytesToDraw, dstRowBytes = dstRowBytes)
-        if (successfulRead) {
-            swingOffscreenDrawer.draw(g, bytesToDraw, width, height)
-        }
+        swingOffscreenDrawer.draw(g, surface)
     }
 
     /**

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/LinuxOpenGLSwingRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/LinuxOpenGLSwingRedrawer.kt
@@ -85,7 +85,7 @@ internal class LinuxOpenGLSwingRedrawer(
 
     private fun flush(surface: Surface, g: Graphics2D) {
         surface.flushAndSubmit(syncCpu = true)
-        getSwingDrawer().draw(g, surface)
+        getSwingDrawer().draw(g, surface, texture = 0)
     }
 
     /**

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/LinuxOpenGLSwingRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/LinuxOpenGLSwingRedrawer.kt
@@ -13,8 +13,6 @@ internal class LinuxOpenGLSwingRedrawer(
         onDeviceChosen("OpenGL OffScreen") // TODO: properly choose device
     }
 
-    private val swingOffscreenDrawer = SwingOffscreenDrawer(swingLayerProperties)
-
     private val offScreenContextPtr: Long = makeOffScreenContext().also {
         if (it == 0L) {
             throw RenderException("Cannot create OpenGL context")
@@ -87,7 +85,7 @@ internal class LinuxOpenGLSwingRedrawer(
 
     private fun flush(surface: Surface, g: Graphics2D) {
         surface.flushAndSubmit(syncCpu = true)
-        swingOffscreenDrawer.draw(g, surface)
+        getSwingDrawer().draw(g, surface)
     }
 
     /**

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/MetalSwingRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/MetalSwingRedrawer.kt
@@ -70,7 +70,7 @@ internal class MetalSwingRedrawer(
 
     private fun flush(surface: Surface, g: Graphics2D) {
         surface.flushAndSubmit(syncCpu = true)
-        getSwingDrawer().draw(g, surface)
+        getSwingDrawer().draw(g, surface, texture = texturePtr)
     }
 
     override fun rendererInfo(): String {

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/MetalSwingRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/MetalSwingRedrawer.kt
@@ -15,7 +15,7 @@ import java.awt.Graphics2D
  * For on-screen rendering see [org.jetbrains.skiko.redrawer.MetalRedrawer].
  *
  * @see SwingRedrawerBase
- * @see SwingOffscreenDrawer
+ * @see SoftwareSwingDrawer
  */
 internal class MetalSwingRedrawer(
     swingLayerProperties: SwingLayerProperties,
@@ -38,8 +38,6 @@ internal class MetalSwingRedrawer(
     init {
         onContextInit()
     }
-
-    private val swingOffscreenDrawer = SwingOffscreenDrawer(swingLayerProperties)
 
     override fun dispose() {
         disposeMetalTexture(texturePtr)
@@ -72,7 +70,7 @@ internal class MetalSwingRedrawer(
 
     private fun flush(surface: Surface, g: Graphics2D) {
         surface.flushAndSubmit(syncCpu = true)
-        swingOffscreenDrawer.draw(g, surface)
+        getSwingDrawer().draw(g, surface)
     }
 
     override fun rendererInfo(): String {

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SoftwareSwingDrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SoftwareSwingDrawer.kt
@@ -12,13 +12,18 @@ import java.nio.ByteOrder
 import java.nio.IntBuffer
 import kotlin.math.*
 
-internal class SwingOffscreenDrawer(
+/**
+ * A specialized implementation of [SwingDrawer] that uses a [BufferedImage] as the intermediate storage.
+ * It dumps the [Surface] underlining raster image directly to the [BufferedImage] back buffer and draws the image onto
+ * the given [Graphics2D].
+ */
+internal class SoftwareSwingDrawer(
     private val swingLayerProperties: SwingLayerProperties
-) {
+) : SwingDrawer {
     private var bufferedImage = BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB_PRE)
     private var bitmap = Bitmap()
 
-    fun draw(g: Graphics2D, surface: Surface) {
+    override fun draw(g: Graphics2D, surface: Surface) {
         val width = surface.width
         val height = surface.height
         if (bitmap.width != width || bitmap.height != height) {
@@ -28,6 +33,10 @@ internal class SwingOffscreenDrawer(
         surface.readPixels(bitmap, 0, 0)
         bufferedImage = createImageFromBytes(bitmap.peekPixels()!!.addr, width, height)
         drawImage(g, bufferedImage)
+    }
+
+    override fun dispose() {
+        bitmap.close()
     }
 
     private fun createImageFromBytes(

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SoftwareSwingDrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SoftwareSwingDrawer.kt
@@ -23,7 +23,7 @@ internal class SoftwareSwingDrawer(
     private var bufferedImage = BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB_PRE)
     private var bitmap = Bitmap()
 
-    override fun draw(g: Graphics2D, surface: Surface) {
+    override fun draw(g: Graphics2D, surface: Surface, texture: Long) {
         val width = surface.width
         val height = surface.height
         if (bitmap.width != width || bitmap.height != height) {

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SoftwareSwingRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SoftwareSwingRedrawer.kt
@@ -58,6 +58,6 @@ internal class SoftwareSwingRedrawer(
     }
 
     private fun flush(g: Graphics2D, surface: Surface) = autoCloseScope() {
-        getSwingDrawer().draw(g, surface)
+        getSwingDrawer().draw(g, surface, texture = 0)
     }
 }

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SoftwareSwingRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SoftwareSwingRedrawer.kt
@@ -13,7 +13,7 @@ import java.awt.Graphics2D
  * Content to draw is provided by [SkikoRenderDelegate].
  *
  * @see SwingRedrawerBase
- * @see SwingOffscreenDrawer
+ * @see SoftwareSwingDrawer
  */
 internal class SoftwareSwingRedrawer(
     swingLayerProperties: SwingLayerProperties,
@@ -27,8 +27,6 @@ internal class SoftwareSwingRedrawer(
     init {
         onDeviceChosen("Software")
     }
-
-    private val swingOffscreenDrawer = SwingOffscreenDrawer(swingLayerProperties)
 
     private val storage = Bitmap()
 
@@ -60,6 +58,6 @@ internal class SoftwareSwingRedrawer(
     }
 
     private fun flush(g: Graphics2D, surface: Surface) = autoCloseScope() {
-        swingOffscreenDrawer.draw(g, surface)
+        getSwingDrawer().draw(g, surface)
     }
 }

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SwingDrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SwingDrawer.kt
@@ -1,0 +1,14 @@
+package org.jetbrains.skiko.swing
+
+import org.jetbrains.skia.Surface
+import java.awt.Graphics2D
+
+/**
+ * Interface for rendering Skia surfaces onto an AWT/Swing `Graphics2D` instance.
+ *
+ * @see SoftwareSwingDrawer
+ */
+interface SwingDrawer {
+    fun draw(g: Graphics2D, surface: Surface)
+    fun dispose()
+}

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SwingDrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SwingDrawer.kt
@@ -9,6 +9,6 @@ import java.awt.Graphics2D
  * @see SoftwareSwingDrawer
  */
 interface SwingDrawer {
-    fun draw(g: Graphics2D, surface: Surface)
+    fun draw(g: Graphics2D, surface: Surface, texture: Long)
     fun dispose()
 }

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SwingOffscreenDrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SwingOffscreenDrawer.kt
@@ -1,116 +1,51 @@
 package org.jetbrains.skiko.swing
 
+import org.jetbrains.skia.Bitmap
+import org.jetbrains.skia.ColorAlphaType
+import org.jetbrains.skia.ImageInfo
+import org.jetbrains.skia.Surface
+import org.jetbrains.skia.impl.BufferUtil
 import java.awt.*
 import java.awt.geom.AffineTransform
 import java.awt.image.*
-import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.nio.IntBuffer
 import kotlin.math.*
 
-// TODO: extract this code to a library and share it with JCEF implementation in IntelliJ
-//  since this code is mostly taken from intellij repository with some small changes
 internal class SwingOffscreenDrawer(
     private val swingLayerProperties: SwingLayerProperties
 ) {
-    @Volatile
-    private var volatileImage: VolatileImage? = null
-    private var bufferedImage: BufferedImage? = null
-    private var bufferedImageGraphics: Graphics2D? = null
+    private var bufferedImage = BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB_PRE)
+    private var bitmap = Bitmap()
 
-    /**
-     * Draws rendered image that is represented by [bytes] on [g].
-     *
-     * If size of the rendered image is bigger than size from [swingLayerProperties]
-     * then only part of the image will be drawn on [g].
-     *
-     * @param g graphics where rendered picture given in [bytes] should be drawn
-     * @param bytes bytes of rendered picture in little endian order
-     * @param width width of rendered picture in real pixels
-     * @param height height of rendered picture in real pixels
-     */
-    fun draw(g: Graphics2D, bytes: ByteArray, width: Int, height: Int) {
-        val dirtyRectangles = listOf(
-            Rectangle(0, 0, width, height)
-        )
-        val image = createImageFromBytes(bytes, width, height, dirtyRectangles)
-        var vi = volatileImage
+    fun draw(g: Graphics2D, surface: Surface) {
+        val width = surface.width
+        val height = surface.height
+        if (bitmap.width != width || bitmap.height != height) {
+            bitmap.allocPixelsFlags(ImageInfo.makeS32(width, height, ColorAlphaType.PREMUL), false)
+        }
 
-        do {
-            if (vi == null || vi.width != swingLayerProperties.width || vi.height != swingLayerProperties.height) {
-                vi = createVolatileImage(image)
-            }
-            drawVolatileImage(vi, image)
-            when (vi.validate(swingLayerProperties.graphicsConfiguration)) {
-                VolatileImage.IMAGE_RESTORED -> drawVolatileImage(vi, image)
-                VolatileImage.IMAGE_INCOMPATIBLE -> vi = createVolatileImage(image)
-            }
-            g.drawImage(vi, 0, 0, null)
-        } while (vi!!.contentsLost())
-
-        volatileImage = vi
+        surface.readPixels(bitmap, 0, 0)
+        bufferedImage = createImageFromBytes(bitmap.peekPixels()!!.addr, width, height)
+        drawImage(g, bufferedImage)
     }
 
     private fun createImageFromBytes(
-        bytes: ByteArray,
+        pBytes: Long,
         width: Int,
         height: Int,
-        dirtyRectangles: List<Rectangle>
     ): BufferedImage {
-        val src = ByteBuffer.wrap(bytes)
-        if (bufferedImage == null || bufferedImage?.width != width || bufferedImage?.height != height) {
-            bufferedImage?.flush()
+        if (bufferedImage.width != width || bufferedImage.height != height) {
             bufferedImage = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB_PRE)
-            bufferedImageGraphics = bufferedImage?.createGraphics()
-        } else {
-            bufferedImageGraphics?.clearRect(0,0, width, height)
         }
-        val image = bufferedImage!!
+        val image = bufferedImage
 
         val dstData = (image.raster.dataBuffer as DataBufferInt).data
+        val src = BufferUtil.getByteBufferFromPointer(pBytes, width * height * 4)
         val srcData: IntBuffer = src.order(ByteOrder.LITTLE_ENDIAN).asIntBuffer()
-        for (rect in dirtyRectangles) {
-            if (rect.width < image.width) {
-                for (line in rect.y until rect.y + rect.height) {
-                    val offset: Int = line * image.width + rect.x
-                    srcData.position(offset)[dstData, offset, min(
-                        rect.width.toDouble(),
-                        (src.capacity() - offset).toDouble()
-                    ).toInt()]
-                }
-            } else { // optimized for a buffer wide dirty rect
-                val offset: Int = rect.y * image.width
-                srcData.position(offset)[dstData, offset, min(
-                    (rect.height * image.width).toDouble(),
-                    (src.capacity() - offset).toDouble()
-                ).toInt()]
-            }
-        }
+        srcData.position(0).get(dstData, 0, min(image.height * image.width, srcData.capacity()))
 
         return image
-    }
-
-    private fun createVolatileImage(image: BufferedImage): VolatileImage {
-        val vi = swingLayerProperties.graphicsConfiguration.createCompatibleVolatileImage(
-            swingLayerProperties.width,
-            swingLayerProperties.height,
-            Transparency.TRANSLUCENT
-        )
-        drawVolatileImage(vi, image)
-        return vi
-    }
-
-    private fun drawVolatileImage(vi: VolatileImage, image: BufferedImage) {
-        val g = vi.graphics.create() as Graphics2D
-        try {
-            g.background = Color(0, 0, 0, 0)
-            g.composite = AlphaComposite.Src
-            g.clearRect(0, 0, swingLayerProperties.width, swingLayerProperties.height)
-            val imageClipRectangle = Rectangle(0, 0, swingLayerProperties.width, swingLayerProperties.height)
-            drawImage(g, image, sourceBounds = imageClipRectangle)
-        } finally {
-            g.dispose()
-        }
     }
 
     private fun drawImage(

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SwingRedrawerBase.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SwingRedrawerBase.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.skiko.swing
 
 import com.jetbrains.JBR
+import com.jetbrains.SharedTextures
 import org.jetbrains.skia.*
 import org.jetbrains.skiko.*
 import org.jetbrains.skiko.SkiaLayerAnalytics.DeviceAnalytics
@@ -102,6 +103,11 @@ internal abstract class SwingRedrawerBase(
     protected fun getSwingDrawer(): SwingDrawer = swingDrawer
 
     private fun createSwingDrawer(): SwingDrawer {
+        if (graphicsApi == GraphicsApi.METAL &&
+            JBR.isSharedTexturesSupported() && JBR.getSharedTextures().textureType == SharedTextures.METAL_TEXTURE_TYPE
+        ) {
+            return AcceleratedSwingDrawer()
+        }
         if (JBR.isNativeRasterLoaderSupported()) {
             // TODO: check if not OpenGL
             // TODO: report a bug

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SwingRedrawerBase.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SwingRedrawerBase.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.skiko.swing
 
+import com.jetbrains.JBR
 import org.jetbrains.skia.*
 import org.jetbrains.skiko.*
 import org.jetbrains.skiko.SkiaLayerAnalytics.DeviceAnalytics
@@ -29,6 +30,7 @@ internal abstract class SwingRedrawerBase(
     private val rendererAnalytics = analytics.renderer(Version.skiko, hostOs, graphicsApi)
     private var deviceAnalytics: DeviceAnalytics? = null
     private var isDisposed = false
+    private val swingDrawer = createSwingDrawer()
 
     init {
         rendererAnalytics.init()
@@ -39,6 +41,7 @@ internal abstract class SwingRedrawerBase(
     override fun dispose() {
         require(!isDisposed) { "$javaClass is disposed" }
         isDisposed = true
+        swingDrawer.dispose()
     }
 
     final override fun redraw(g: Graphics2D) {
@@ -94,5 +97,17 @@ internal abstract class SwingRedrawerBase(
             }
             isFirstFrameRendered = true
         }
+    }
+
+    protected fun getSwingDrawer(): SwingDrawer = swingDrawer
+
+    private fun createSwingDrawer(): SwingDrawer {
+        if (JBR.isNativeRasterLoaderSupported()) {
+            // TODO: check if not OpenGL
+            // TODO: report a bug
+            return VolatileImageSwingDrawer()
+        }
+
+        return SoftwareSwingDrawer(swingLayerProperties)
     }
 }

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/VolatileImageSwingDrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/VolatileImageSwingDrawer.kt
@@ -1,0 +1,49 @@
+package org.jetbrains.skiko.swing
+
+import com.jetbrains.JBR
+import org.jetbrains.skia.Bitmap
+import org.jetbrains.skia.ColorAlphaType
+import org.jetbrains.skia.ImageInfo
+import org.jetbrains.skia.Surface
+import java.awt.Graphics2D
+import java.awt.Transparency
+import java.awt.image.VolatileImage
+
+/**
+ * A specialized implementation of [SwingDrawer] that uses a [VolatileImage] as the intermediate storage.
+ * It dumps the [Surface] underlining raster and uploads it to the [VolatileImage] using
+ * <a href="https://github.com/JetBrains/JetBrainsRuntimeApi/blob/main/src/com/jetbrains/NativeRasterLoader.java">NativeRasterLoader JBR API</a>
+ */
+class VolatileImageSwingDrawer : SwingDrawer {
+    private var volatileImage: VolatileImage? = null
+    private val bitmap: Bitmap = Bitmap()
+    private val rasterLoader =
+        if (JBR.isNativeRasterLoaderSupported()) JBR.getNativeRasterLoader()
+        else throw UnsupportedOperationException("NativeRasterLoader is not supported")
+
+    override fun draw(g: Graphics2D, surface: Surface) {
+        if (volatileImage?.width != surface.width || volatileImage?.height != surface.height ||
+            volatileImage?.validate(g.deviceConfiguration) == VolatileImage.IMAGE_INCOMPATIBLE
+        ) {
+            volatileImage = g.deviceConfiguration.createCompatibleVolatileImage(
+                surface.width,
+                surface.height,
+                Transparency.TRANSLUCENT
+            )
+        }
+
+        if (bitmap.width != surface.width || bitmap.height != surface.height) {
+            bitmap.allocPixelsFlags(ImageInfo.makeS32(surface.width, surface.height, ColorAlphaType.PREMUL), false)
+        }
+        surface.readPixels(bitmap, 0, 0)
+
+        do {
+            rasterLoader.loadNativeRaster(volatileImage, bitmap.peekPixels()!!.addr, bitmap.width, bitmap.height, 0, 0)
+            g.drawImage(volatileImage, 0, 0, null)
+        } while (volatileImage!!.contentsLost())
+    }
+
+    override fun dispose() {
+        bitmap.close()
+    }
+}

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/VolatileImageSwingDrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/VolatileImageSwingDrawer.kt
@@ -21,7 +21,7 @@ class VolatileImageSwingDrawer : SwingDrawer {
         if (JBR.isNativeRasterLoaderSupported()) JBR.getNativeRasterLoader()
         else throw UnsupportedOperationException("NativeRasterLoader is not supported")
 
-    override fun draw(g: Graphics2D, surface: Surface) {
+    override fun draw(g: Graphics2D, surface: Surface, texture: Long) {
         if (volatileImage?.width != surface.width || volatileImage?.height != surface.height ||
             volatileImage?.validate(g.deviceConfiguration) == VolatileImage.IMAGE_INCOMPATIBLE
         ) {


### PR DESCRIPTION
This PR contains:
1. Simplify work with rendering via BuffferedImage. It also gives some performance grow
2. Introduce direct raster loading to the VolatileImage
3. Introduce shared textures on Metal

**Perfomance measurements.**
`BufImg` - drawing with `SoftwareSwingDrawer`. It's a simplified version of the current drawer.
`VolImg` - drawing with loading native raster directly to the volatile image - `VolatileImageSwingDrawer`
`SharedTexture` - `AcceleratedSwingDrawer`

`Render(ms)` - time to prepare the offscreen image(without dumping it to Bitmap) but including the synchronization(`Surface#flushAndSubmit`)
`Draw(ms)` - time to draw the rendered image to `Graphics2D` including dumping the image from the texture to a `Bitmap` if needed.
`Total(ms)` - time to render the offscreen image and draw it to `Graphics2D`. Basically time to run `SwingRedrawerBase#onRender`
```
MetalSwingRedrawer
Test: ClocksAwt
Size: 3200x2400(real size)
MacBook Pro M1 M1 Max

              Current    BufImg     VolImg   SharedTexture
FPS              64        76         82        122
Render(ms)      8.25      8.16       8.08       8.03
Draw(ms)        7.02      4.62       3.81       0.0008
Total(ms)      15.28     12.79      11.90       8.04
```

Direct3DSwingRedrawer
```
TODO
```

LinuxOpenGLSwingRedrawer
```
TODO
```