### PR TITLE
Fix the background flashing when closing a window/dialog.

### DIFF
--- a/skiko/src/awtMain/objectiveC/macos/MetalRedrawer.mm
+++ b/skiko/src/awtMain/objectiveC/macos/MetalRedrawer.mm
@@ -269,7 +269,6 @@ JNIEXPORT void JNICALL Java_org_jetbrains_skiko_redrawer_MetalRedrawer_disposeDe
         env->DeleteGlobalRef(device.layer.javaRef);
         [[NSNotificationCenter defaultCenter] removeObserver:device.occlusionObserver];
         [device.layer removeFromSuperlayer];
-        [CATransaction flush];
     }
 }
 


### PR DESCRIPTION
Flushing the transaction causes the window background to be visible for a frame when closing the window. 

Fixes: https://youtrack.jetbrains.com/issue/CMP-5651

This reverts https://github.com/JetBrains/skiko/pull/552. I have tested the IDE sample from Jewel, and that issue does not seem to reproduce anymore, even without flushing the transaction.


https://github.com/user-attachments/assets/a3c7c0ab-2342-4cae-8c52-669faeb1f516

