### PR TITLE
Point `SVGCanvas` to the correct native symbol

### DIFF
--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/svg/SVGCanvas.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/svg/SVGCanvas.kt
@@ -62,7 +62,7 @@ object SVGCanvas {
     }
 }
 
-@ExternalSymbolName("org_jetbrains_skia_svg_SVGCanvasKt__1nMake")
-@ModuleImport("./skiko.mjs", "org_jetbrains_skia_svg_SVGCanvasKt__1nMake")
+@ExternalSymbolName("org_jetbrains_skia_svg_SVGCanvas__1nMake")
+@ModuleImport("./skiko.mjs", "org_jetbrains_skia_svg_SVGCanvas__1nMake")
 private external fun _nMake(left: Float, top: Float, right: Float, bottom: Float, wstreamPtr: NativePointer, flags: Int): NativePointer
 


### PR DESCRIPTION
https://github.com/JetBrains/skiko/blob/10a91fc95a7fe2c3a6aa98f4001a065406eaf371/skiko/src/nativeJsMain/cpp/svg/SVGCanvas.cc#L7