### PR TITLE
[Metal] Fix window background flash on dispose/hide while animation is running

### DIFF
--- a/skiko/src/awtMain/objectiveC/macos/MetalRedrawer.mm
+++ b/skiko/src/awtMain/objectiveC/macos/MetalRedrawer.mm
@@ -246,6 +246,7 @@ JNIEXPORT void JNICALL Java_org_jetbrains_skiko_redrawer_MetalRedrawer_disposeDe
         MetalDevice *device = (__bridge_transfer MetalDevice *) (void *) devicePtr;
         env->DeleteGlobalRef(device.layer.javaRef);
         [[NSNotificationCenter defaultCenter] removeObserver:device.occlusionObserver];
+        device.layer.displaySyncEnabled = false;  // Prevents window background flashing when the window is disposed
         [device.layer removeFromSuperlayer];
     }
 }


### PR DESCRIPTION
The issue with flashing on dispose is fixed by disabling `displaySyncEnabled` on the native layer in `MetalRedrawer_disposeDevice`.

The issue with flashing on hide is fixed by avoiding a call to `MetalRedrawer.setVisible(false)` in the particular scenario of the window becoming hidden.