### PR TITLE
Do not change window properties during `MetalRedrawer` creation

### DIFF
--- a/skiko/src/awtMain/objectiveC/macos/MetalRedrawer.mm
+++ b/skiko/src/awtMain/objectiveC/macos/MetalRedrawer.mm
@@ -115,26 +115,6 @@ static jmethodID getOnOcclusionStateChangedMethodID(JNIEnv *env, jobject redrawe
     return onOcclusionStateChanged;
 }
 
-
-static void setWindowPropertiesUnsafe(NSWindow* window, jboolean transparency) {
-    if (window == NULL) return;
-    if (transparency) {
-        window.hasShadow = NO;
-    }
-}
-
-static void setWindowProperties(NSWindow* window, jboolean transparency) {
-    if (NSThread.currentThread.isMainThread) {
-        setWindowPropertiesUnsafe(window, transparency);
-    } else {
-        // In case of OpenJDK, EDT thread != NSThread main thread
-        __weak NSWindow *weakWindow = window;
-        dispatch_async(dispatch_get_main_queue(), ^{
-            setWindowPropertiesUnsafe(weakWindow, transparency);
-        });
-    }
-}
-
 extern "C"
 {
 
@@ -181,8 +161,6 @@ JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_redrawer_MetalRedrawer_createMe
         device.inflightSemaphore = dispatch_semaphore_create(device.layer.maximumDrawableCount);
 
         NSWindow* window = (__bridge NSWindow*) (void *) windowPtr;
-        setWindowProperties(window, transparency);
-
         jmethodID onOcclusionStateChanged = getOnOcclusionStateChangedMethodID(env, redrawer);
         device.occlusionObserver =
             [[NSNotificationCenter defaultCenter] addObserverForName:NSWindowDidChangeOcclusionStateNotification


### PR DESCRIPTION
Creating transparent views/renderers shouldn't disable window shadows

Context: [CMP-7752](https://youtrack.jetbrains.com/issue/CMP-7752) Interop blending should not disable window shadows on macOS