### PR TITLE
Fix PathSegment.hashCode() not handling PathVerb.CLOSE

### DIFF
--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/PathSegment.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/PathSegment.kt
@@ -114,7 +114,7 @@ class PathSegment constructor(
                 isClosedContour
             )
             PathVerb.CUBIC -> objectHashes(verb, p0, p1, p2, p3, isClosedContour)
-            else -> throw RuntimeException("Unreachable")
+            PathVerb.CLOSE -> objectHashes(verb, p0, isClosedContour)
         }
     }
 }

--- a/skiko/src/commonTest/kotlin/org/jetbrains/skia/PathTest.kt
+++ b/skiko/src/commonTest/kotlin/org/jetbrains/skia/PathTest.kt
@@ -189,4 +189,25 @@ class PathTest {
         assertEquals(p0, line?.get(0))
         assertEquals(p1, line?.get(1))
     }
+
+    @Test
+    fun closedPathIntersectTest() {
+        val builder1 = PathBuilder()
+            .moveTo(0f, 0f)
+            .lineTo(40f, 40f)
+            .lineTo(40f, 20f)
+            .closePath()
+
+        val builder2 = PathBuilder()
+            .moveTo(0f, 0f)
+            .lineTo(20f, 20f)
+            .lineTo(40f, 20f)
+            .closePath()
+
+        val triangle1 = builder1.detach()
+        val triangle2 = builder2.detach()
+
+        val result = triangle1.intersect(triangle2)
+        assertTrue(result.isNotEmpty())
+    }
 }


### PR DESCRIPTION
PathSegment.hashCode() threw RuntimeException("Unreachable") for PathVerb.CLOSE segments when used in hash-based collections such as intersect(). Added CLOSE case consistent with what equals() checks for CLOSE segments. Also removed the else branch since all PathVerb values are now handled. Added a test which fails unless CLOSE is handled in hashCode().

## Testing
Ran test on awt locally — the new test `closedPathIntersectTest` fails 
before the fix and passes after.

## Release Notes
Fix crash when using closed paths in hash-based collections such as `intersect()`

Fixes: [SKIKO-1038](https://youtrack.jetbrains.com/issue/SKIKO-1038)