### PR TITLE
Update linux-amd64 Dockerfile to Ubuntu 20.04

### DIFF
--- a/skiko/docker/linux-amd64/Dockerfile
+++ b/skiko/docker/linux-amd64/Dockerfile
@@ -1,11 +1,11 @@
-FROM ubuntu:trusty-20191217
-
+FROM ubuntu:20.04
+ARG DEBIAN_FRONTEND=noninteractive
 # Update binutils, g++, gcc
 RUN apt-get update -y && \
     apt-get install build-essential software-properties-common -y && \
     add-apt-repository ppa:ubuntu-toolchain-r/test -y && \
     apt-get update -y && \
-    apt-get install binutils-2.26 && \
+    apt-get install binutils && \
     apt-get install build-essential software-properties-common -y && \
     apt-get update && \
     apt-get install gcc-9 g++-9 -y && \
@@ -14,7 +14,6 @@ RUN apt-get update -y && \
     apt-get install gcc-9-aarch64-linux-gnu g++-9-aarch64-linux-gnu -y && \
     update-alternatives --install /usr/bin/aarch64-linux-gnu-gcc aarch64-linux-gnu-gcc /usr/bin/aarch64-linux-gnu-gcc-9 60 --slave /usr/bin/aarch64-linux-gnu-g++ aarch64-linux-gnu-g++ /usr/bin/aarch64-linux-gnu-g++-9 && \
     update-alternatives --config aarch64-linux-gnu-gcc
-ENV PATH=/usr/lib/binutils-2.26/bin:$PATH
 
 # Install libs & tools
 ENV DEPOT_TOOLS=/usr/depot_tools


### PR DESCRIPTION
Needed to add `ARG DEBIAN_FRONTEND=noninteractive` so installation does not get stuck, copied this from another Dockerfile.
Also `binutils-2.26` was missing so replaced it with `binutils`, this is in line with the other docker files, but I am unsure if this could break anything.

On my PC the image build is successful (using `build.sh` script). The `run.sh` script is also successful after adapting its paths to my local setup. Unsure about publishing.