### PR TITLE
Point `TextBlobBuilderRunHandler` to the correct native symbol

### DIFF
--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/shaper/TextBlobBuilderRunHandler.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/shaper/TextBlobBuilderRunHandler.kt
@@ -80,14 +80,14 @@ class TextBlobBuilderRunHandler<T> internal constructor(
     }
 }
 
-@ExternalSymbolName("org_jetbrains_skia_TextBlobBuilderRunHandler__1nGetFinalizer")
-@ModuleImport("./skiko.mjs", "org_jetbrains_skia_TextBlobBuilderRunHandler__1nGetFinalizer")
+@ExternalSymbolName("org_jetbrains_skia_shaper_TextBlobBuilderRunHandler__1nGetFinalizer")
+@ModuleImport("./skiko.mjs", "org_jetbrains_skia_shaper_TextBlobBuilderRunHandler__1nGetFinalizer")
 private external fun TextBlobBuilderRunHandler_nGetFinalizer(): NativePointer
 
-@ExternalSymbolName("org_jetbrains_skia_TextBlobBuilderRunHandler__1nMake")
-@ModuleImport("./skiko.mjs", "org_jetbrains_skia_TextBlobBuilderRunHandler__1nMake")
+@ExternalSymbolName("org_jetbrains_skia_shaper_TextBlobBuilderRunHandler__1nMake")
+@ModuleImport("./skiko.mjs", "org_jetbrains_skia_shaper_TextBlobBuilderRunHandler__1nMake")
 private external fun TextBlobBuilderRunHandler_nMake(textPtr: NativePointer, offsetX: Float, offsetY: Float): NativePointer
 
-@ExternalSymbolName("org_jetbrains_skia_TextBlobBuilderRunHandler__1nMakeBlob")
-@ModuleImport("./skiko.mjs", "org_jetbrains_skia_TextBlobBuilderRunHandler__1nMakeBlob")
+@ExternalSymbolName("org_jetbrains_skia_shaper_TextBlobBuilderRunHandler__1nMakeBlob")
+@ModuleImport("./skiko.mjs", "org_jetbrains_skia_shaper_TextBlobBuilderRunHandler__1nMakeBlob")
 private external fun _nMakeBlob(ptr: NativePointer): NativePointer


### PR DESCRIPTION
https://github.com/JetBrains/skiko/blob/10a91fc95a7fe2c3a6aa98f4001a065406eaf371/skiko/src/nativeJsMain/cpp/shaper/TextBlobBuilderRunHandler.cc#L9
https://github.com/JetBrains/skiko/blob/10a91fc95a7fe2c3a6aa98f4001a065406eaf371/skiko/src/nativeJsMain/cpp/shaper/TextBlobBuilderRunHandler.cc#L14
https://github.com/JetBrains/skiko/blob/10a91fc95a7fe2c3a6aa98f4001a065406eaf371/skiko/src/nativeJsMain/cpp/shaper/TextBlobBuilderRunHandler.cc#L21

Fixes [SKIKO-740](https://youtrack.jetbrains.com/issue/SKIKO-740) (#740) with #1050.