### PR TITLE
Add configurable clearColor to SkiaLayer to avoid white background during resize on Windows.

### DIFF
--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt
@@ -30,6 +30,7 @@ actual open class SkiaLayer internal constructor(
     private val analytics: SkiaLayerAnalytics = SkiaLayerAnalytics.Empty,
     actual val pixelGeometry: PixelGeometry = PixelGeometry.UNKNOWN,
 ) : JPanel() {
+    actual val clearColor: Int = properties.clearColor
 
     internal companion object {
         init {

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skiko/SkiaLayer.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skiko/SkiaLayer.kt
@@ -44,6 +44,11 @@ expect open class SkiaLayer {
     var renderDelegate: SkikoRenderDelegate?
 
     /**
+     * Clear color for the canvas.
+     */
+    val clearColor: Int
+
+    /**
      * Attach this [SkikoRenderDelegate] to platform container.
      * Actual type of attach container is platform-specific.
      */

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skiko/context/ContextHandler.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skiko/context/ContextHandler.kt
@@ -41,7 +41,7 @@ internal abstract class ContextHandler(
         }
         initCanvas()
         canvas?.apply {
-            clear(if (isTransparentBackground()) Color.TRANSPARENT else Color.WHITE)
+            clear(if (isTransparentBackground()) Color.TRANSPARENT else layer.clearColor)
             drawContent()
         }
         flush()

--- a/skiko/src/jsWasmMain/kotlin/org/jetbrains/skiko/SkiaLayer.js.kt
+++ b/skiko/src/jsWasmMain/kotlin/org/jetbrains/skiko/SkiaLayer.js.kt
@@ -46,6 +46,11 @@ actual open class SkiaLayer {
         }
 
     /**
+     * Clear color for the canvas.
+     */
+    actual val clearColor: Int = org.jetbrains.skia.Color.WHITE
+
+    /**
      * Schedules a drawFrame to the appropriate moment.
      */
     actual fun needRedraw() {

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/SkiaLayerProperties.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/SkiaLayerProperties.kt
@@ -22,6 +22,8 @@ class SkiaLayerProperties(
     val renderApi: GraphicsApi = SkikoProperties.renderApi,
     val adapterPriority: GpuPriority = SkikoProperties.gpuPriority,
 ) {
+    val clearColor: Int = clearColorFromSystem()
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
 
@@ -55,5 +57,22 @@ class SkiaLayerProperties(
         result = 31 * result + renderApi.hashCode()
         result = 31 * result + adapterPriority.hashCode()
         return result
+    }
+
+    companion object {
+        var defaultClearColor: Int = org.jetbrains.skia.Color.WHITE
+
+        fun clearColorFromSystem(): Int {
+            val colorFromEnv = System.getProperty("SKIKO_CLEAR_COLOR")?.let {
+                try {
+                    if (it[0] == '#') {
+                        it.drop(1).toInt(16)
+                    } else {
+                        it.toInt()
+                    }
+                } catch (_: Exception) { null }
+            }
+            return colorFromEnv ?: defaultClearColor
+        }
     }
 }

--- a/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/SkiaLayer.linux.kt
+++ b/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/SkiaLayer.linux.kt
@@ -15,6 +15,8 @@ actual open class SkiaLayer  {
     actual var transparency: Boolean
         get() = TODO("Not yet implemented")
         set(value) {}
+    actual val clearColor: Int
+        get() = TODO("Not yet implemented")
     actual val component: Any?
         get() = TODO("Not yet implemented")
     actual fun needRedraw() {

--- a/skiko/src/macosMain/kotlin/org/jetbrains/skiko/SkiaLayer.macos.kt
+++ b/skiko/src/macosMain/kotlin/org/jetbrains/skiko/SkiaLayer.macos.kt
@@ -33,6 +33,8 @@ actual open class SkiaLayer {
             field = value
         }
 
+    actual val clearColor: Int = Color.WHITE
+
     /**
      * The scale factor of [NSWindow]
      * https://developer.apple.com/documentation/appkit/nswindow/1419459-backingscalefactor

--- a/skiko/src/uikitMain/kotlin/org/jetbrains/skiko/SkiaLayer.uikit.kt
+++ b/skiko/src/uikitMain/kotlin/org/jetbrains/skiko/SkiaLayer.uikit.kt
@@ -2,6 +2,7 @@ package org.jetbrains.skiko
 
 import kotlinx.cinterop.useContents
 import org.jetbrains.skia.Canvas
+import org.jetbrains.skia.Color
 import org.jetbrains.skia.PixelGeometry
 import org.jetbrains.skia.Surface
 import platform.UIKit.*
@@ -24,6 +25,8 @@ actual open class SkiaLayer {
     actual var transparency: Boolean
         get() = false
         set(_) { throw UnsupportedOperationException() }
+
+    actual val clearColor: Int = Color.WHITE
 
     actual fun needRedraw() {
         needRedrawCallback.invoke()


### PR DESCRIPTION
This adds a `clearColor` field to `SkiaLayer`, supported by a new SkiaLayerProperties.clearColor value.
It defaults to white but can be overridden via a system property (`SKIKO_CLEAR_COLOR`) or by setting `SkiaLayerProperties.defaultClearColor` early at startup.

This helps eliminate the white flicker during window resizing in Compose Desktop (observed on Windows).
The change is fully backward-compatible and has no effect unless explicitly configured.

I’ve tested it, and the white background disappears completely. Here are links to issues on YouTrack that describe the issue:
https://youtrack.jetbrains.com/issue/CMP-7700/Desktop-Synchronize-Compose-and-Swing-layout-and-rendering-phases
https://youtrack.jetbrains.com/issue/CMP-7919/White-background-flicker-during-window-resize-in-Compose-Desktop
