### PR TITLE
Call the listeners of PropertyKind.Renderer on render API fallback

### DIFF
--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/Actuals.awt.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/Actuals.awt.kt
@@ -8,7 +8,6 @@ import java.awt.datatransfer.DataFlavor
 import java.awt.datatransfer.StringSelection
 import java.awt.datatransfer.UnsupportedFlavorException
 import java.io.IOException
-import java.net.MalformedURLException
 import java.net.URI
 import java.net.URL
 import javax.swing.UIManager
@@ -16,13 +15,8 @@ import javax.swing.UIManager
 actual fun setSystemLookAndFeel() = UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName())
 
 internal actual fun makeDefaultRenderFactory(): RenderFactory =
-    object : RenderFactory {
-        override fun createRedrawer(
-            layer: SkiaLayer,
-            renderApi: GraphicsApi,
-            analytics: SkiaLayerAnalytics,
-            properties: SkiaLayerProperties
-        ): Redrawer = when (hostOs) {
+    RenderFactory { layer, renderApi, analytics, properties ->
+        when (hostOs) {
             OS.MacOS -> when (renderApi) {
                 GraphicsApi.SOFTWARE_COMPAT, GraphicsApi.SOFTWARE_FAST -> SoftwareRedrawer(layer, analytics, properties)
                 else -> MetalRedrawer(layer, analytics, properties)

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SkiaSwingLayer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SkiaSwingLayer.kt
@@ -4,11 +4,11 @@ import org.jetbrains.skia.Canvas
 import org.jetbrains.skiko.*
 import org.jetbrains.skiko.redrawer.RedrawerManager
 import java.awt.Component
+import java.awt.Graphics
 import java.awt.Graphics2D
 import java.awt.GraphicsConfiguration
 import javax.accessibility.Accessible
 import javax.accessibility.AccessibleContext
-import javax.swing.JComponent
 import javax.swing.JPanel
 import javax.swing.SwingUtilities.isEventDispatchThread
 
@@ -65,10 +65,13 @@ open class SkiaSwingLayer(
             get() = this@SkiaSwingLayer.properties.adapterPriority
     }
 
-    private val redrawerManager = RedrawerManager<SwingRedrawer>(properties.renderApi) { renderApi, oldRedrawer ->
-        oldRedrawer?.dispose()
-        createSwingRedrawer(swingLayerProperties, renderDelegateWithClipping, renderApi, analytics)
-    }
+    private val redrawerManager = RedrawerManager<SwingRedrawer>(
+        properties.renderApi,
+        redrawerFactory = { renderApi, oldRedrawer ->
+            oldRedrawer?.dispose()
+            createSwingRedrawer(swingLayerProperties, renderDelegateWithClipping, renderApi, analytics)
+        }
+    )
 
     private val redrawer: SwingRedrawer?
         get() = redrawerManager.redrawer
@@ -109,7 +112,7 @@ open class SkiaSwingLayer(
         }
     }
 
-    override fun paint(g: java.awt.Graphics) {
+    override fun paint(g: Graphics) {
         try {
             redrawer?.redraw(g as Graphics2D)
         } catch (e: RenderException) {

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/RenderFactory.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/RenderFactory.kt
@@ -2,7 +2,7 @@ package org.jetbrains.skiko
 
 import org.jetbrains.skiko.redrawer.*
 
-internal interface RenderFactory {
+internal fun interface RenderFactory {
     fun createRedrawer(
         layer: SkiaLayer,
         renderApi: GraphicsApi,


### PR DESCRIPTION
Currently, these listeners are only called when the `renderApi` is set manually, not when it changes to a fallback.