### PR TITLE
Fix "ComposePanel doesn't use hardware acceleration with RenderSettings.SwingGraphics on Linux"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,7 +286,7 @@ jobs:
           java-version: '21'
           cache: 'gradle'
 
-      # OPENGL is ignored as it doesn't exist on GitHub actions agents
+      # OPENGL is ignored as it doesn't exist on the Windows GitHub agent
       - shell: bash
         name: 'Compile and run AWT tests'
         run: ./gradlew --stacktrace --info -Pskiko.test.onci=true -Pskiko.test.ui.renderApi.ignoreAssertsFor=OPENGL :skiko:awtTest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
           sudo apt-get install gcc-9-aarch64-linux-gnu g++-9-aarch64-linux-gnu -y
           sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-gcc aarch64-linux-gnu-gcc /usr/bin/aarch64-linux-gnu-gcc-9 60 --slave /usr/bin/aarch64-linux-gnu-g++ aarch64-linux-gnu-g++ /usr/bin/aarch64-linux-gnu-g++-9
           sudo update-alternatives --config aarch64-linux-gnu-gcc
-          sudo Xvfb :0 -screen 0 1280x720x24 &
+          sudo Xvfb :0 -screen 0 1280x720x24 +extension GLX &
 
       - shell: bash
         name: 'Compile and run Linux x64 tests'
@@ -178,12 +178,11 @@ jobs:
         run: |
           ./gradlew --no-daemon --stacktrace --info -Pskiko.native.enabled=true -Pskiko.test.onci=true :skiko:linkDebugTestLinuxArm64
 
-      # OPENGL is ignored as it doesn't exist on GitHub actions agents
       - shell: bash
         name: 'Compile and run AWT tests'
         run: |
           export DISPLAY=:0
-          ./gradlew --no-daemon --stacktrace --info -Pskiko.native.enabled=true -Pkotlin.native.cacheKind.linuxX64=none -Pskiko.test.onci=true -Pskiko.test.ui.renderApi.ignoreAssertsFor=OPENGL :skiko:awtTest
+          ./gradlew --no-daemon --stacktrace --info -Pskiko.native.enabled=true -Pkotlin.native.cacheKind.linuxX64=none -Pskiko.test.onci=true :skiko:awtTest
         timeout-minutes: 25
 
       - shell: bash
@@ -239,7 +238,7 @@ jobs:
           sudo apt-get remove g++ -y
           sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-11 100
           sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-11 100
-          sudo Xvfb :0 -screen 0 1280x720x24 &
+          sudo Xvfb :0 -screen 0 1280x720x24 +extension GLX &
 
       - shell: bash
         name: 'Run Linux arm64 tests'
@@ -249,12 +248,11 @@ jobs:
           chmod +x ./build/bin/linuxArm64/debugTest/test.kexe
           ./build/bin/linuxArm64/debugTest/test.kexe
 
-      # OPENGL is ignored as it doesn't exist on GitHub actions agents
       - shell: bash
         name: 'Compile and run AWT tests'
         run: |
           export DISPLAY=:0
-          ./gradlew --no-daemon --stacktrace --info -Pskiko.test.onci=true -Pskiko.test.ui.renderApi.ignoreAssertsFor=OPENGL :skiko:awtTest
+          ./gradlew --no-daemon --stacktrace --info -Pskiko.test.onci=true :skiko:awtTest
         timeout-minutes: 25
 
       - shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,11 +178,12 @@ jobs:
         run: |
           ./gradlew --no-daemon --stacktrace --info -Pskiko.native.enabled=true -Pskiko.test.onci=true :skiko:linkDebugTestLinuxArm64
 
+      # OPENGL is ignored as it doesn't exist on GitHub actions agents
       - shell: bash
         name: 'Compile and run AWT tests'
         run: |
           export DISPLAY=:0
-          ./gradlew --no-daemon --stacktrace --info -Pskiko.native.enabled=true -Pkotlin.native.cacheKind.linuxX64=none -Pskiko.test.onci=true :skiko:awtTest
+          ./gradlew --no-daemon --stacktrace --info -Pskiko.native.enabled=true -Pkotlin.native.cacheKind.linuxX64=none -Pskiko.test.onci=true -Pskiko.test.ui.renderApi.ignoreAssertsFor=OPENGL :skiko:awtTest
         timeout-minutes: 25
 
       - shell: bash
