### PR TITLE
[build] Correct kotlin.version parametrizaton in skiko/skiko

### DIFF
--- a/skiko/buildSrc/build.gradle.kts
+++ b/skiko/buildSrc/build.gradle.kts
@@ -10,6 +10,7 @@ repositories {
 dependencies {
     implementation(kotlin("stdlib"))
     compileOnly(gradleApi())
-    implementation(kotlin("gradle-plugin", "1.9.21"))
+    val kotlinVersion = project.properties["kotlin.version"] as String
+    implementation(kotlin("gradle-plugin", kotlinVersion))
     implementation("de.undercouch:gradle-download-task:5.5.0")
 }

--- a/skiko/buildSrc/gradle.properties
+++ b/skiko/buildSrc/gradle.properties
@@ -1,0 +1,1 @@
+kotlin.version=1.9.21

--- a/skiko/gradle.properties
+++ b/skiko/gradle.properties
@@ -25,8 +25,6 @@ dependencies.skia=m132-a00c390e98-1
 
 org.gradle.jvmargs=-Xmx3G -XX:MaxMetaspaceSize=512m
 
-kotlin.version=1.9.21
-
 skiko.awt.enabled=true
 skiko.js.enabled=false
 skiko.wasm.enabled=false

--- a/skiko/settings.gradle.kts
+++ b/skiko/settings.gradle.kts
@@ -28,9 +28,10 @@ pluginManagement {
     }
 
     plugins {
-        val kotlinVersion = extra["kotlin.version"] as String
-        kotlin("jvm").version(kotlinVersion)
-        kotlin("multiplatform").version(kotlinVersion)
+        // whatever kotlinVersion we point to here, it will be ignored due to the nature of gradle design
+        // the actual version is set in buildSrc/gradle.properties
+        kotlin("jvm")
+        kotlin("multiplatform")
         id("com.android.library").version("7.4.2") apply false
     }
 }


### PR DESCRIPTION
This PR solves misleading kotlin.version parametrization which actually was not working as expected: The actual version was always resolved from buildSrc.

some context
https://jetbrains.slack.com/archives/C0288G57R/p1749820141169649