### PR TITLE
Fixed Macos multiplatform sample

### DIFF
--- a/samples/SkiaMultiplatformSample/src/macosMain/kotlin/org/jetbrains/skiko/sample/App.macos.kt
+++ b/samples/SkiaMultiplatformSample/src/macosMain/kotlin/org/jetbrains/skiko/sample/App.macos.kt
@@ -50,5 +50,6 @@ fun main() {
     val clocks = MacosClocks(skiaLayer, window)
     skiaLayer.renderDelegate = SkiaLayerRenderDelegate(skiaLayer, clocks)
     window.makeKeyAndOrderFront(app)
+    skiaLayer.needRedraw()
     app.run()
 }

--- a/samples/SkiaMultiplatformSample/src/macosMain/kotlin/org/jetbrains/skiko/sample/MacosClocks.kt
+++ b/samples/SkiaMultiplatformSample/src/macosMain/kotlin/org/jetbrains/skiko/sample/MacosClocks.kt
@@ -11,7 +11,7 @@ import platform.AppKit.NSViewHeightSizable
 import platform.AppKit.NSViewWidthSizable
 import platform.AppKit.NSWindow
 
-class MacosClocks(skiaLayer: SkiaLayer, window: NSWindow) : Clocks(layer::renderApi) {
+class MacosClocks(layer: SkiaLayer, window: NSWindow) : Clocks(layer::renderApi) {
     init {
         val nsView = object : NSView(window.frame) {
             private var trackingArea : NSTrackingArea? = null
@@ -39,6 +39,6 @@ class MacosClocks(skiaLayer: SkiaLayer, window: NSWindow) : Clocks(layer::render
         val contentView = window.contentView!!
         nsView.autoresizingMask = NSViewHeightSizable or NSViewWidthSizable
         contentView.addSubview(nsView)
-        skiaLayer.attachTo(nsView)
+        layer.attachTo(nsView)
     }
 }


### PR DESCRIPTION
Fixed 
- Unresolved reference 'layer' in MacosClocks constructor
- Added startup trigger `skiaLayer.needRedraw()` in main()