### PR TITLE
Minor cleanup.

### DIFF
--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
@@ -89,11 +89,6 @@ internal class MetalRedrawer(
         onContextInit()
     }
 
-    fun drawSync() {
-        layer.update(System.nanoTime())
-        performDraw()
-    }
-
     override fun dispose() = synchronized(drawLock) {
         frameDispatcher.cancel()
         contextHandler.dispose()

--- a/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
+++ b/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
@@ -98,11 +98,11 @@ class SkiaLayerTest {
                 override fun keyTyped(e: KeyEvent?) {
                     launch {
                         val redrawer = window.layer.redrawer as MetalRedrawer
-                        redrawer.drawSync()
+                        redrawer.redrawImmediately()
                         counter1 += 1
-                        redrawer.drawSync()
+                        redrawer.redrawImmediately()
                         counter2 += 1
-                        redrawer.drawSync()
+                        redrawer.redrawImmediately()
                     }
                 }
             })

--- a/skiko/src/awtTest/kotlin/org/jetbrains/skiko/util/UiTest.kt
+++ b/skiko/src/awtTest/kotlin/org/jetbrains/skiko/util/UiTest.kt
@@ -59,11 +59,6 @@ internal class UiTestScope(
         init {
             setupContent()
         }
-
-        override fun dispose() {
-            layer.dispose()
-            super.dispose()
-        }
     }
 }
 

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skiko/Logging.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skiko/Logging.kt
@@ -44,7 +44,7 @@ class DefaultConsoleLogger(override val isTraceEnabled: Boolean = false,
 
     companion object {
         fun fromLevel(level: String): DefaultConsoleLogger {
-            val logLevel = LogLevel.values().filter { it.name == level }.firstOrNull() ?: LogLevel.INFO
+            val logLevel = LogLevel.entries.firstOrNull { it.name == level } ?: LogLevel.INFO
             return DefaultConsoleLogger(
                 isTraceEnabled = LogLevel.TRACE.noMoreVerboseThan(logLevel),
                 isDebugEnabled = LogLevel.DEBUG.noMoreVerboseThan(logLevel),


### PR DESCRIPTION
1. In `DefaultConsoleLogger.fromLevel` use `LogLevel.entries.firstOrNull` instead of `LogLevel.values().filter().firstOrNull`.
2. `UiTestWindow` does not need to override `dispose` to dispose the layer, as the layer disposes itself when the window is disposed (from `removeNotify`).
3. Remove `MetalRedrawer.drawSync`, which was only used in tests, as there's already `redrawImmediately`.