### PR TITLE
Upgrade Skiko to new build-helpers:publishing version

### DIFF
--- a/skiko/ci/build.gradle.kts
+++ b/skiko/ci/build.gradle.kts
@@ -78,7 +78,7 @@ val deleteGithubRelease by tasks.registering {
 val uploadSkikoArtifactsToMavenCentral by tasks.registering(UploadToSonatypeTask::class) {
     dependsOn(downloadSkikoArtifactsFromComposeDev)
 
-    version.set(skiko.deployVersion)
+    stagingDescription.set("Skiko ${skiko.deployVersion}")
     modulesToUpload.set(skikoMavenModules(skiko.deployVersion))
 
     sonatypeServer.set("https://oss.sonatype.org")

--- a/skiko/settings.gradle.kts
+++ b/skiko/settings.gradle.kts
@@ -12,13 +12,7 @@ pluginManagement {
             google()
         }
         dependencies {
-            // TODO Removing this makes publishing module below crash android internal plugin
-            classpath("org.ow2.asm:asm:9.6")
-
-            // TODO https://youtrack.jetbrains.com/issue/SKIKO-1003/Unify-Maven-publication-of-Skiko-with-Compose
-            classpath("org.jetbrains.compose.internal.build-helpers:publishing:0.1.3")
-            // used by org.jetbrains.compose.internal.build-helpers:publishing because of https://youtrack.jetbrains.com/issue/CMP-7603/Fix-Maven-Central-publication
-            classpath("org.jetbrains:space-sdk-jvm:2024.3-185883")
+            classpath("org.jetbrains.compose.internal.build-helpers:publishing:0.1.6")
 
             classpath("org.kohsuke:github-api:1.116")
 


### PR DESCRIPTION
New sources are in https://github.com/JetBrains/compose-multiplatform/pull/5343

Was published in https://teamcity.jetbrains.com/buildConfiguration/JetBrainsPublicProjects_Compose_PublishBuildHelpers/5279403 from a branch