### PR TITLE
metal: accelerate swing rendering

### DIFF
--- a/samples/SkiaAwtSample/build.gradle.kts
+++ b/samples/SkiaAwtSample/build.gradle.kts
@@ -9,6 +9,7 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
+    maven("https://packages.jetbrains.team/maven/p/ij/intellij-dependencies")
 }
 
 val osName = System.getProperty("os.name")
@@ -39,6 +40,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-swing:1.5.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.5.0")
     implementation("org.jetbrains.skiko:skiko-awt-runtime-$target:$version")
+    implementation("com.jetbrains:jbr-api:1.4.0")
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit")
 }

--- a/samples/SkiaAwtSample/build.gradle.kts
+++ b/samples/SkiaAwtSample/build.gradle.kts
@@ -9,7 +9,6 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
-    maven("https://packages.jetbrains.team/maven/p/ij/intellij-dependencies")
 }
 
 val osName = System.getProperty("os.name")
@@ -40,7 +39,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-swing:1.5.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.5.0")
     implementation("org.jetbrains.skiko:skiko-awt-runtime-$target:$version")
-    implementation("com.jetbrains:jbr-api:1.4.0")
+    implementation("org.jetbrains.runtime:jbr-api:1.5.0")
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit")
 }

--- a/skiko/build.gradle.kts
+++ b/skiko/build.gradle.kts
@@ -45,6 +45,7 @@ allprojects {
 
 repositories {
     mavenCentral()
+    maven("https://packages.jetbrains.team/maven/p/ij/intellij-dependencies")
 }
 
 kotlin {
@@ -159,6 +160,7 @@ kotlin {
             dependencies {
                 implementation(kotlin("stdlib"))
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
+                implementation("com.jetbrains:jbr-api:1.4.0")
             }
         }
         val commonTest by getting {

--- a/skiko/build.gradle.kts
+++ b/skiko/build.gradle.kts
@@ -45,7 +45,6 @@ allprojects {
 
 repositories {
     mavenCentral()
-    maven("https://packages.jetbrains.team/maven/p/ij/intellij-dependencies")
 }
 
 kotlin {
@@ -160,7 +159,7 @@ kotlin {
             dependencies {
                 implementation(kotlin("stdlib"))
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
-                implementation("com.jetbrains:jbr-api:1.4.0")
+                implementation("org.jetbrains.runtime:jbr-api:1.5.0")
             }
         }
         val commonTest by getting {

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/AcceleratedSwingPainter.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/AcceleratedSwingPainter.kt
@@ -1,0 +1,36 @@
+package org.jetbrains.skiko.swing
+
+import org.jetbrains.skia.Surface
+import java.awt.Graphics2D
+import com.jetbrains.JBR
+import com.jetbrains.SharedTextures
+import org.jetbrains.skiko.RenderException
+import java.awt.GraphicsConfiguration
+import java.awt.GraphicsEnvironment
+import java.awt.Image
+
+class AcceleratedSwingPainter : SwingPainter {
+    private val sharedTextures =
+        if (JBR.isSharedTexturesSupported() &&
+            JBR.getSharedTextures().textureType == SharedTextures.METAL_TEXTURE_TYPE
+        ) JBR.getSharedTextures()
+        else throw RenderException("Shared textures are not supported")
+
+    private var imageWrapper: Image? = null
+    private var texturePtr: Long = 0L
+    private var gc: GraphicsConfiguration = GraphicsEnvironment.getLocalGraphicsEnvironment()
+        .defaultScreenDevice.defaultConfiguration
+
+    override fun paint(g: Graphics2D, surface: Surface, texture: Long) {
+        if (g.deviceConfiguration != gc || texturePtr != texture || imageWrapper == null) {
+            gc = g.deviceConfiguration
+            texturePtr = texture
+            imageWrapper = sharedTextures.wrapTexture(gc, texturePtr)
+        }
+
+        g.drawImage(imageWrapper, 0, 0, null)
+    }
+
+    override fun dispose() {
+    }
+}

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/AcceleratedSwingPainter.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/AcceleratedSwingPainter.kt
@@ -9,7 +9,7 @@ import java.awt.GraphicsConfiguration
 import java.awt.GraphicsEnvironment
 import java.awt.Image
 
-class AcceleratedSwingPainter : SwingPainter {
+internal class AcceleratedSwingPainter : SwingPainter {
     private val sharedTextures =
         if (JBR.isSharedTexturesSupported() &&
             JBR.getSharedTextures().textureType == SharedTextures.METAL_TEXTURE_TYPE

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/Direct3DSwingRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/Direct3DSwingRedrawer.kt
@@ -87,18 +87,9 @@ internal class Direct3DSwingRedrawer(
 
     fun flush(surface: Surface, g: Graphics2D) {
         surface.flushAndSubmit(syncCpu = false)
-
-        val bytesArraySize = surface.width * surface.height * 4
-        if (bytesToDraw.size != bytesArraySize) {
-            bytesToDraw = ByteArray(bytesArraySize)
-        }
-
         waitForCompletion(device, texturePtr)
-        if(!readPixels(texturePtr, bytesToDraw)) {
-            throw RenderException("Couldn't read pixels")
-        }
 
-        swingOffscreenDrawer.draw(g, bytesToDraw, surface.width, surface.height)
+        swingOffscreenDrawer.draw(g, surface)
     }
 
     private fun makeRenderTarget() = BackendRenderTarget(

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/LinuxOpenGLSwingRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/LinuxOpenGLSwingRedrawer.kt
@@ -13,7 +13,7 @@ internal class LinuxOpenGLSwingRedrawer(
         onDeviceChosen("OpenGL OffScreen") // TODO: properly choose device
     }
 
-    private val swingOffscreenDrawer = SwingOffscreenDrawer(swingLayerProperties)
+    private val painter: SwingPainter = SoftwareSwingPainter(swingLayerProperties)
 
     private val offScreenContextPtr: Long = makeOffScreenContext().also {
         if (it == 0L) {
@@ -37,6 +37,7 @@ internal class LinuxOpenGLSwingRedrawer(
         storage.close()
         disposeOffScreenBuffer(offScreenBufferPtr)
         disposeOffScreenContext(offScreenContextPtr)
+        painter.dispose()
         super.dispose()
     }
 
@@ -87,7 +88,7 @@ internal class LinuxOpenGLSwingRedrawer(
 
     private fun flush(surface: Surface, g: Graphics2D) {
         surface.flushAndSubmit(syncCpu = true)
-        swingOffscreenDrawer.draw(g, surface)
+        painter.paint(g, surface, 0)
     }
 
     /**

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/LinuxOpenGLSwingRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/LinuxOpenGLSwingRedrawer.kt
@@ -87,22 +87,7 @@ internal class LinuxOpenGLSwingRedrawer(
 
     private fun flush(surface: Surface, g: Graphics2D) {
         surface.flushAndSubmit(syncCpu = true)
-
-        val width = surface.width
-        val height = surface.height
-
-        val dstRowBytes = width * 4
-        if (storage.width != width || storage.height != height) {
-            storage.allocPixelsFlags(ImageInfo.makeS32(width, height, ColorAlphaType.PREMUL), false)
-            bytesToDraw = ByteArray(storage.getReadPixelsArraySize(dstRowBytes = dstRowBytes))
-        }
-        // TODO: it copies pixels from GPU to CPU, so it is really slow
-        surface.readPixels(storage, 0, 0)
-
-        val successfulRead = storage.readPixels(bytesToDraw, dstRowBytes = dstRowBytes)
-        if (successfulRead) {
-            swingOffscreenDrawer.draw(g, bytesToDraw, width, height)
-        }
+        swingOffscreenDrawer.draw(g, surface)
     }
 
     /**

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/MetalSwingRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/MetalSwingRedrawer.kt
@@ -26,6 +26,12 @@ internal class MetalSwingRedrawer(
         init {
             Library.load()
         }
+
+        private fun createSwingPainter(swingLayerProperties: SwingLayerProperties): SwingPainter = try {
+            AcceleratedSwingPainter()
+        } catch (_ : RenderException) {
+            SoftwareSwingPainter(swingLayerProperties)
+        }
     }
 
     private val adapter: MetalAdapter = chooseMetalAdapter(swingLayerProperties.adapterPriority).also {
@@ -39,7 +45,7 @@ internal class MetalSwingRedrawer(
         onContextInit()
     }
 
-    private val painter: SwingPainter = SoftwareSwingPainter(swingLayerProperties)
+    private val painter: SwingPainter = createSwingPainter(swingLayerProperties)
 
     override fun dispose() {
         disposeMetalTexture(texturePtr)

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/MetalSwingRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/MetalSwingRedrawer.kt
@@ -15,7 +15,7 @@ import java.awt.Graphics2D
  * For on-screen rendering see [org.jetbrains.skiko.redrawer.MetalRedrawer].
  *
  * @see SwingRedrawerBase
- * @see SwingOffscreenDrawer
+ * @see SoftwareSwingPainter
  */
 internal class MetalSwingRedrawer(
     swingLayerProperties: SwingLayerProperties,
@@ -39,12 +39,13 @@ internal class MetalSwingRedrawer(
         onContextInit()
     }
 
-    private val swingOffscreenDrawer = SwingOffscreenDrawer(swingLayerProperties)
+    private val painter: SwingPainter = SoftwareSwingPainter(swingLayerProperties)
 
     override fun dispose() {
         disposeMetalTexture(texturePtr)
         context.close()
         adapter.dispose()
+        painter.dispose()
         super.dispose()
     }
 
@@ -72,7 +73,7 @@ internal class MetalSwingRedrawer(
 
     private fun flush(surface: Surface, g: Graphics2D) {
         surface.flushAndSubmit(syncCpu = true)
-        swingOffscreenDrawer.draw(g, surface)
+        painter.paint(g, surface, texturePtr)
     }
 
     override fun rendererInfo(): String {

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SoftwareSwingPainter.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SoftwareSwingPainter.kt
@@ -13,13 +13,13 @@ import java.nio.ByteOrder
 import java.nio.IntBuffer
 import kotlin.math.*
 
-internal class SwingOffscreenDrawer(
+internal class SoftwareSwingPainter(
     private val swingLayerProperties: SwingLayerProperties
-) {
+) : SwingPainter {
     private var bufferedImage = BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB_PRE)
     private var bitmap = Bitmap()
 
-    fun draw(g: Graphics2D, surface: Surface) {
+    override fun paint(g: Graphics2D, surface: Surface, texture: Long) {
         val width = surface.width
         val height = surface.height
         if (bitmap.width != width || bitmap.height != height) {
@@ -30,6 +30,10 @@ internal class SwingOffscreenDrawer(
         val bufferPtr = bitmap.peekPixels()?.addr ?: throw RenderException("Can't get pixels address")
         bufferedImage = createImageFromBytes(bufferPtr, width, height)
         drawImage(g, bufferedImage)
+    }
+
+    override fun dispose() {
+        bitmap.close()
     }
 
     private fun createImageFromBytes(

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SoftwareSwingRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SoftwareSwingRedrawer.kt
@@ -13,7 +13,7 @@ import java.awt.Graphics2D
  * Content to draw is provided by [SkikoRenderDelegate].
  *
  * @see SwingRedrawerBase
- * @see SwingOffscreenDrawer
+ * @see SoftwareSwingPainter
  */
 internal class SoftwareSwingRedrawer(
     swingLayerProperties: SwingLayerProperties,
@@ -28,7 +28,7 @@ internal class SoftwareSwingRedrawer(
         onDeviceChosen("Software")
     }
 
-    private val swingOffscreenDrawer = SwingOffscreenDrawer(swingLayerProperties)
+    private val painter: SwingPainter = SoftwareSwingPainter(swingLayerProperties)
 
     private val storage = Bitmap()
 
@@ -39,6 +39,7 @@ internal class SoftwareSwingRedrawer(
     override fun dispose() {
         super.dispose()
         storage.close()
+        painter.dispose()
     }
 
     override fun onRender(g: Graphics2D, width: Int, height: Int, nanoTime: Long) = autoCloseScope {
@@ -60,6 +61,6 @@ internal class SoftwareSwingRedrawer(
     }
 
     private fun flush(g: Graphics2D, surface: Surface) = autoCloseScope() {
-        swingOffscreenDrawer.draw(g, surface)
+        painter.paint(g, surface, 0)
     }
 }

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SwingPainter.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SwingPainter.kt
@@ -1,0 +1,14 @@
+package org.jetbrains.skiko.swing
+
+import org.jetbrains.skia.Surface
+import java.awt.Graphics2D
+
+/**
+ * Interface for rendering Skia surfaces onto an AWT/Swing `Graphics2D` instance.
+ *
+ * @see SoftwareSwingDrawer
+ */
+interface SwingPainter {
+    fun paint(g: Graphics2D, surface: Surface, texture: Long)
+    fun dispose()
+}

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SwingPainter.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SwingPainter.kt
@@ -8,7 +8,7 @@ import java.awt.Graphics2D
  *
  * @see SoftwareSwingDrawer
  */
-interface SwingPainter {
+internal interface SwingPainter {
     fun paint(g: Graphics2D, surface: Surface, texture: Long)
     fun dispose()
 }


### PR DESCRIPTION
This PR contain:
1. Using shared metal textures with this JBR API - [SharedTextures](https://github.com/JetBrains/JetBrainsRuntimeApi/blob/main/src/com/jetbrains/SharedTextures.java). See `AcceleratedSwingPainter`.

2. Not ultimate, but visible improvement of the not accelerated painting for Windows(~%25), and MacOS(~20%). Unfortunately, didn't manage to see a positive change on Linux with XRender pipeline(about the same, probably few percents down). With opengl pipeline it also got ~20% faster. But currently our pipeline on linux is XRender
I got rid of make one extra copy of the raster image. See `SoftwareSwingPainter`

`com.jetbrains:jbr-api` size is about 44kb

Benchmarks:
`Redraw` - time to prepare the offscreen image including sync, but not including fetching texture to the CPU RAM
`Paint` - time to get the image from GPU(if needed) and draw onto `Graphics2D`
`Total` - total time to deliver the frame

```
MetalSwingRedrawer:
Image size: 3200x2344
Test: ClocksAwt
MacBook Pro M1 Max
java2d pipeline = Metal
               Current   SoftwareSwingPainter   AcceleratedSwingPainter
FPS              66             80                      141
Redraw(ms)      7.13           7.13                     6.92
Paint(ms)       7.65           6.07                     0.006
Total(ms)      14.78          12.16                     6.92


Direct3DSwingRedrawer
Image size: 3176x2284
Dell Prescision 5570, i9-12900H + GPU Nvidia
Test: ClocksAwt
java2d pipeline = GDI
               Current   SoftwareSwingPainter
FPS              32             41
Redraw(ms)     12.58          11.57
Paint(ms)      17.43          11.54
Total(ms)      29.93          23.11


LinuxOpenGLSwingRedrawer
Image size: 3192x2230
Dell Prescision 5570, i9-12900H + GPU Nvidia
Test: ClocksAwt
java2d pipeline = XRender
               Current   SoftwareSwingPainter
FPS              24             23
Redraw(ms)     20.07          19.64
Paint(ms)      19.69          22.73
Total(ms)      39.77          42.39
```