### PR TITLE
Remove DSK_TRIVIAL_ABI, we don't need it anymore

### DIFF
--- a/skiko/buildSrc/src/main/kotlin/properties.kt
+++ b/skiko/buildSrc/src/main/kotlin/properties.kt
@@ -82,7 +82,7 @@ enum class SkiaBuildType(
     DEBUG(
         id = "Debug",
         flags = arrayOf("-DSK_DEBUG"),
-        clangFlags = arrayOf("-std=c++2a", "-g", "-DSK_TRIVIAL_ABI=[[clang::trivial_abi]]"),
+        clangFlags = arrayOf("-std=c++2a", "-g"),
         winCompilerFlags = arrayOf("/Zi", "/std:c++20"),
         winLinkerFlags = arrayOf("/DEBUG"),
     ),


### PR DESCRIPTION
We must use the same clang flags to build JNI cpp shims as we use to build skia