### PR TITLE
Update android ndk version in CI to fix publication of android 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
         name: 'Set up Android NDK'
         id: setup-ndk
         with:
-          ndk-version: r21e
+          ndk-version: r27d
 
       - uses: android-actions/setup-android@v2
         name: 'Set up Android SDK'

--- a/skiko/docker/linux-android-amd64/Dockerfile
+++ b/skiko/docker/linux-android-amd64/Dockerfile
@@ -19,12 +19,12 @@ RUN mkdir -p $CMD_TOOLS_ROOT && \
     unzip cmd-tools.zip && \
     rm cmd-tools.zip && \
     mv cmdline-tools/* $CMD_TOOLS_ROOT/
-ARG ANDROID_PLATFORM=android-33
+ARG ANDROID_PLATFORM=android-35
 RUN yes | $SDK_MANAGER --licenses && \
     $SDK_MANAGER "platforms;$ANDROID_PLATFORM" && \
     cd $ANDROID_SDK_ROOT/platforms/$ANDROID_PLATFORM && \
     ls -1 | grep -v android.jar | xargs rm -rf
-ARG NDK_VERSION=21.4.7075529
+ARG NDK_VERSION=27.3.13750724
 RUN $SDK_MANAGER "ndk;$NDK_VERSION" && \
     cd $ANDROID_SDK_ROOT/ndk/$NDK_VERSION && \
     ls -1 | grep -v toolchains | xargs rm -rf


### PR DESCRIPTION
This refs https://youtrack.jetbrains.com/issue/SKIKO-761
The distributed binary published to the maven repo still does not work correctly. 
