### PR TITLE
Remove 0.0.0-SNAPSHOT note

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,3 @@ class SkikoAppDelegate : UIResponder, UIApplicationDelegateProtocol {
 }
 ```
 See this [sample](/samples/SkiaMultiplatformSample) for complete example.
-
-To use latest development snapshot use version `0.0.0-SNAPSHOT`.
-


### PR DESCRIPTION
https://jetbrains.slack.com/archives/C02DDNREC77/p1744211587478839?thread_ts=1744180296.015109&cid=C02DDNREC77

- now 0.0.1-SNAPSHOT is built
- it can't be used, as it is built from any branch, not only from master