@@ -248,11 +249,12 @@ jobs:
           chmod +x ./build/bin/linuxArm64/debugTest/test.kexe
           ./build/bin/linuxArm64/debugTest/test.kexe
 
+      # OPENGL is ignored as it doesn't exist on GitHub actions agents
       - shell: bash
         name: 'Compile and run AWT tests'
         run: |
           export DISPLAY=:0
-          ./gradlew --no-daemon --stacktrace --info -Pskiko.test.onci=true :skiko:awtTest
+          ./gradlew --no-daemon --stacktrace --info -Pskiko.test.onci=true -Pskiko.test.ui.renderApi.ignoreAssertsFor=OPENGL :skiko:awtTest
         timeout-minutes: 25
 
       - shell: bash
@@ -286,9 +288,10 @@ jobs:
           java-version: '21'
           cache: 'gradle'
 
+      # OPENGL is ignored as it doesn't exist on GitHub actions agents
       - shell: bash
         name: 'Compile and run AWT tests'
-        run: ./gradlew --stacktrace --info -Pskiko.test.onci=true :skiko:awtTest
+        run: ./gradlew --stacktrace --info -Pskiko.test.onci=true -Pskiko.test.ui.renderApi.ignoreAssertsFor=OPENGL :skiko:awtTest
 
       - shell: bash
         name: 'Publish to Maven Local, check AWT sample'

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/JvmTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/JvmTasksConfiguration.kt
@@ -504,6 +504,7 @@ fun SkikoProjectContext.setupJvmTestTask(skikoAwtJarForTests: TaskProvider<Jar>,
             )
             systemProperty("skiko.test.ui.enabled", System.getProperty("skiko.test.ui.enabled", canRunUiTests.toString()))
             systemProperty("skiko.test.ui.renderApi", System.getProperty("skiko.test.ui.renderApi", "all"))
+            systemProperty("skiko.test.ui.renderApi.ignoreAssertsFor", System.getProperty("skiko.test.ui.renderApi.ignoreAssertsFor", "OPENGL"))
             systemProperty("skiko.test.debug", buildType == SkiaBuildType.DEBUG)
 
             // Tests should be deterministic, so disable scaling.

