### PR TITLE
Correct the usage of FinalizationRegistry API in web targets

### DIFF
--- a/skiko/src/jsMain/kotlin/org/jetbrains/skia/impl/Managed.js.kt
+++ b/skiko/src/jsMain/kotlin/org/jetbrains/skia/impl/Managed.js.kt
@@ -1,8 +1,19 @@
 package org.jetbrains.skia.impl
 
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry
+ */
 internal external class FinalizationRegistry(cleanup: (dynamic) -> Unit) {
-    fun register(obj: dynamic, handle: dynamic)
-    fun unregister(obj: dynamic)
+
+    /**
+     * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry/register
+     */
+    fun register(obj: dynamic, handle: dynamic, unregisterToken: dynamic)
+
+    /**
+     * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry/unregister
+     */
+    fun unregister(unregisterToken: dynamic)
 }
 
 private val registry = FinalizationRegistry {
@@ -11,7 +22,7 @@ private val registry = FinalizationRegistry {
 }
 
 internal actual fun register(managed: Managed, thunk: FinalizationThunk) {
-    registry.register(managed, thunk)
+    registry.register(managed, thunk, managed)
 }
 
 internal actual fun unregister(managed: Managed) {

--- a/skiko/src/wasmJsMain/kotlin/org/jetbrains/skia/impl/Managed.wasm.kt
+++ b/skiko/src/wasmJsMain/kotlin/org/jetbrains/skia/impl/Managed.wasm.kt
@@ -1,8 +1,18 @@
 package org.jetbrains.skia.impl
 
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry
+ */
 internal external class FinalizationRegistry(cleanup: (JsReference<FinalizationThunk>) -> Unit) {
-    fun register(obj: JsReference<Managed>, handle: JsReference<FinalizationThunk>)
-    fun unregister(obj: JsReference<Managed>)
+    /**
+     * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry/register
+     */
+    fun register(obj: JsReference<Managed>, handle: JsReference<FinalizationThunk>, unregisterToken: JsReference<Managed>)
+
+    /**
+     * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry/unregister
+     */
+    fun unregister(unregisterToken: JsReference<Managed>)
 }
 
 private val registry = FinalizationRegistry { thunk: JsReference<FinalizationThunk> ->
@@ -10,7 +20,8 @@ private val registry = FinalizationRegistry { thunk: JsReference<FinalizationThu
 }
 
 internal actual fun register(managed: Managed, thunk: FinalizationThunk) {
-    registry.register(managed.toJsReference(), thunk.toJsReference())
+    val managedRef = managed.toJsReference()
+    registry.register(managedRef, thunk.toJsReference(), managedRef)
 }
 
 internal actual fun unregister(managed: Managed) {


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/projects/SKIKO/issues/SKIKO-1040/Web-targets-not-optimal-use-of-FinalizationRegistry-API

It improves some microbenhcmarks according to https://github.com/WebKit/JetStream/pull/84#discussion_r2254866128 