### PR TITLE
Document required Emscripten version

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -3,20 +3,26 @@
 * Prepare the system
   * `macOs` Install Xcode Command Line Tools
   * `Linux` Install these tools:
+
     ```
     sudo apt-get install ninja-build fontconfig libfontconfig1-dev libglu1-mesa-dev libxrandr-dev libdbus-1-dev zip libx11-dev
     ```
+
   * `Windows`
     1. Download [Visual Studio Build Tools 2019](https://learn.microsoft.com/en-us/visualstudio/releases/2019/history) (search "BuildTools" on the page).
     2. During the installation, select "Desktop development with C++"
     3. Add an environment variable SKIKO_VSBT_PATH=C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools
+
        ```
        Control Panel|All Control Panel Items|System|Advanced system settings|Environment variables
        ```
+
        or by running `cmd` as administrator:
+
        ```
        setx /M SKIKO_VSBT_PATH "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools"
        ```
+
     4. Skiko is built using Clang-cl. Clang-cl is a part of LLVM and can be downloaded from the [LLVM project's website](https://releases.llvm.org/). Please also make sure that Clang-cl.exe is available in %PATH%.
 
 * Install Emscripten v3.1.56 (other versions might not work)
@@ -33,14 +39,18 @@ re-evaluates tasks, when outputs are changed).
 To use custom version of the dependencies, specify `SKIA_DIR` environment variable.
 
 #### Running UI tests
+
 Add `-Dskiko.test.ui.enabled=true` to enable UI tests (integration tests, which run in the native window). Each UI test will be run on every available Graphics API of the current target.
 
 For example, if we want to include UI tests when we test JVM target, call this:
+
 ```
 ./gradlew awtTest -Dskiko.test.ui.enabled=true
 ```
+
 Don't run any background tasks, click mouse, or press keys during the tests. Otherwise, they probably fail.
 
 #### Run samples
-- First follow the instruction here: [Building JVM bindings](#building-jvm-bindings)
-- `./gradlew :SkiaAwtSample:run`
+
+* First follow the instruction here: [Building JVM bindings](#building-jvm-bindings)
+* `./gradlew :SkiaAwtSample:run`

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -19,7 +19,7 @@
        ```
     4. Skiko is built using Clang-cl. Clang-cl is a part of LLVM and can be downloaded from the [LLVM project's website](https://releases.llvm.org/). Please also make sure that Clang-cl.exe is available in %PATH%.
 
-* Install Emscripten
+* Install Emscripten v3.1.56 (other versions might not work)
 * Set `JAVA_HOME` to location of JDK, at least version 11
 * `./gradlew :skiko:publishToMavenLocal` will build the artifact and publish it to local Maven repo
 


### PR DESCRIPTION
Task `./gradlew :publishToMavenLocal` runs another task called `:linkWasmWithES6`. When using current latest emsdk v4.0.6, `:linkWasmWithES6` fails with the following error messages:

```
error: undefined symbol: saveSetjmp(referenced by root reference (e.g. compiled C/C++ code)) undefined symbol: saveSetjmp(referenced by root reference (e.g. compiled C/C++ code))
...
error: undefined symbol: testSetjmp (referenced by root reference (e.g. compiled C/C++ code)) undefined symbol: testSetjmp (referenced by root reference (e.g. compiled C/C++ code))
```

I assume that the issue lies in different compiler versions used for the project and its dependencies. This seems to be true, because changing from v4.0.6 to v3.1.56 fixes the errors.