### PR TITLE
Fix possible logic error in SkiaSwingLayer

### DIFF
--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SkiaSwingLayer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SkiaSwingLayer.kt
@@ -39,7 +39,7 @@ open class SkiaSwingLayer(
     @Volatile
     private var isDisposed = false
 
-    val clipComponents: MutableList<ClipRectangle> get() = mutableListOf()
+    val clipComponents: MutableList<ClipRectangle> = mutableListOf()
 
     private val renderDelegateWithClipping = SkikoRenderDelegate { canvas, width, height, nanoTime ->
         val scale = graphicsConfiguration.defaultTransform.scaleX.toFloat()


### PR DESCRIPTION
Fixes [SKIKO-1135](https://youtrack.jetbrains.com/issue/SKIKO-1135/SkiaSwingLayer-possible-logic-error)
Since it was accessed in
```kotlin
    private val renderDelegateWithClipping = SkikoRenderDelegate { canvas, width, height, nanoTime ->
        val scale = graphicsConfiguration.defaultTransform.scaleX.toFloat()
        // clipping
        clipComponents.fastForEach { component ->
            canvas.cutoutFromClip(component, scale)
        }
        renderDelegate.onRender(canvas, width, height, nanoTime)
    }
``` 
on every frame it will create a MutableList object with 10 as initial capacity, whether there was clip components or not.
I don't know if I'm missing something....

Jewel and everyone using Swing as a lightweight alternative to AWT, possibly affecting their performance??