### PR TITLE
Use maven cache redirector

### DIFF
--- a/samples/SkiaAndroidSample/build.gradle.kts
+++ b/samples/SkiaAndroidSample/build.gradle.kts
@@ -5,7 +5,9 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 buildscript {
     repositories {
         google()
-        mavenCentral()
+        mavenCentral {
+            url = uri("https://cache-redirector.jetbrains.com/maven-central")
+        }
         maven("https://redirector.kotlinlang.org/maven/compose-dev")
     }
 
@@ -17,7 +19,9 @@ buildscript {
 repositories {
     mavenLocal()
     google()
-    mavenCentral()
+    mavenCentral {
+        url = uri("https://cache-redirector.jetbrains.com/maven-central")
+    }
     maven("https://redirector.kotlinlang.org/maven/compose-dev")
 }
 

--- a/samples/SkiaAwtSample/build.gradle.kts
+++ b/samples/SkiaAwtSample/build.gradle.kts
@@ -7,7 +7,9 @@ plugins {
 
 repositories {
     mavenLocal()
-    mavenCentral()
+    mavenCentral {
+        url = uri("https://cache-redirector.jetbrains.com/maven-central")
+    }
     maven("https://redirector.kotlinlang.org/maven/compose-dev")
 }
 

--- a/samples/SkiaAwtSample/settings.gradle.kts
+++ b/samples/SkiaAwtSample/settings.gradle.kts
@@ -1,6 +1,8 @@
 pluginManagement {
     repositories {
-        mavenCentral()
+        mavenCentral {
+            url = uri("https://cache-redirector.jetbrains.com/maven-central")
+        }
         gradlePluginPortal()
     }
 

--- a/samples/SkiaMultiplatformSample/build.gradle.kts
+++ b/samples/SkiaMultiplatformSample/build.gradle.kts
@@ -3,7 +3,9 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.*
 buildscript {
     repositories {
         google()
-        mavenCentral()
+        mavenCentral {
+            url = uri("https://cache-redirector.jetbrains.com/maven-central")
+        }
         maven("https://redirector.kotlinlang.org/maven/compose-dev")
     }
 
@@ -20,7 +22,9 @@ plugins {
 
 repositories {
     google()
-    mavenCentral()
+    mavenCentral {
+        url = uri("https://cache-redirector.jetbrains.com/maven-central")
+    }
     mavenLocal()
     maven("https://redirector.kotlinlang.org/maven/compose-dev")
 }

--- a/samples/SkiaMultiplatformSample/settings.gradle.kts
+++ b/samples/SkiaMultiplatformSample/settings.gradle.kts
@@ -1,6 +1,8 @@
 pluginManagement {
     repositories {
-        mavenCentral()
+        mavenCentral {
+            url = uri("https://cache-redirector.jetbrains.com/maven-central")
+        }
         gradlePluginPortal()
         google()
         maven("https://redirector.kotlinlang.org/maven/compose-dev")

--- a/samples/SkiaWebSample/build.gradle.kts
+++ b/samples/SkiaWebSample/build.gradle.kts
@@ -3,7 +3,9 @@ plugins {
 }
 
 repositories {
-    mavenCentral()
+    mavenCentral {
+        url = uri("https://cache-redirector.jetbrains.com/maven-central")
+    }
     maven("https://redirector.kotlinlang.org/maven/compose-dev")
     mavenLocal()
 }

--- a/samples/SkiaWebSample/settings.gradle.kts
+++ b/samples/SkiaWebSample/settings.gradle.kts
@@ -1,7 +1,9 @@
 pluginManagement {
     repositories {
         mavenLocal()
-        mavenCentral()
+        mavenCentral {
+            url = uri("https://cache-redirector.jetbrains.com/maven-central")
+        }
         gradlePluginPortal()
         maven {
             url = uri("https://dl.bintray.com/kotlin/kotlin-eap")

--- a/skiko/build.gradle.kts
+++ b/skiko/build.gradle.kts
@@ -54,7 +54,9 @@ allprojects {
 }
 
 repositories {
-    mavenCentral()
+    mavenCentral {
+        url = uri("https://cache-redirector.jetbrains.com/maven-central")
+    }
     google()
 }
 

--- a/skiko/buildSrc/settings.gradle.kts
+++ b/skiko/buildSrc/settings.gradle.kts
@@ -1,6 +1,8 @@
 pluginManagement {
     repositories {
-        mavenCentral()
+        mavenCentral {
+            url = uri("https://cache-redirector.jetbrains.com/maven-central")
+        }
         gradlePluginPortal()
     }
 }
@@ -29,7 +31,9 @@ dependencyResolutionManagement {
             }
         }
 
-        mavenCentral()
+        mavenCentral {
+            url = uri("https://cache-redirector.jetbrains.com/maven-central")
+        }
     }
 
     versionCatalogs {

--- a/skiko/import-generator/build.gradle.kts
+++ b/skiko/import-generator/build.gradle.kts
@@ -5,7 +5,9 @@ plugins {
 }
 
 repositories {
-    mavenCentral()
+    mavenCentral {
+        url = uri("https://cache-redirector.jetbrains.com/maven-central")
+    }
 }
 
 kotlin {

--- a/skiko/settings.gradle.kts
+++ b/skiko/settings.gradle.kts
@@ -8,7 +8,9 @@ dependencyResolutionManagement {
 
 pluginManagement {
     repositories {
-        mavenCentral()
+        mavenCentral {
+            url = uri("https://cache-redirector.jetbrains.com/maven-central")
+        }
         gradlePluginPortal()
         google()
     }


### PR DESCRIPTION
```
Failed to get resource: GET. [HTTP HTTP/1.1 429 Too Many Requests: https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugins-bom/2.0.21/kotlin-gradle-plugins-bom-2.0.21.pom)]
Failed to get resource: GET. [HTTP HTTP/1.1 429 Too Many Requests: https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/2.0.21/kotlin-stdlib-2.0.21.pom)]
```