### PR TITLE
Make configureSignAndPublishDependencies use proper android task names

### DIFF
--- a/samples/SkiaAndroidSample/build.gradle.kts
+++ b/samples/SkiaAndroidSample/build.gradle.kts
@@ -79,7 +79,7 @@ var version = if (project.hasProperty("skiko.version")) {
 // ./gradlew -Pskiko.android.enabled=true \
 //    publishSkikoJvmRuntimeAndroidX64PublicationToMavenLocal \
 //    publishSkikoJvmRuntimeAndroidArm64PublicationToMavenLocal \
-//    publishAndroidPublicationToMavenLocal
+//    publishAndroidReleasePublicationToMavenLocal
 dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.0")
     implementation("org.jetbrains.skiko:skiko-android:$version")

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/CommonTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/CommonTasksConfiguration.kt
@@ -129,9 +129,9 @@ fun Project.configureSignAndPublishDependencies() {
     }
     if (supportAndroid) {
         tasks.configureEach {
-            val signAndroid = "signAndroidPublication"
-            val generateMetadata = "generateMetadataFileForAndroidPublication"
-            val publishAndroid = "publishAndroidPublicationTo"
+            val signAndroid = "signAndroidReleasePublication"
+            val generateMetadata = "generateMetadataFileForAndroidReleasePublication"
+            val publishAndroid = "publishAndroidReleasePublicationTo"
             val publishX64 = "publishSkikoJvmRuntimeAndroidX64PublicationTo"
             val publishArm64 = "publishSkikoJvmRuntimeAndroidArm64PublicationTo"
             val signX64 = "signSkikoJvmRuntimeAndroidX64Publication"


### PR DESCRIPTION
"AndroidRelease" should be used instead of "Android" since using the android plugin introduces release/debug variants.

Note: `./gradlew publish -Pskiko.android.enabled=true` would still fail with the following, but this task is as I understand not used on CI and "build repo" seem to be a local thing.
```
> Task :publishAndroidReleasePublicationToBuildRepoRepository FAILED

FAILURE: Build failed with an exception.

* What went wrong:
A problem was found with the configuration of task ':publishAndroidReleasePublicationToBuildRepoRepository' (type 'PublishToMavenRepository').
  - Gradle detected a problem with the following location: '/Users/cdelabou/workspace/misc/skiko/skiko/build/libs/skiko-0.0.0-SNAPSHOT-javadoc.jar.asc'.
    
    Reason: Task ':publishAndroidReleasePublicationToBuildRepoRepository' uses this output of task ':signKotlinMultiplatformPublication' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
```