### PR TITLE
build: fix local machine build scripts

### DIFF
--- a/skiko/build-with-local-skia.sh
+++ b/skiko/build-with-local-skia.sh
@@ -14,9 +14,11 @@ else
   skikoBuildType=Release
 fi
 
+hostArch=$(uname -m)
+
 case $SKIA_TARGET in
   "ios")
-    if [[ $(uname -m) == 'arm64' ]]; then
+    if [[ $hostArch == 'arm64' ]]; then
       SKIKO_TARGET_FLAGS="-Pskiko.native.ios.arm64.enabled=true -Pskiko.awt.enabled=false"
       skikoMachines=("arm64")
     else
@@ -25,7 +27,7 @@ case $SKIA_TARGET in
     fi
     ;;
   "iosSim")
-    if [[ $(uname -m) == 'arm64' ]]; then
+    if [[ $hostArch == 'arm64' ]]; then
       SKIKO_TARGET_FLAGS="-Pskiko.native.ios.simulatorArm64.enabled=true -Pskiko.awt.enabled=false"
       skikoMachines=("arm64")
     else
@@ -35,7 +37,7 @@ case $SKIA_TARGET in
     ;;
   "macos")
     SKIKO_TARGET_FLAGS="-Pskiko.awt.enabled=true"
-    if [[ $(uname -m) == 'arm64' ]]; then
+    if [[ $hostArch == 'arm64' ]]; then
       skikoMachines=("arm64" "x64") # bash arrays split elements by spaces
     else
       skikoMachines=("x64")
@@ -43,7 +45,7 @@ case $SKIA_TARGET in
     ;;
   "windows")
     SKIKO_TARGET_FLAGS="-Pskiko.awt.enabled=true"
-    if [[ $(uname -m) == 'arm64' ]]; then
+    if [[ $hostArch == 'arm64' ]]; then
       skikoMachines=("arm64")
     else
       skikoMachines=("x64")
@@ -51,7 +53,7 @@ case $SKIA_TARGET in
     ;;
   "linux")
     SKIKO_TARGET_FLAGS="-Pskiko.awt.enabled=true"
-    if [[ $(uname -m) == 'arm64' ]]; then
+    if [[ $hostArch == 'arm64' || $hostArch == 'aarch64' ]]; then
       skikoMachines=("arm64")
     else
       skikoMachines=("x64")
@@ -59,11 +61,7 @@ case $SKIA_TARGET in
     ;;
   "wasm")
     SKIKO_TARGET_FLAGS="-Pskiko.wasm.enabled=true -Pskiko.awt.enabled=false"
-    if [[ $(uname -m) == 'arm64' ]]; then
-      skikoMachines=("arm64")
-    else
-      skikoMachines=("x64")
-    fi
+    skikoMachines=("wasm")
     ;;
   *)
     echo "can't determine skia target"; exit 1

--- a/skiko/buildSrc/src/main/kotlin/properties.kt
+++ b/skiko/buildSrc/src/main/kotlin/properties.kt
@@ -9,7 +9,7 @@ enum class OS(
     Linux("linux", arrayOf()),
     Android("android", arrayOf()),
     Windows("windows", arrayOf()),
-    MacOS("macos", arrayOf("-mmacosx-version-min=10.13")),
+    MacOS("macos", arrayOf("-mmacosx-version-min=10.15")),
     Wasm("wasm", arrayOf()),
     IOS("ios", arrayOf()),
     TVOS("tvos", arrayOf())

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/WasmTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/WasmTasksConfiguration.kt
@@ -80,7 +80,9 @@ fun SkikoProjectContext.createWasmLinkTasks(): LinkWasmTasks = with(this.project
         if (outputES6) buildSuffix.set("es6")
         if (isForD8) buildSuffix.set("d8")
 
-        libFiles = project.fileTree(unpackedSkia) { include("**/*.a") }
+        val skiaBinSubdir = "$unpackedSkia/out/${buildType.id}-wasm-wasm"
+
+        libFiles = project.fileTree(skiaBinSubdir) { include("**/*.a") }
         objectFiles = project.fileTree(compileWasm.map { it.outDir.get() }) {
             include("**/*.o")
         }


### PR DESCRIPTION
* WASM was trying to double-link the libraries (on macOS)
* The minimal macOS version was not alignd between Skia and Skiko
* ARM Linux was misdetected (`uname -a` reports "aarch64" in that case)