### PR TITLE
Provide a way to configure Skia's DirectContext GPU Resource Cache size

### DIFF
--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/DirectContext.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/DirectContext.kt
@@ -5,8 +5,20 @@ import org.jetbrains.skia.impl.Library.Companion.staticLoad
 import org.jetbrains.skiko.RenderException
 import org.jetbrains.skiko.loadOpenGLLibrary
 
-class DirectContext internal constructor(ptr: NativePointer) : RefCnt(ptr) {
+class DirectContext : RefCnt {
+
+    internal constructor(ptr: NativePointer) : super(ptr) {
+         DirectContext_nSetResourceCacheLimit(ptr, resourceCacheLimit)
+    }
+
     companion object {
+
+        /**
+         *  GPU resource cache limit in bytes used by DirectContext instances.
+         *  Set the property on the early startup of an application to take effect.
+         */
+        var resourceCacheLimit: Long = 256 * 1024 * 1024 // the same as Skia's default, see GrResourceCache.h, kDefaultMaxSize
+
         fun makeGL(): DirectContext {
             Stats.onNativeCall()
             loadOpenGLLibrary()
@@ -138,6 +150,9 @@ private external fun DirectContext_nFlush(ptr: NativePointer, surfacePtr: Native
 
 @ExternalSymbolName("org_jetbrains_skia_DirectContext__1nFlushDefault")
 private external fun DirectContext_nFlushDefault(ptr: NativePointer)
+
+@ExternalSymbolName("org_jetbrains_skia_DirectContext__1nSetResourceCacheLimit")
+private external fun DirectContext_nSetResourceCacheLimit(ptr: NativePointer, maxResourceBytes: Long)
 
 @ExternalSymbolName("org_jetbrains_skia_DirectContext__1nMakeGL")
 private external fun _nMakeGL(): NativePointer

--- a/skiko/src/jvmMain/cpp/common/DirectContext.cc
+++ b/skiko/src/jvmMain/cpp/common/DirectContext.cc
@@ -62,6 +62,12 @@ extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_DirectContextKt_Direct
     context->flush(skSurface);
 }
 
+extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_DirectContextKt_DirectContext_1nSetResourceCacheLimit
+(JNIEnv* env, jclass jclass, jlong ptr, jlong maxResourceBytes) {
+    GrDirectContext* context = reinterpret_cast<GrDirectContext*>(static_cast<uintptr_t>(ptr));
+    context->setResourceCacheLimit((size_t) maxResourceBytes);
+}
+
 GrSyncCpu grSyncCpuFromBool(bool syncCpu) {
   if (syncCpu) return GrSyncCpu::kYes;
   return GrSyncCpu::kNo;

--- a/skiko/src/nativeJsMain/cpp/DirectContext.cc
+++ b/skiko/src/nativeJsMain/cpp/DirectContext.cc
@@ -68,6 +68,13 @@ SKIKO_EXPORT void org_jetbrains_skia_DirectContext__1nFlush
     context->flush(skSurface);
 }
 
+SKIKO_EXPORT void org_jetbrains_skia_DirectContext__1nSetResourceCacheLimit
+        (KNativePointer ptr, KLong maxResourceBytes) {
+    GrDirectContext* context = reinterpret_cast<GrDirectContext*>(ptr);
+    context->setResourceCacheLimit((size_t) maxResourceBytes);
+}
+
+
 GrSyncCpu grSyncCpuFromBool(bool syncCpu) {
     if (syncCpu) return GrSyncCpu::kYes;
     return GrSyncCpu::kNo;


### PR DESCRIPTION
Fixes: [CMP-8916](https://youtrack.jetbrains.com/issue/CMP-8916/Provide-a-way-to-configure-Skias-DirectContext-GPU-Resource-Cache-size)