### PR TITLE
Enable wasm skiko artefact building whenever we are building it for a sample in composite mode

### DIFF
--- a/skiko/buildSrc/src/main/kotlin/SkikoProjectContext.kt
+++ b/skiko/buildSrc/src/main/kotlin/SkikoProjectContext.kt
@@ -100,6 +100,10 @@ internal val Project.isInIdea: Boolean
         return System.getProperty("idea.active")?.toBoolean() == true
     }
 
+// gradle.parent property is not null only when module is an included build
+private val Project.isCompositeBuild: Boolean
+    get() = gradle.parent != null
+
 val Project.supportAndroid: Boolean
     get() = findProperty("skiko.android.enabled") == "true" // || isInIdea
 
@@ -149,7 +153,7 @@ val Project.supportAnyNative: Boolean
     get() = supportAllNative || supportAnyNativeIos || supportNativeMac || supportNativeLinux
 
 val Project.supportWeb: Boolean
-    get() = findProperty("skiko.wasm.enabled") == "true" || isInIdea
+    get() = findProperty("skiko.wasm.enabled") == "true" || isInIdea || isCompositeBuild
 
 fun Project.skiaVersion(target: String): String {
     val platformSpecificVersion = "dependencies.skia.$target"


### PR DESCRIPTION
As of now whenever we run web samples with `skiko.composite.build=1` from Idea we enforce enabling relevant targets -but this was not the case for running from Terminal or any other non-Idea environment (without Idea present)

This can confuse users and require from them an additional level of mental effort to figure out what's going on.

The goal of this PR is to solve this problem via approaching the problem similarly to IDEA-backed configuration - that is - enabled the relevant property when build is composite

