### PR TITLE
Update runners to ubuntu-22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
           retention-days: 5
 
   linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         name: 'Check out code'

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   web:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: browser-actions/setup-chrome@v1
         with:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -35,7 +35,7 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install binutils build-essential -y
           sudo apt-get install software-properties-common -y
-          sudo apt-get install python git curl wget -y
+          sudo apt-get install python-is-python3 git curl wget -y
           if [ -d ./emsdk ]; then
             cd ./emsdk
             git pull


### PR DESCRIPTION
The current runners fail with:

This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101

GitHub Actions has encountered an internal error when running your job.