--- a/skiko/src/awtMain/cpp/linux/swingRedrawer.cc
+++ b/skiko/src/awtMain/cpp/linux/swingRedrawer.cc
@@ -30,9 +30,8 @@ public:
 
     static OffScreenContext* create() {
         const int glxContextAttribs[] {
-            GLX_DRAWABLE_TYPE, GLX_WINDOW_BIT,
+            GLX_DRAWABLE_TYPE, GLX_PBUFFER_BIT,
             GLX_RENDER_TYPE, GLX_RGBA_BIT,
-            GLX_DOUBLEBUFFER, False,
             GLX_RED_SIZE, 8,
             GLX_GREEN_SIZE, 8,
             GLX_BLUE_SIZE, 8,

--- a/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
+++ b/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
@@ -182,6 +182,8 @@ class SkiaLayerTest {
             window.layer.needRedraw()
             delay(1000)
             screenshots.assert(window.bounds, "frame2")
+
+            assertEquals(window.layer.renderApi, renderApi)
         } finally {
             window.close()
         }
@@ -211,6 +213,8 @@ class SkiaLayerTest {
             layer.repaint()
             delay(1000)
             screenshots.assert(window.bounds, "frame2")
+
+            assertEquals(layer.renderApi, renderApi)
         } finally {
             window.close()
         }
@@ -237,6 +241,8 @@ class SkiaLayerTest {
             window.layer.needRedraw()
             delay(1000)
             screenshots.assert(window.bounds, "frame2")
+
+            assertEquals(window.layer.renderApi, renderApi)
         } finally {
             window.close()
         }
@@ -288,6 +294,8 @@ class SkiaLayerTest {
             layer.size = Dimension(40, 40)
             delay(1000)
             assertEquals((40 * density).toInt(), renderedWidth)
+
+            assertEquals(layer.renderApi, renderApi)
         } finally {
             layer.dispose()
             window.close()
@@ -330,6 +338,8 @@ class SkiaLayerTest {
             box.setBounds(100, 0, 100, 100)
             delay(1000)
             screenshots.assert(window.bounds, "frame2")
+
+            assertEquals(layer.renderApi, renderApi)
         } finally {
             layer.dispose()
             window.close()
@@ -352,6 +362,8 @@ class SkiaLayerTest {
             delay(1000)
 
             screenshots.assert(window.bounds)
+
+            assertEquals(window.layer.renderApi, renderApi)
         } finally {
             window.close()
         }
@@ -386,6 +398,10 @@ class SkiaLayerTest {
             window3.toFront()
             delay(1000)
             screenshots.assert(window3.bounds, "window3")
+
+            assertEquals(window1.layer.renderApi, renderApi)
+            assertEquals(window2.layer.renderApi, renderApi)
+            assertEquals(window3.layer.renderApi, renderApi)
         } finally {
             window1.close()
             window2.close()
@@ -410,6 +426,7 @@ class SkiaLayerTest {
 
             delay(1000)
             assertEquals(true, stateRemainsFullscreen)
+            assertEquals(window.layer.renderApi, renderApi)
         } finally {
             window.close()
 
@@ -490,6 +507,9 @@ class SkiaLayerTest {
             if (delayCount > 0) {
                 delay(delayCount * 10)
             }
+            openedWindows.forEach {
+                assertEquals(it.layer.renderApi, renderApi)
+            }
         }
 
         openedWindows.forEach(JFrame::close)
@@ -514,6 +534,7 @@ class SkiaLayerTest {
         repeat(100) {
             window.size = Dimension(200 + Random.nextInt(200), 200 + Random.nextInt(200))
             window.paint(window.graphics)
+            assertEquals(window.layer.renderApi, renderApi)
             yield()
         }
 
@@ -542,6 +563,7 @@ class SkiaLayerTest {
             window.layer.needRedraw()
             yield()
             window.paint(window.graphics)
+            assertEquals(window.layer.renderApi, renderApi)
             window.close()
         }
     }
@@ -690,6 +712,7 @@ class SkiaLayerTest {
             window.isVisible = true
 
             onDrawCompleted.await()
+            assertEquals(window.layer.renderApi, renderApi)
         } finally {
             window.close()
         }
@@ -977,6 +1000,7 @@ class SkiaLayerTest {
             assertEquals(0, lineMetrics.first().lineNumber)
 
             screenshots.assert(window.bounds)
+            assertEquals(window.layer.renderApi, renderApi)
         } finally {
             window.close()
         }

--- a/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
+++ b/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
@@ -183,7 +183,7 @@ class SkiaLayerTest {
             delay(1000)
             screenshots.assert(window.bounds, "frame2")
 
-            assertEquals(window.layer.renderApi, renderApi)
+            assertRenderApiFor(window.layer)
         } finally {
             window.close()
         }
@@ -214,7 +214,7 @@ class SkiaLayerTest {
             delay(1000)
             screenshots.assert(window.bounds, "frame2")
 
-            assertEquals(layer.renderApi, renderApi)
+            assertRenderApiFor(layer)
         } finally {
             window.close()
         }
@@ -242,7 +242,7 @@ class SkiaLayerTest {
             delay(1000)
             screenshots.assert(window.bounds, "frame2")
 
-            assertEquals(window.layer.renderApi, renderApi)
+            assertRenderApiFor(window.layer)
         } finally {
             window.close()
         }
@@ -295,7 +295,7 @@ class SkiaLayerTest {
             delay(1000)
             assertEquals((40 * density).toInt(), renderedWidth)
 
-            assertEquals(layer.renderApi, renderApi)
+            assertRenderApiFor(layer)
         } finally {
             layer.dispose()
             window.close()
@@ -339,7 +339,7 @@ class SkiaLayerTest {
             delay(1000)
             screenshots.assert(window.bounds, "frame2")
 
-            assertEquals(layer.renderApi, renderApi)
+            assertRenderApiFor(layer)
         } finally {
             layer.dispose()
             window.close()
@@ -363,7 +363,7 @@ class SkiaLayerTest {
 
             screenshots.assert(window.bounds)
 
-            assertEquals(window.layer.renderApi, renderApi)
+            assertRenderApiFor(window.layer)
         } finally {
             window.close()
         }
@@ -399,9 +399,9 @@ class SkiaLayerTest {
             delay(1000)
             screenshots.assert(window3.bounds, "window3")
 
-            assertEquals(window1.layer.renderApi, renderApi)
-            assertEquals(window2.layer.renderApi, renderApi)
-            assertEquals(window3.layer.renderApi, renderApi)
+            assertRenderApiFor(window1.layer)
+            assertRenderApiFor(window2.layer)
+            assertRenderApiFor(window3.layer)
         } finally {
             window1.close()
             window2.close()
@@ -426,7 +426,7 @@ class SkiaLayerTest {
 
             delay(1000)
             assertEquals(true, stateRemainsFullscreen)
-            assertEquals(window.layer.renderApi, renderApi)
+            assertRenderApiFor(window.layer)
         } finally {
             window.close()
 
@@ -507,8 +507,9 @@ class SkiaLayerTest {
             if (delayCount > 0) {
                 delay(delayCount * 10)
             }
+
             openedWindows.forEach {
-                assertEquals(it.layer.renderApi, renderApi)
+                assertRenderApiFor(it.layer)
             }
         }
 
@@ -534,7 +535,7 @@ class SkiaLayerTest {
         repeat(100) {
             window.size = Dimension(200 + Random.nextInt(200), 200 + Random.nextInt(200))
             window.paint(window.graphics)
-            assertEquals(window.layer.renderApi, renderApi)
+            assertRenderApiFor(window.layer)
             yield()
         }
 
@@ -563,7 +564,7 @@ class SkiaLayerTest {
             window.layer.needRedraw()
             yield()
             window.paint(window.graphics)
-            assertEquals(window.layer.renderApi, renderApi)
+            assertRenderApiFor(window.layer)
             window.close()
         }
     }
@@ -712,7 +713,7 @@ class SkiaLayerTest {
             window.isVisible = true
 
             onDrawCompleted.await()
-            assertEquals(window.layer.renderApi, renderApi)
+            assertRenderApiFor(window.layer)
         } finally {
             window.close()
         }
@@ -1000,7 +1001,7 @@ class SkiaLayerTest {
             assertEquals(0, lineMetrics.first().lineNumber)
 
             screenshots.assert(window.bounds)
-            assertEquals(window.layer.renderApi, renderApi)
+            assertRenderApiFor(window.layer)
         } finally {
             window.close()
         }

--- a/skiko/src/awtTest/kotlin/org/jetbrains/skiko/util/UiTest.kt
+++ b/skiko/src/awtTest/kotlin/org/jetbrains/skiko/util/UiTest.kt
@@ -3,6 +3,8 @@ package org.jetbrains.skiko.util
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.skiko.*
+import org.jetbrains.skiko.swing.SkiaSwingLayer
+import org.junit.Assert.assertEquals
 import org.junit.Assume.assumeFalse
 import org.junit.Assume.assumeTrue
 import java.awt.GraphicsEnvironment
@@ -58,6 +60,25 @@ internal class UiTestScope(
 
         init {
             setupContent()
+        }
+    }
+
+    private val ignoreAssertsFor =
+        System.getProperty("skiko.test.ui.renderApi.ignoreAssertsFor")
+            .split(",")
+            .filter { it.isNotBlank() }
+            .map(GraphicsApi::valueOf)
+
+    fun assertRenderApiFor(layer: SkiaLayer) {
+        if (renderApi !in ignoreAssertsFor) {
+            assertEquals(renderApi, layer.renderApi)
+        }
+    }
+
+    @OptIn(ExperimentalSkikoApi::class)
+    fun assertRenderApiFor(layer: SkiaSwingLayer) {
+        if (renderApi !in ignoreAssertsFor) {
+            assertEquals(renderApi, layer.renderApi)
         }
     }
 }


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-8936

`glXChooseFBConfig` fails to find a config with `GLX_DOUBLEBUFFER, False` on my machine, it only has double buffered configs. But double/single buffering doesn't matter as we use pixel buffers.

Also choose a correct config that is required by https://registry.khronos.org/OpenGL-Refpages/gl2.1/xhtml/glXCreatePbuffer.xml:
```
BadMatch is generated if config does not support rendering to pixel buffers (e.g., GLX_DRAWABLE_TYPE does not contain GLX_PBUFFER_BIT)
```

## Testing
- manually, in the clocks example
- the modified test failed before the fix, now it doesn't fail

## Release Notes (Skiko)
Fix "SkiaSwingLayer doesn't use hardware acceleration on Linux"

## Release Notes (Compose)
### Fixes - Desktop 
Fix "ComposePanel doesn't use hardware acceleration with RenderSettings.SwingGraphics on Linux"