### PR TITLE
Add linuxArm64 target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,9 @@ jobs:
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-9
           sudo update-alternatives --config gcc
           sudo apt-get install ninja-build fontconfig libfontconfig1-dev libglu1-mesa-dev libxrandr-dev libdbus-1-dev zip xvfb -y
+          sudo apt-get install gcc-9-aarch64-linux-gnu g++-9-aarch64-linux-gnu multistrap -y
+          sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-gcc aarch64-linux-gnu-gcc /usr/bin/aarch64-linux-gnu-gcc-9 60 --slave /usr/bin/aarch64-linux-gnu-g++ aarch64-linux-gnu-g++ /usr/bin/aarch64-linux-gnu-g++-9
+          sudo update-alternatives --config aarch64-linux-gnu-gcc
           sudo Xvfb :0 -screen 0 1280x720x24 &
 
       - shell: bash

--- a/skiko/build.gradle.kts
+++ b/skiko/build.gradle.kts
@@ -134,6 +134,7 @@ kotlin {
     }
     if (supportNativeLinux) {
         skikoProjectContext.configureNativeTarget(OS.Linux, Arch.X64, linuxX64())
+        skikoProjectContext.configureNativeTarget(OS.Linux, Arch.Arm64, linuxArm64())
     }
     if (supportNativeIosArm64) {
         skikoProjectContext.configureNativeTarget(OS.IOS, Arch.Arm64, iosArm64())
@@ -282,6 +283,12 @@ kotlin {
                         dependsOn(linuxMain)
                     }
                     val linuxX64Test by getting {
+                        dependsOn(linuxTest)
+                    }
+                    val linuxArm64Main by getting {
+                        dependsOn(linuxMain)
+                    }
+                    val linuxArm64Test by getting {
                         dependsOn(linuxTest)
                     }
                 }

