### PR TITLE
SkiaMultiplatformSample. Fix showing render API after fallback

### DIFF
--- a/samples/SkiaMultiplatformSample/src/awtMain/kotlin/org/jetbrains/skiko/sample/AwtClocks.kt
+++ b/samples/SkiaMultiplatformSample/src/awtMain/kotlin/org/jetbrains/skiko/sample/AwtClocks.kt
@@ -8,7 +8,7 @@ import java.awt.event.MouseMotionListener
 import java.awt.event.MouseWheelEvent
 import java.awt.event.MouseWheelListener
 
-class AwtClocks(private val layer: SkiaLayer) : Clocks({ layer.renderApi }), MouseMotionListener, MouseWheelListener {
+class AwtClocks(private val layer: SkiaLayer) : Clocks(layer::renderApi), MouseMotionListener, MouseWheelListener {
     private val cursorManager = CursorManager()
 
     init {

--- a/samples/SkiaMultiplatformSample/src/awtMain/kotlin/org/jetbrains/skiko/sample/AwtClocks.kt
+++ b/samples/SkiaMultiplatformSample/src/awtMain/kotlin/org/jetbrains/skiko/sample/AwtClocks.kt
@@ -8,7 +8,7 @@ import java.awt.event.MouseMotionListener
 import java.awt.event.MouseWheelEvent
 import java.awt.event.MouseWheelListener
 
-class AwtClocks(private val layer: SkiaLayer) : Clocks(layer.renderApi), MouseMotionListener, MouseWheelListener {
+class AwtClocks(private val layer: SkiaLayer) : Clocks({ layer.renderApi }), MouseMotionListener, MouseWheelListener {
     private val cursorManager = CursorManager()
 
     init {

--- a/samples/SkiaMultiplatformSample/src/commonMain/kotlin/org/jetbrains/skiko/sample/Clocks.kt
+++ b/samples/SkiaMultiplatformSample/src/commonMain/kotlin/org/jetbrains/skiko/sample/Clocks.kt
@@ -12,7 +12,6 @@ import org.jetbrains.skia.paragraph.TextStyle
 import org.jetbrains.skiko.FPSCounter
 import org.jetbrains.skiko.GraphicsApi
 import org.jetbrains.skiko.OS
-import org.jetbrains.skiko.SkiaLayer
 import org.jetbrains.skiko.SkikoRenderDelegate
 import org.jetbrains.skiko.currentSystemTheme
 import org.jetbrains.skiko.hostOs
@@ -20,7 +19,7 @@ import kotlin.math.PI
 import kotlin.math.cos
 import kotlin.math.sin
 
-abstract class Clocks(private val renderApi: GraphicsApi): SkikoRenderDelegate {
+abstract class Clocks(private val renderApi: () -> GraphicsApi): SkikoRenderDelegate {
     private val withFps = true
     private val fpsCounter = FPSCounter()
     private val platformYOffset = if (hostOs == OS.Ios) 50f else 5f
@@ -102,7 +101,7 @@ abstract class Clocks(private val renderApi: GraphicsApi): SkikoRenderDelegate {
 
         val renderInfo = ParagraphBuilder(style, fontCollection)
             .pushStyle(TextStyle().setColor(0xFF000000.toInt()))
-            .addText("Graphics API: $renderApi ✿ﾟ ${currentSystemTheme}${maybeFps}")
+            .addText("Graphics API: ${renderApi()} ✿ﾟ ${currentSystemTheme}${maybeFps}")
             .popStyle()
             .build()
         renderInfo.layout(Float.POSITIVE_INFINITY)

--- a/samples/SkiaMultiplatformSample/src/macosMain/kotlin/org/jetbrains/skiko/sample/MacosClocks.kt
+++ b/samples/SkiaMultiplatformSample/src/macosMain/kotlin/org/jetbrains/skiko/sample/MacosClocks.kt
@@ -11,7 +11,7 @@ import platform.AppKit.NSViewHeightSizable
 import platform.AppKit.NSViewWidthSizable
 import platform.AppKit.NSWindow
 
-class MacosClocks(skiaLayer: SkiaLayer, window: NSWindow) : Clocks(skiaLayer.renderApi) {
+class MacosClocks(skiaLayer: SkiaLayer, window: NSWindow) : Clocks({ skiaLayer.renderApi }) {
     init {
         val nsView = object : NSView(window.frame) {
             private var trackingArea : NSTrackingArea? = null

--- a/samples/SkiaMultiplatformSample/src/macosMain/kotlin/org/jetbrains/skiko/sample/MacosClocks.kt
+++ b/samples/SkiaMultiplatformSample/src/macosMain/kotlin/org/jetbrains/skiko/sample/MacosClocks.kt
@@ -11,7 +11,7 @@ import platform.AppKit.NSViewHeightSizable
 import platform.AppKit.NSViewWidthSizable
 import platform.AppKit.NSWindow
 
-class MacosClocks(skiaLayer: SkiaLayer, window: NSWindow) : Clocks({ skiaLayer.renderApi }) {
+class MacosClocks(skiaLayer: SkiaLayer, window: NSWindow) : Clocks(layer::renderApi) {
     init {
         val nsView = object : NSView(window.frame) {
             private var trackingArea : NSTrackingArea? = null

--- a/samples/SkiaMultiplatformSample/src/uikitMain/kotlin/org/jetbrains/skiko/sample/IosClocks.kt
+++ b/samples/SkiaMultiplatformSample/src/uikitMain/kotlin/org/jetbrains/skiko/sample/IosClocks.kt
@@ -5,7 +5,7 @@ import org.jetbrains.skiko.SkikoUIView
 import platform.UIKit.NSLayoutConstraint
 import platform.UIKit.UIViewController
 
-class IosClocks(skiaLayer: SkiaLayer) : Clocks(skiaLayer.renderApi) {
+class IosClocks(skiaLayer: SkiaLayer) : Clocks({ skiaLayer.renderApi }) {
     val viewController: UIViewController
     init {
         val view = SkikoUIView(skiaLayer)

--- a/samples/SkiaMultiplatformSample/src/uikitMain/kotlin/org/jetbrains/skiko/sample/IosClocks.kt
+++ b/samples/SkiaMultiplatformSample/src/uikitMain/kotlin/org/jetbrains/skiko/sample/IosClocks.kt
@@ -5,7 +5,7 @@ import org.jetbrains.skiko.SkikoUIView
 import platform.UIKit.NSLayoutConstraint
 import platform.UIKit.UIViewController
 
-class IosClocks(skiaLayer: SkiaLayer) : Clocks({ skiaLayer.renderApi }) {
+class IosClocks(skiaLayer: SkiaLayer) : Clocks(layer::renderApi) {
     val viewController: UIViewController
     init {
         val view = SkikoUIView(skiaLayer)

--- a/samples/SkiaMultiplatformSample/src/webMain/kotlin/org/jetbrains/skiko/sample/WebClocks.web.kt
+++ b/samples/SkiaMultiplatformSample/src/webMain/kotlin/org/jetbrains/skiko/sample/WebClocks.web.kt
@@ -8,7 +8,7 @@ import org.w3c.dom.events.Event
 import org.w3c.dom.events.MouseEvent
 import org.w3c.dom.get
 
-class WebClocks(skiaLayer: SkiaLayer, canvas: HTMLCanvasElement) : Clocks(skiaLayer.renderApi) {
+class WebClocks(skiaLayer: SkiaLayer, canvas: HTMLCanvasElement) : Clocks({ skiaLayer.renderApi }) {
     init {
         val scale = window.devicePixelRatio.toFloat()
         val bounds = canvas.getBoundingClientRect()

--- a/samples/SkiaMultiplatformSample/src/webMain/kotlin/org/jetbrains/skiko/sample/WebClocks.web.kt
+++ b/samples/SkiaMultiplatformSample/src/webMain/kotlin/org/jetbrains/skiko/sample/WebClocks.web.kt
@@ -8,7 +8,7 @@ import org.w3c.dom.events.Event
 import org.w3c.dom.events.MouseEvent
 import org.w3c.dom.get
 
-class WebClocks(skiaLayer: SkiaLayer, canvas: HTMLCanvasElement) : Clocks({ skiaLayer.renderApi }) {
+class WebClocks(skiaLayer: SkiaLayer, canvas: HTMLCanvasElement) : Clocks(layer::renderApi) {
     init {
         val scale = window.devicePixelRatio.toFloat()
         val bounds = canvas.getBoundingClientRect()


### PR DESCRIPTION
renderApi can change if there was a fallback (DIRECT3D -> OpenGL -> Software). We need to always call it in the frame.

Noticed it during testing.