### PR TITLE
SKIKO-1013: Migrate skiko android target to proper androidTarget using AGP

### DIFF
--- a/samples/SkiaAndroidSample/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/SkiaAndroidSample/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/samples/SkiaAndroidSample/src/main/AndroidManifest.xml
+++ b/samples/SkiaAndroidSample/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="org.jetbrains.skiko.sample">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application
         android:allowBackup="true"

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/CommonTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/CommonTasksConfiguration.kt
@@ -161,7 +161,8 @@ fun Project.configureSignAndPublishDependencies() {
 fun KotlinTarget.generateVersion(
     targetOs: OS,
     targetArch: Arch,
-    skikoProperties: SkikoProperties
+    skikoProperties: SkikoProperties,
+    compilationName: String = "main"
 ) {
     val targetName = this.name
     val isUikitSim = isUikitSimulator()
@@ -194,9 +195,11 @@ fun KotlinTarget.generateVersion(
         }
     }
 
-    val compilation = compilations["main"] ?: error("Could not find 'main' compilation for target '$this'")
-    compilation.compileKotlinTaskProvider.configure {
-        dependsOn(generateVersionTask)
-        (this as KotlinCompileTool).source(generatedDir.get().asFile)
+    // Needs to be lazily loaded as android compilations are not available right away
+    compilations.matching { it.name == compilationName }.configureEach {
+        compileTaskProvider.configure {
+            dependsOn(generateVersionTask)
+            (this as KotlinCompileTool).source(generatedDir.get().asFile)
+        }
     }
 }

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/JvmTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/JvmTasksConfiguration.kt
@@ -515,8 +515,13 @@ fun SkikoProjectContext.setupJvmTestTask(skikoAwtJarForTests: TaskProvider<Jar>,
 }
 
 fun Project.androidHomePath(): Provider<String> {
-    val androidHomeFromSdkRoot: Provider<String> =
+    val androidHomeFromSdkHome: Provider<String> =
+        project.providers.environmentVariable("ANDROID_HOME")
+
+    // ANDROID_SDK_ROOT name is deprecated in favor of ANDROID_HOME
+    val deprecatedAndroidHomeFromSdkRoot: Provider<String> =
         project.providers.environmentVariable("ANDROID_SDK_ROOT")
+
     val androidHomeFromUserHome: Provider<String> =
         project.providers.systemProperty("user.home")
             .map { userHome ->
@@ -525,26 +530,7 @@ fun Project.androidHomePath(): Provider<String> {
                     .firstOrNull { File(it).exists() }
                     ?: error("Define Android SDK via ANDROID_SDK_ROOT")
             }
-    return androidHomeFromSdkRoot
+    return androidHomeFromSdkHome
+        .orElse(deprecatedAndroidHomeFromSdkRoot)
         .orElse(androidHomeFromUserHome)
 }
-fun Project.androidJar(askedVersion: String = ""): Provider<File> =
-    androidHomePath().map { androidHomePath ->
-        val androidHome = File(androidHomePath)
-        val version = if (askedVersion.isEmpty()) {
-            val platformsDir = androidHome.resolve("platforms")
-            val versions = platformsDir.list().orEmpty()
-            versions.maxByOrNull { name -> // possible name: "android-32", "android-33-ext4"
-                name.split("-").getOrNull(1)?.toIntOrNull() ?: 0
-            } ?: error(
-                buildString {
-                    appendLine("'$platformsDir' does not contain any directories matching expected 'android-NUMBER' format: ${versions}")
-                }
-            )
-        } else {
-            "android-$askedVersion"
-        }
-        androidHome.resolve("platforms/$version/android.jar").also {
-            println("Skiko task androidJar uses android SDK in $it")
-        }
-    }

--- a/skiko/settings.gradle.kts
+++ b/skiko/settings.gradle.kts
@@ -2,20 +2,28 @@ pluginManagement {
     repositories {
         mavenCentral()
         gradlePluginPortal()
+        google()
     }
     buildscript {
         repositories {
             mavenCentral()
             maven("https://maven.pkg.jetbrains.space/public/p/compose/internal")
             maven("https://maven.pkg.jetbrains.space/public/p/space/maven")
+            google()
         }
         dependencies {
+            // TODO Removing this makes publishing module below crash android internal plugin
+            classpath("org.ow2.asm:asm:9.6")
+
             // TODO https://youtrack.jetbrains.com/issue/SKIKO-1003/Unify-Maven-publication-of-Skiko-with-Compose
             classpath("org.jetbrains.compose.internal.build-helpers:publishing:0.1.3")
             // used by org.jetbrains.compose.internal.build-helpers:publishing because of https://youtrack.jetbrains.com/issue/CMP-7603/Fix-Maven-Central-publication
             classpath("org.jetbrains:space-sdk-jvm:2024.3-185883")
 
             classpath("org.kohsuke:github-api:1.116")
+
+            // Added dependency for Android Gradle plugin
+            classpath("com.android.tools.build:gradle:8.2.2")
         }
     }
 
@@ -23,6 +31,7 @@ pluginManagement {
         val kotlinVersion = extra["kotlin.version"] as String
         kotlin("jvm").version(kotlinVersion)
         kotlin("multiplatform").version(kotlinVersion)
+        id("com.android.library").version("8.2.2") apply false
     }
 }
 rootProject.name = "skiko"


### PR DESCRIPTION
This also fixes SKIKO-934 by making the dependency between `merge*JniLibFolders` and `unzip*` tasks explicit (the patch actually adds too much dependencies but this should be limited to android tasks). After this patch the android sample works from my configuration (might be worth checking if other issues are still relevant?).

Few things to consider for review:
- I've changed versions of Gradle / AGP / Kotlin until I got something working on both samples and library side.
- If `ANDROID_SDK_ROOT` environment variable was specified on a CI before, it should now be `ANDROID_HOME` to work with android gradle plugin (internal utilities will work with both).
- I've introduce some lazyness in configurations (`matching { ... }`), as android plugin and previous code would race (android seems to declare it's configurations quite late). If there's a better way to express it, please let me know!