--- a/skiko/buildSrc/src/main/kotlin/properties.kt
+++ b/skiko/buildSrc/src/main/kotlin/properties.kt
@@ -39,7 +39,7 @@ fun compilerForTarget(os: OS, arch: Arch): String =
     when (os) {
         OS.Linux -> when (arch) {
             Arch.X64 -> "g++"
-            Arch.Arm64 -> "clang++"
+            Arch.Arm64 -> if (hostArch == Arch.Arm64) "g++" else "aarch64-linux-gnu-g++"
             Arch.Wasm -> "Unexpected combination: $os & $arch"
         }
         OS.Android -> "clang++"

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/NativeTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/NativeTasksConfiguration.kt
@@ -7,6 +7,7 @@ import SkiaBuildType
 import SkikoProjectContext
 import WriteCInteropDefFile
 import compilerForTarget
+import hostArch
 import isCompatibleWithHost
 import joinToTitleCamelCase
 import listOfFrameworks
@@ -51,11 +52,19 @@ fun SkikoProjectContext.compileNativeBridgesTask(
 ): TaskProvider<CompileSkikoCppTask> = with (this.project) {
     val skiaNativeDir = registerOrGetSkiaDirProvider(os, arch, isUikitSim = isUikitSim)
 
+    val setupMultistrapTask = if (os == OS.Linux && arch == Arch.Arm64 && hostArch != Arch.Arm64) {
+        setupMultistrapTask(os, arch, isUikitSim = isUikitSim)
+    } else {
+        null
+    }
+
     val actionName = "compileNativeBridges".withSuffix(isUikitSim = isUikitSim)
 
     return project.registerSkikoTask<CompileSkikoCppTask>(actionName, os, arch) {
         dependsOn(skiaNativeDir)
         val unpackedSkia = skiaNativeDir.get()
+
+        setupMultistrapTask?.let { dependsOn(it) }
 
         compiler.set(compilerForTarget(os, arch))
         buildTargetOS.set(os)
@@ -239,17 +248,24 @@ fun SkikoProjectContext.configureNativeTarget(os: OS, arch: Arch, target: Kotlin
             configureCinterop("uikit", os, arch, target, targetString, tvosFrameworks)
             mutableListOfLinkerOptions(tvosFrameworks)
         }
-        OS.Linux -> mutableListOfLinkerOptions(
-            "-L/usr/lib/x86_64-linux-gnu",
-            "-lfontconfig",
-            "-lGL",
-            // TODO: an ugly hack, Linux linker searches only unresolved symbols.
-            "$skiaBinDir/libsksg.a",
-            "$skiaBinDir/libskshaper.a",
-            "$skiaBinDir/libskunicode_core.a",
-            "$skiaBinDir/libskunicode_icu.a",
-            "$skiaBinDir/libskia.a"
-        )
+        OS.Linux -> {
+            val options = mutableListOf(
+                "-L/usr/lib/${if (arch == Arch.Arm64) "aarch64" else "x86_64"}-linux-gnu",
+                "-lfontconfig",
+                "-lGL",
+                // TODO: an ugly hack, Linux linker searches only unresolved symbols.
+                "$skiaBinDir/libsksg.a",
+                "$skiaBinDir/libskshaper.a",
+                "$skiaBinDir/libskunicode_core.a",
+                "$skiaBinDir/libskunicode_icu.a",
+                "$skiaBinDir/libskia.a"
+            )
+            if (arch == Arch.Arm64 && hostArch != Arch.Arm64) {
+                options.add(0, "-L$buildDir/multistrap-arm64/usr/lib")
+                options.add(1, "-L$buildDir/multistrap-arm64/usr/lib/aarch64-linux-gnu")
+            }
+            mutableListOfLinkerOptions(options)
+        }
         else -> mutableListOf()
     }
     if (skiko.includeTestHelpers) {
@@ -307,6 +323,23 @@ fun SkikoProjectContext.configureNativeTarget(os: OS, arch: Arch, target: Kotlin
         }
     }
 }
+
+fun SkikoProjectContext.setupMultistrapTask(
+    os: OS, arch: Arch, isUikitSim: Boolean
+): TaskProvider<Exec> = with (this.project) {
+    require(os == OS.Linux)
+    require(arch == Arch.Arm64)
+
+    val skiaNativeDir = registerOrGetSkiaDirProvider(os, arch, isUikitSim = isUikitSim)
+
+    val actionName = "setupMultistrap".withSuffix(isUikitSim = isUikitSim)
+
+    return project.registerSkikoTask<Exec>(actionName, os, arch) {
+        workingDir(projectDir)
+        commandLine("multistrap", "-f", "multistrap-config-${arch.id}")
+    }
+}
+
 
 fun KotlinMultiplatformExtension.configureIOSTestsWithMetal(project: Project) {
     val metalTestTargets = listOf("iosX64", "iosSimulatorArm64")

--- a/skiko/ci/build.gradle.kts
+++ b/skiko/ci/build.gradle.kts
@@ -19,6 +19,7 @@ val skikoArtifactIds: List<String> =
         SkikoArtifacts.jsArtifactId,
         SkikoArtifacts.wasmArtifactId,
         SkikoArtifacts.nativeArtifactIdFor(OS.Linux, Arch.X64),
+        SkikoArtifacts.nativeArtifactIdFor(OS.Linux, Arch.Arm64),
         SkikoArtifacts.nativeArtifactIdFor(OS.MacOS, Arch.Arm64),
         SkikoArtifacts.nativeArtifactIdFor(OS.MacOS, Arch.X64),
         SkikoArtifacts.nativeArtifactIdFor(OS.IOS, Arch.X64),

--- a/skiko/multistrap-config-arm64
+++ b/skiko/multistrap-config-arm64
@@ -1,0 +1,15 @@
+[General]
+arch=arm64
+directory=build/multistrap-arm64
+cleanup=true
+noauth=false
+unpack=true
+cleanup=true
+aptsources=Ubuntu
+bootstrap=Ubuntu
+
+[Ubuntu]
+packages=build-essential software-properties-common gcc-9 g++-9 fontconfig libfontconfig1-dev libglu1-mesa-dev libxrandr-dev libdbus-1-dev
+source=https://ports.ubuntu.com/
+keyring=ubuntu-keyring
+suite=focal


### PR DESCRIPTION
This PR adds support for the linuxArm64 target. It can be cross compiled from a Linux x64 host.