### PR TITLE
Restore `Path.updateBoundsCache` native bridge and add regression test

### DIFF
--- a/skiko/src/commonTest/kotlin/org/jetbrains/skia/PathTest.kt
+++ b/skiko/src/commonTest/kotlin/org/jetbrains/skia/PathTest.kt
@@ -112,6 +112,14 @@ class PathTest {
     }
 
     @Test
+    fun updateBoundsCacheTest() {
+        val path = PathBuilder().lineTo(40f, 40f).lineTo(40f, 0f).lineTo(0f, 40f).lineTo(0f, 0f).closePath().detach()
+        val bounds = Rect(0.0f, 0.0f, 40.0f, 40.0f)
+        assertTrue(path.updateBoundsCache() === path)
+        assertCloseEnough(bounds, path.bounds)
+    }
+
+    @Test
     fun rawTest() {
         val pts = arrayOf(Point(0f, 0f), Point(10f, 10f), Point(20f, 0f))
         val verbs = arrayOf(PathVerb.MOVE, PathVerb.LINE, PathVerb.LINE)

--- a/skiko/src/jvmMain/cpp/common/Path.cc
+++ b/skiko/src/jvmMain/cpp/common/Path.cc
@@ -195,6 +195,11 @@ extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_PathKt__1nGetBounds(JN
     skija::Rect::copyToInterop(env, instance->getBounds(), resultArray);
 }
 
+extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_PathKt__1nUpdateBoundsCache(JNIEnv* env, jclass jclass, jlong ptr) {
+    SkPath* instance = reinterpret_cast<SkPath*>(static_cast<uintptr_t>(ptr));
+    instance->updateBoundsCache();
+}
+
 extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_PathKt__1nComputeTightBounds(JNIEnv* env, jclass jclass, jlong ptr, jfloatArray resultArray) {
     SkPath* instance = reinterpret_cast<SkPath*>(static_cast<uintptr_t>(ptr));
     skija::Rect::copyToInterop(env, instance->computeTightBounds(), resultArray);

--- a/skiko/src/nativeJsMain/cpp/Path.cc
+++ b/skiko/src/nativeJsMain/cpp/Path.cc
@@ -187,6 +187,11 @@ SKIKO_EXPORT void org_jetbrains_skia_Path__1nGetBounds(KNativePointer ptr, KInte
     skija::Rect::copyToInterop(bounds, resultArray);
 }
 
+SKIKO_EXPORT void org_jetbrains_skia_Path__1nUpdateBoundsCache(KNativePointer ptr) {
+    SkPath* instance = reinterpret_cast<SkPath*>((ptr));
+    instance->updateBoundsCache();
+}
+
 SKIKO_EXPORT void org_jetbrains_skia_Path__1nComputeTightBounds(KNativePointer ptr, KInteropPointer resultArray) {
     SkPath* instance = reinterpret_cast<SkPath*>((ptr));
     SkRect bounds = instance->computeTightBounds();


### PR DESCRIPTION
[CMP-10199](https://youtrack.jetbrains.com/issue/CMP-10199) [iOS] Undefined symbol '_org_jetbrains_skia_Path__1nUpdateBoundsCache

It was removed in #1187 by accident, and there was no test to catch it