### PR TITLE
Make getCurrentSystemTheme on Linux thread-safe

### DIFF
--- a/skiko/src/awtMain/cpp/linux/theme.cc
+++ b/skiko/src/awtMain/cpp/linux/theme.cc
@@ -5,33 +5,28 @@
 
 #include "jni_helpers.h"
 
+static bool initDbusThreads(void* lib) {
+    auto func = (dbus_bool_t(*)()) dlsym(lib, "dbus_threads_init_default");
+    if (func) func();
+    return true;
+}
+
 static void* loadLibDbus() {
-    static void* result = nullptr;
-    if (result != nullptr) return result;
-    result = dlopen("libdbus-1.so", RTLD_LAZY | RTLD_LOCAL);
+    static void* result = dlopen("libdbus-1.so", RTLD_LAZY | RTLD_LOCAL);
+    static bool _ = result && initDbusThreads(result);
     return result;
 }
 
 static DBusMessage* dbus_message_new_method_call_dynamic(const char *bus_name, const char *path, const char *iface, const char *method) {
     typedef DBusMessage* (*dbus_message_new_method_call_t)(const char*, const char*, const char*, const char*);
-    static dbus_message_new_method_call_t func = nullptr;
-    if(!func) {
-        void* lib = loadLibDbus();
-        if(!lib) return nullptr;
-        func = (dbus_message_new_method_call_t) dlsym(lib, "dbus_message_new_method_call");
-    }
-    if(!func) return nullptr;
+    static dbus_message_new_method_call_t func = (dbus_message_new_method_call_t) dlsym(loadLibDbus(), "dbus_message_new_method_call");
+    if (!func) return nullptr;
     return func(bus_name, path, iface, method);
 }
 
 static dbus_bool_t dbus_message_append_args_dynamic(DBusMessage *message, int first_arg_type, ...) {
     typedef dbus_bool_t (*dbus_message_append_args_valist_t)(DBusMessage *, int, va_list);
-    static dbus_message_append_args_valist_t func = nullptr;
-    if (!func) {
-        void *lib = loadLibDbus();
-        if (!lib) return false;
-        func = (dbus_message_append_args_valist_t) dlsym(lib, "dbus_message_append_args_valist");
-    }
+    static dbus_message_append_args_valist_t func = (dbus_message_append_args_valist_t) dlsym(loadLibDbus(), "dbus_message_append_args_valist");
     if (!func) return false;
     va_list var_args;
     va_start(var_args, first_arg_type);
@@ -42,112 +37,67 @@ static dbus_bool_t dbus_message_append_args_dynamic(DBusMessage *message, int fi
 
 static DBusMessage* dbus_connection_send_with_reply_and_block_dynamic(DBusConnection *connection, DBusMessage *message, int timeout_milliseconds, DBusError *error) {
     typedef DBusMessage* (*dbus_connection_send_with_reply_and_block_t)(DBusConnection*, DBusMessage*, int, DBusError*);
-    static dbus_connection_send_with_reply_and_block_t func = nullptr;
-    if(!func) {
-        void* lib = loadLibDbus();
-        if(!lib) return nullptr;
-        func = (dbus_connection_send_with_reply_and_block_t) dlsym(lib, "dbus_connection_send_with_reply_and_block");
-    }
-    if(!func) return nullptr;
+    static dbus_connection_send_with_reply_and_block_t func = (dbus_connection_send_with_reply_and_block_t) dlsym(loadLibDbus(), "dbus_connection_send_with_reply_and_block");
+    if (!func) return nullptr;
     return func(connection, message, timeout_milliseconds, error);
 }
 
 static bool dbus_message_unref_dynamic(DBusMessage *message) {
     typedef void* (*dbus_message_unref_t)(DBusMessage*);
-    static dbus_message_unref_t func = nullptr;
-    if(!func) {
-        void* lib = loadLibDbus();
-        if(!lib) return false;
-        func = (dbus_message_unref_t) dlsym(lib, "dbus_message_unref");
-    }
-    if(!func) return false;
+    static dbus_message_unref_t func = (dbus_message_unref_t) dlsym(loadLibDbus(), "dbus_message_unref");
+    if (!func) return false;
     func(message);
     return true;
 }
 
 static dbus_bool_t dbus_error_is_set_dynamic(const DBusError *error) {
     typedef dbus_bool_t (*dbus_error_is_set_t)(const DBusError*);
-    static dbus_error_is_set_t func = nullptr;
-    if(!func) {
-        void* lib = loadLibDbus();
-        if(!lib) return true;
-        func = (dbus_error_is_set_t) dlsym(lib, "dbus_error_is_set");
-    }
-    if(!func) return true;
+    static dbus_error_is_set_t func = (dbus_error_is_set_t) dlsym(loadLibDbus(), "dbus_error_is_set");
+    if (!func) return true;
     return func(error);
 }
 
 static dbus_bool_t dbus_message_iter_init_dynamic(DBusMessage *message, DBusMessageIter *iter) {
     typedef dbus_bool_t (*dbus_message_iter_init_t)(DBusMessage*, DBusMessageIter*);
-    static dbus_message_iter_init_t func = nullptr;
-    if(!func) {
-        void* lib = loadLibDbus();
-        if(!lib) return false;
-        func = (dbus_message_iter_init_t) dlsym(lib, "dbus_message_iter_init");
-    }
-    if(!func) return false;
+    static dbus_message_iter_init_t func = (dbus_message_iter_init_t) dlsym(loadLibDbus(), "dbus_message_iter_init");
+    if (!func) return false;
     return func(message, iter);
 }
 
 static int dbus_message_iter_get_arg_type_dynamic(DBusMessageIter *iter) {
     typedef int (*dbus_message_iter_get_arg_type_t)(DBusMessageIter*);
-    static dbus_message_iter_get_arg_type_t func = nullptr;
-    if(!func) {
-        void* lib = loadLibDbus();
-        if(!lib) return -1;
-        func = (dbus_message_iter_get_arg_type_t) dlsym(lib, "dbus_message_iter_get_arg_type");
-    }
-    if(!func) return -1;
+    static dbus_message_iter_get_arg_type_t func = (dbus_message_iter_get_arg_type_t) dlsym(loadLibDbus(), "dbus_message_iter_get_arg_type");
+    if (!func) return -1;
     return func(iter);
 }
 
 static bool dbus_message_iter_recurse_dynamic(DBusMessageIter *iter, DBusMessageIter *sub) {
     typedef void (*dbus_message_iter_recurse_t)(DBusMessageIter*, DBusMessageIter*);
-    static dbus_message_iter_recurse_t func = nullptr;
-    if(!func) {
-        void* lib = loadLibDbus();
-        if(!lib) return false;
-        func = (dbus_message_iter_recurse_t) dlsym(lib, "dbus_message_iter_recurse");
-    }
-    if(!func) return false;
+    static dbus_message_iter_recurse_t func = (dbus_message_iter_recurse_t) dlsym(loadLibDbus(), "dbus_message_iter_recurse");
+    if (!func) return false;
     func(iter, sub);
     return true;
 }
 
 static bool dbus_message_iter_get_basic_dynamic(DBusMessageIter *iter, void *value) {
     typedef void (*dbus_message_iter_get_basic_t)(DBusMessageIter*, void*);
-    static dbus_message_iter_get_basic_t func = nullptr;
-    if(!func) {
-        void* lib = loadLibDbus();
-        if(!lib) return false;
-        func = (dbus_message_iter_get_basic_t) dlsym(lib, "dbus_message_iter_get_basic");
-    }
-    if(!func) return false;
+    static dbus_message_iter_get_basic_t func = (dbus_message_iter_get_basic_t) dlsym(loadLibDbus(), "dbus_message_iter_get_basic");
+    if (!func) return false;
     func(iter, value);
     return true;
 }
 
 static DBusConnection* dbus_bus_get_dynamic(DBusBusType type, DBusError *error) {
     typedef DBusConnection* (*dbus_bus_get_t)(DBusBusType, DBusError*);
-    static dbus_bus_get_t func = nullptr;
-    if(!func) {
-        void* lib = loadLibDbus();
-        if(!lib) return nullptr;
-        func = (dbus_bus_get_t) dlsym(lib, "dbus_bus_get");
-    }
-    if(!func) return nullptr;
+    static dbus_bus_get_t func = (dbus_bus_get_t) dlsym(loadLibDbus(), "dbus_bus_get");
+    if (!func) return nullptr;
     return func(type, error);
 }
 
 static bool dbus_error_init_dynamic(DBusError *error) {
     typedef void (*dbus_error_init_t)(DBusError*);
-    static dbus_error_init_t func = nullptr;
-    if(!func) {
-        void* lib = loadLibDbus();
-        if(!lib) return false;
-        func = (dbus_error_init_t) dlsym(lib, "dbus_error_init");
-    }
-    if(!func) return false;
+    static dbus_error_init_t func = (dbus_error_init_t) dlsym(loadLibDbus(), "dbus_error_init");
+    if (!func) return false;
     func(error);
     return true;
 }

--- a/skiko/src/awtMain/cpp/linux/theme.cc
+++ b/skiko/src/awtMain/cpp/linux/theme.cc
@@ -5,16 +5,20 @@
 
 #include "jni_helpers.h"
 
-static bool initDbusThreads(void* lib) {
+static dbus_bool_t initDbusThreads(void* lib) {
     auto func = (dbus_bool_t(*)()) dlsym(lib, "dbus_threads_init_default");
-    if (func) func();
-    return true;
+    if (func) return func();
+    return false;
 }
 
 static void* loadLibDbus() {
-    static void* result = dlopen("libdbus-1.so", RTLD_LAZY | RTLD_LOCAL);
-    static bool _ = result && initDbusThreads(result);
-    return result;
+    static void* dlOpenResult = dlopen("libdbus-1.so", RTLD_LAZY | RTLD_LOCAL);
+    static bool initSuccess = dlOpenResult && initDbusThreads(dlOpenResult);
+    if (initSuccess) {
+        return dlOpenResult;
+    } else {
+        return nullptr;
+    }
 }
 
 static DBusMessage* dbus_message_new_method_call_dynamic(const char *bus_name, const char *path, const char *iface, const char *method) {


### PR DESCRIPTION
1. Makes initialization thread-safe using [C++ magic statics](https://blog.mbedded.ninja/programming/languages/c-plus-plus/magic-statics/)
2. Makes dbus use thread-safe by calling [`dbus_threads_init_default()`](https://dbus.freedesktop.org/doc/api/html/group__DBusThreads.html#ga33b6cf3b8f1e41bad5508f84758818a7)

Created with:
Claude Code Sonnet 4.6
  Total cost:            $1.20
  Total duration (API):  7m 14s
  Total duration (wall): 21m 14s
  Total code changes:    36 lines added, 86 lines removed