### PR TITLE
Restore `/var/lib/apt/lists` in `linux-amd64` docker image

### DIFF
--- a/skiko/docker/linux-amd64/Dockerfile
+++ b/skiko/docker/linux-amd64/Dockerfile
@@ -11,8 +11,7 @@ RUN apt-get update -y && \
     update-alternatives --config gcc && \
     apt-get install gcc-9-aarch64-linux-gnu g++-9-aarch64-linux-gnu -y && \
     update-alternatives --install /usr/bin/aarch64-linux-gnu-gcc aarch64-linux-gnu-gcc /usr/bin/aarch64-linux-gnu-gcc-9 60 --slave /usr/bin/aarch64-linux-gnu-g++ aarch64-linux-gnu-g++ /usr/bin/aarch64-linux-gnu-g++-9 && \
-    update-alternatives --config aarch64-linux-gnu-gcc && \
-    rm -rf /var/lib/apt/lists/*
+    update-alternatives --config aarch64-linux-gnu-gcc
 
 # Install chromium tools
 ENV DEPOT_TOOLS=/usr/depot_tools


### PR DESCRIPTION
It fixes
```
:setupMultistrapLinuxArm64
  E: Can't find a source to download version '2020.02.11.4' of 'ubuntu-keyring:amd64'
```
failure on CI (#1096 regression).

Usually `/var/lib/apt/lists` is recommended to be removed from final docker images. But in our case, `multistrap` tool requires downloading some dependencies during the build.
It's the issue only on `linux-amd64`, for others linux images this removal is correct.