### PR TITLE
Generalize Skiko build configuration

### DIFF
--- a/skiko/build.gradle.kts
+++ b/skiko/build.gradle.kts
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import tasks.configuration.*
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+import dsl.SkikoDependencyScope
 
 plugins {
     kotlin("multiplatform")
@@ -35,17 +36,159 @@ val buildType = skiko.buildType
 val targetOs = hostOs
 val targetArch = skiko.targetArch
 
+val coreDependencies: SkikoDependencyScope.() -> Unit = {
+    targets {
+        all {
+            staticSkiaLibs(
+                "skia",
+                "skia_ganesh_ext",
+                "svg",
+                "skparagraph",
+                "skshaper",
+                "skunicode_core",
+                "skunicode_icu",
+                "icu",
+                "harfbuzz",
+                "skresources",
+                "png",
+                "jpeg",
+                "webp",
+                "webp_sse41",
+                "zlib",
+                "expat",
+                "skottie",
+                "sksg",
+                "jsonreader"
+            )
+        }
+        jvm {
+            macos {
+                staticSkiaLibs("piex", "dng_sdk")
+                linkFlags("-lobjc")
+                frameworks(
+                    "AppKit",
+                    "CoreFoundation",
+                    "CoreGraphics",
+                    "CoreServices",
+                    "CoreText",
+                    "Foundation",
+                    "IOKit",
+                    "Metal",
+                    "OpenGL",
+                    "QuartzCore",  // for CoreAnimation
+                )
+            }
+
+            windows {
+                    staticSkiaLibs("d3d12allocator")
+            }
+
+            linux {
+                // Hack to fix problem with linker not always finding certain declarations.
+                directStaticSkiaLibs(
+                    "sksg",
+                    "skia",
+                    "skia_ganesh_ext",
+                    "skunicode_core",
+                    "skunicode_icu",
+                    "skshaper",
+                    "jsonreader"
+                )
+                dynamicSystemLibs("GL", "X11", "fontconfig", "expat")
+                arm64 { dynamicSystemLibs("EGL") }
+            }
+
+            android {
+                // Hack to fix problem with linker not always finding certain declarations.
+                directStaticSkiaLibs("skia", "skia_ganesh_ext")
+                dynamicSystemLibs("GLESv3", "EGL")
+            }
+        }
+        native {
+            staticSkiaLibs(
+                "piex",
+                "dng_sdk",
+            )
+
+            linux {
+                // Hack to fix problem with linker not always finding certain declarations.
+                directStaticSkiaLibs(
+                    "skottie",
+                    "jsonreader",
+                    "sksg",
+                    "skshaper",
+                    "skunicode_core",
+                    "skunicode_icu",
+                    "skia",
+                    "skia_ganesh_ext"
+                )
+                dynamicSystemLibs("fontconfig", "GL")
+                arm64 { dynamicSystemLibs("EGL") }
+            }
+
+            macos {
+                frameworks(
+                    "Metal",
+                    "CoreGraphics",
+                    "CoreText",
+                    "CoreServices",
+                )
+            }
+
+            ios {
+                frameworks(
+                    "Metal",
+                    "CoreGraphics",
+                    "CoreText",
+                    "UIKit",
+                )
+            }
+
+            tvos {
+                frameworks(
+                    "Metal",
+                    "CoreGraphics",
+                    "CoreText",
+                    "UIKit",
+                )
+            }
+        }
+        wasm {
+            staticSkiaLibs(
+                "bentleyottmann",
+                "freetype2",
+                "jpeg12",
+                "jpeg16",
+                "wuffs",
+                "skcms",
+                "brotli",
+            )
+            linkFlags(
+                "-l", "GL",
+                "-s", "MAX_WEBGL_VERSION=2",
+                "-s", "MIN_WEBGL_VERSION=2",
+                "-s", "MODULARIZE=1",
+                "-s", "EXPORT_NAME=loadSkikoWASM",
+                "-s", "EXPORTED_RUNTIME_METHODS=\"[GL, wasmExports]\"",
+                "--bind",
+            )
+        }
+    }
+}
+
 val skikoProjectContext = SkikoProjectContext(
     project = project,
     skiko = skiko,
     kotlin = kotlin,
+    kind = SkikoModuleKind.CORE,
     windowsSdkPathProvider = {
         findWindowsSdkPaths(gradle, targetArch)
     },
     createChecksumsTask = { targetOs: OS, targetArch: Arch, fileToChecksum: Provider<File> ->
         createChecksumsTask(targetOs, targetArch, fileToChecksum)
     },
-    additionalRuntimeLibraries = project.registerAdditionalLibraries(targetOs, targetArch, skiko)
+    additionalRuntimeLibraries = project.registerAdditionalLibraries(targetOs, targetArch, skiko),
+    configureDependencies = coreDependencies
 )
 
 allprojects {

--- a/skiko/build.gradle.kts
+++ b/skiko/build.gradle.kts
@@ -95,7 +95,7 @@ val coreDependencies: SkikoDependencyScope.() -> Unit = {
                     "skshaper",
                     "jsonreader"
                 )
-                dynamicSystemLibs("GL", "X11", "fontconfig", "expat")
+                dynamicSystemLibs("GL", "X11", "fontconfig")
                 arm64 { dynamicSystemLibs("EGL") }
             }
 

--- a/skiko/build.gradle.kts
+++ b/skiko/build.gradle.kts
@@ -35,6 +35,7 @@ val skiko = SkikoProperties(rootProject)
 val buildType = skiko.buildType
 val targetOs = hostOs
 val targetArch = skiko.targetArch
+val skikoArtifacts = SkikoArtifacts()
 
 val coreDependencies: SkikoDependencyScope.() -> Unit = {
     targets {
@@ -181,18 +182,19 @@ val skikoProjectContext = SkikoProjectContext(
     skiko = skiko,
     kotlin = kotlin,
     kind = SkikoModuleKind.CORE,
+    artifacts = skikoArtifacts,
     windowsSdkPathProvider = {
         findWindowsSdkPaths(gradle, targetArch)
     },
     createChecksumsTask = { targetOs: OS, targetArch: Arch, fileToChecksum: Provider<File> ->
         createChecksumsTask(targetOs, targetArch, fileToChecksum)
     },
-    additionalRuntimeLibraries = project.registerAdditionalLibraries(targetOs, targetArch, skiko),
+    additionalRuntimeLibraries = project.registerAdditionalLibraries(targetOs, targetArch, skiko, skikoArtifacts),
     configureDependencies = coreDependencies
 )
 
 allprojects {
-    group = SkikoArtifacts.groupId
+    group = SkikoArtifacts.DEFAULT_GROUP_ID
     version = skiko.deployVersion
 }
 

--- a/skiko/buildSrc/src/main/kotlin/AdditionalRuntimeLibraries.kt
+++ b/skiko/buildSrc/src/main/kotlin/AdditionalRuntimeLibraries.kt
@@ -3,7 +3,8 @@ import org.gradle.api.Project
 fun Project.registerAdditionalLibraries(
     targetOs: OS,
     targetArch: Arch,
-    skikoProperties: SkikoProperties
+    skikoProperties: SkikoProperties,
+    artifacts: SkikoArtifacts,
 ): List<AdditionalRuntimeLibrary> {
     val angleTag = property("dependencies.angle") as String
     return listOfNotNull(
@@ -12,6 +13,7 @@ fun Project.registerAdditionalLibraries(
                 targetOs = targetOs,
                 targetArch = targetArch,
                 skikoProperties = skikoProperties,
+                artifacts = artifacts,
                 name = "angle",
                 archiveUrl = "https://github.com/JetBrains/angle-pack/releases/download/$angleTag/Angle-$angleTag-${targetOs.id}-Release-${targetArch.id}.zip",
                 filesToInclude = listOf(

--- a/skiko/buildSrc/src/main/kotlin/AdditionalRuntimeLibrary.kt
+++ b/skiko/buildSrc/src/main/kotlin/AdditionalRuntimeLibrary.kt
@@ -1,4 +1,3 @@
-import SkikoArtifacts.jvmAdditionalRuntimeArtifactIdFor
 import de.undercouch.gradle.tasks.download.Download
 import org.gradle.api.Project
 import org.gradle.api.file.DuplicatesStrategy
@@ -27,6 +26,7 @@ fun Project.registerAdditionalRuntimeLibrary(
     targetOs: OS,
     targetArch: Arch,
     skikoProperties: SkikoProperties,
+    artifacts: SkikoArtifacts,
     name: String,
     archiveUrl: String,
     filesToInclude: List<String>,
@@ -70,7 +70,7 @@ fun Project.registerAdditionalRuntimeLibrary(
         group = visibleName
         dependsOn(unzipTask)
         dependsOn(checksumTask)
-        archiveBaseName.set("skiko-$name")
+        archiveBaseName.set("${artifacts.artifactIdPrefix}-$name")
         archiveClassifier.set(targetId)
         from(unzipTask)
         from(checksumTask)
@@ -85,8 +85,8 @@ fun Project.registerAdditionalRuntimeLibrary(
             pomNameForPublication: MutableMap<String, String>
         ) {
             container.create("skikoJvmRuntime$taskSuffix", MavenPublication::class.java) {
-                pomNameForPublication[this.name] = "Skiko $visibleName for ${targetOs.id} ${targetArch.id}"
-                artifactId = jvmAdditionalRuntimeArtifactIdFor(name, targetOs, targetArch)
+                pomNameForPublication[this.name] = "${artifacts.displayName} $visibleName for ${targetOs.id} ${targetArch.id}"
+                artifactId = artifacts.jvmAdditionalRuntimeArtifactIdFor(name, targetOs, targetArch)
                 afterEvaluate {
                     artifact(jarTask.map { it.archiveFile.get() })
                     artifact(emptySourcesJar)

--- a/skiko/buildSrc/src/main/kotlin/SkikoProjectContext.kt
+++ b/skiko/buildSrc/src/main/kotlin/SkikoProjectContext.kt
@@ -126,26 +126,20 @@ fun SkikoProjectContext.declareSkiaTasks() {
                 description = "unzips to $outputDir"
 
                 dependsOn(downloadSkiaTask)
-                from(project.zipTree(downloadSkiaTask.get().dest))
-
-                into(outputDir)
-
-                // On Windows, some of the skia libraries have lib prefix and some do not
-                // Let's standardize it
-                if (config == "windows") {
-                    doLast {
-                        outputDir.walkTopDown().forEach { file ->
-                            if (file.isFile && file.name.startsWith("lib") && file.name.endsWith(".lib")) {
-                                val newName = file.name.removePrefix("lib")
-                                val renamedFile = File(file.parentFile, newName)
-
-                                if (file.renameTo(renamedFile)) {
-                                    logger.info("Normalized Windows lib: ${file.name} -> $newName")
-                                }
+                from(project.zipTree(downloadSkiaTask.get().dest)) {
+                    // On Windows, some of the skia libraries have lib prefix and some do not
+                    // Let's standardize it
+                    if (config == "windows") {
+                        rename { name ->
+                            if (name.startsWith("lib") && name.endsWith(".lib")) {
+                                name.removePrefix("lib")
+                            } else {
+                                name
                             }
                         }
                     }
                 }
+                into(outputDir)
             }
         }
     }

--- a/skiko/buildSrc/src/main/kotlin/SkikoProjectContext.kt
+++ b/skiko/buildSrc/src/main/kotlin/SkikoProjectContext.kt
@@ -17,6 +17,7 @@ class SkikoProjectContext(
     val project: Project,
     val skiko: SkikoProperties,
     val kind: SkikoModuleKind,
+    val artifacts: SkikoArtifacts,
     val kotlin: KotlinMultiplatformExtension,
     val windowsSdkPathProvider: () -> WindowsSdkPaths,
     val createChecksumsTask: (OS, Arch, Provider<File>) -> TaskProvider<*>,
@@ -38,9 +39,8 @@ class SkikoProjectContext(
     val allJvmRuntimeJars = mutableMapOf<Pair<OS, Arch>, TaskProvider<Jar>>()
 
     val projectPath: String = if (kind == SkikoModuleKind.CORE) ":" else ":${project.name}"
-    val libBaseName: String = if (kind == SkikoModuleKind.CORE) "skiko" else project.name
-    val nativeBridgesLibPrefix: String =
-        if (kind == SkikoModuleKind.CORE) "skiko-native-bridges" else "${project.name}-native-bridges"
+    val libBaseName: String = artifacts.artifactIdPrefix
+    val nativeBridgesLibPrefix: String = "${artifacts.artifactIdPrefix}-native-bridges"
     val cinteropName: String = libBaseName
 
     fun staticLibBaseNames(os: OS, arch: Arch, env: TargetEnv): List<String> =

--- a/skiko/buildSrc/src/main/kotlin/SkikoProjectContext.kt
+++ b/skiko/buildSrc/src/main/kotlin/SkikoProjectContext.kt
@@ -9,15 +9,25 @@ import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import java.io.File
+import dsl.*
+
+enum class SkikoModuleKind { CORE, EXTENSION }
 
 class SkikoProjectContext(
     val project: Project,
     val skiko: SkikoProperties,
+    val kind: SkikoModuleKind,
     val kotlin: KotlinMultiplatformExtension,
     val windowsSdkPathProvider: () -> WindowsSdkPaths,
     val createChecksumsTask: (OS, Arch, Provider<File>) -> TaskProvider<*>,
     val additionalRuntimeLibraries: List<AdditionalRuntimeLibrary>,
+    configureDependencies: (SkikoDependencyScope.() -> Unit)
 ) {
+    val dependencyRegistry = BinaryRegistry()
+
+    init {
+        SkikoDependencyScope(dependencyRegistry).configureDependencies()
+    }
 
     val buildType = skiko.buildType
 
@@ -26,6 +36,52 @@ class SkikoProjectContext(
     }
 
     val allJvmRuntimeJars = mutableMapOf<Pair<OS, Arch>, TaskProvider<Jar>>()
+
+    val projectPath: String = if (kind == SkikoModuleKind.CORE) ":" else ":${project.name}"
+    val libBaseName: String = if (kind == SkikoModuleKind.CORE) "skiko" else project.name
+    val nativeBridgesLibPrefix: String =
+        if (kind == SkikoModuleKind.CORE) "skiko-native-bridges" else "${project.name}-native-bridges"
+    val cinteropName: String = libBaseName
+
+    fun staticLibBaseNames(os: OS, arch: Arch, env: TargetEnv): List<String> =
+        dependencyRegistry.getLibs(os, arch, env, Linkage.STATIC)
+
+    fun directStaticLibBaseNames(os: OS, arch: Arch, env: TargetEnv): List<String> =
+        dependencyRegistry.getLibs(os, arch, env, Linkage.DIRECT_STATIC)
+
+    private fun archivePaths(os: OS, libBaseNames: List<String>, skiaBinDir: String): List<String> {
+        val prefix = if (os == OS.Windows) "" else "lib"
+        val suffix = when (os) {
+            OS.Windows -> ".lib"
+            OS.Wasm -> ".wasm.a"
+            else -> ".a"
+        }
+
+        return libBaseNames.map { baseName ->
+            "$skiaBinDir/$prefix$baseName$suffix"
+        }
+    }
+
+    fun staticArchivePaths(os: OS, arch: Arch, env: TargetEnv, skiaBinDir: String): List<String> =
+        archivePaths(os, staticLibBaseNames(os, arch, env), skiaBinDir)
+
+    fun directStaticArchivePaths(os: OS, arch: Arch, env: TargetEnv, skiaBinDir: String): List<String> =
+        archivePaths(os, directStaticLibBaseNames(os, arch, env), skiaBinDir)
+
+    fun dynamicLibNames(os: OS, arch: Arch, env: TargetEnv): List<String> =
+        dependencyRegistry.getLibs(os, arch, env, Linkage.DYNAMIC)
+
+    fun resolveBinaryInputs(os: OS, arch: Arch, env: TargetEnv, skiaBinDir: String): ResolvedBinaryConfiguration {
+        return ResolvedBinaryConfiguration(
+            staticLibBaseNames = staticLibBaseNames(os, arch, env),
+            staticArchivePaths = staticArchivePaths(os, arch, env, skiaBinDir),
+            directStaticLibBaseNames = directStaticLibBaseNames(os, arch, env),
+            directStaticArchivePaths = directStaticArchivePaths(os, arch, env, skiaBinDir),
+            dynamicLibNames = dynamicLibNames(os, arch, env),
+            frameworks = dependencyRegistry.getFrameworks(os, arch, env),
+            linkFlags = dependencyRegistry.getLinkFlags(os, arch, env)
+        )
+    }
 }
 
 fun SkikoProjectContext.declareSkiaTasks() {
@@ -73,6 +129,23 @@ fun SkikoProjectContext.declareSkiaTasks() {
                 from(project.zipTree(downloadSkiaTask.get().dest))
 
                 into(outputDir)
+
+                // On Windows, some of the skia libraries have lib prefix and some do not
+                // Let's standardize it
+                if (config == "windows") {
+                    doLast {
+                        outputDir.walkTopDown().forEach { file ->
+                            if (file.isFile && file.name.startsWith("lib") && file.name.endsWith(".lib")) {
+                                val newName = file.name.removePrefix("lib")
+                                val renamedFile = File(file.parentFile, newName)
+
+                                if (file.renameTo(renamedFile)) {
+                                    logger.info("Normalized Windows lib: ${file.name} -> $newName")
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/skiko/buildSrc/src/main/kotlin/dsl/SkikoDependency.kt
+++ b/skiko/buildSrc/src/main/kotlin/dsl/SkikoDependency.kt
@@ -1,0 +1,231 @@
+package dsl
+
+import Arch
+import OS
+
+enum class TargetEnv { JVM, NATIVE, WASM }
+enum class Linkage { STATIC, DIRECT_STATIC, DYNAMIC }
+
+data class ResolvedBinaryConfiguration(
+    val staticLibBaseNames: List<String> = emptyList(),
+    val staticArchivePaths: List<String> = emptyList(),
+    val directStaticLibBaseNames: List<String> = emptyList(),
+    val directStaticArchivePaths: List<String> = emptyList(),
+    val dynamicLibNames: List<String> = emptyList(),
+    val frameworks: List<String> = emptyList(),
+    val linkFlags: List<String> = emptyList(),
+)
+
+@DslMarker
+annotation class SkikoBinaryDsl
+
+val OS.validEnvs: List<TargetEnv>
+    get() = when (this) {
+        OS.MacOS, OS.Linux -> listOf(TargetEnv.JVM, TargetEnv.NATIVE)
+        OS.Windows, OS.Android -> listOf(TargetEnv.JVM)
+        OS.IOS, OS.TVOS -> listOf(TargetEnv.NATIVE)
+        OS.Wasm -> listOf(TargetEnv.WASM)
+    }
+
+class BinaryRegistry {
+
+    private enum class RuleKind {
+        STATIC_LIBS,
+        DIRECT_STATIC_LIBS,
+        DYNAMIC_LIBS,
+        LINK_FLAGS,
+        FRAMEWORKS,
+    }
+
+    private data class Rule(
+        val os: OS,
+        val arch: Arch?,
+        val env: TargetEnv,
+        val kind: RuleKind,
+        val values: List<String>,
+    ) {
+        fun matches(os: OS, arch: Arch, env: TargetEnv, kind: RuleKind): Boolean =
+            this.os == os && (this.arch == null || this.arch == arch) && this.env == env && this.kind == kind
+    }
+
+    private val rules = mutableListOf<Rule>()
+
+    fun on(
+        os: OS,
+        env: TargetEnv,
+        linkage: Linkage,
+        vararg libs: String,
+        arch: Arch? = null
+    ) {
+        rules.add(Rule(os, arch, env, linkage.ruleKind, libs.toList()))
+    }
+
+    fun linkFlags(os: OS, env: TargetEnv, vararg flags: String, arch: Arch? = null) {
+        rules.add(Rule(os, arch, env, RuleKind.LINK_FLAGS, flags.toList()))
+    }
+
+    fun frameworks(os: OS, env: TargetEnv, vararg frameworks: String, arch: Arch? = null) {
+        rules.add(Rule(os, arch, env, RuleKind.FRAMEWORKS, frameworks.toList()))
+    }
+
+    fun getLibs(os: OS, arch: Arch, env: TargetEnv, linkage: Linkage): List<String> =
+        valuesFor(os, arch, env, linkage.ruleKind)
+
+    fun getLinkFlags(os: OS, arch: Arch, env: TargetEnv): List<String> =
+        valuesFor(os, arch, env, RuleKind.LINK_FLAGS)
+
+    fun getFrameworks(os: OS, arch: Arch, env: TargetEnv): List<String> =
+        valuesFor(os, arch, env, RuleKind.FRAMEWORKS).flatMap { listOf("-framework", it) }
+
+    private fun valuesFor(os: OS, arch: Arch, env: TargetEnv, kind: RuleKind): List<String> =
+        rules
+            .filter { it.matches(os, arch, env, kind) }
+            .flatMap { it.values }
+
+    private val Linkage.ruleKind: RuleKind
+        get() = when (this) {
+            Linkage.STATIC -> RuleKind.STATIC_LIBS
+            Linkage.DIRECT_STATIC -> RuleKind.DIRECT_STATIC_LIBS
+            Linkage.DYNAMIC -> RuleKind.DYNAMIC_LIBS
+        }
+}
+
+@SkikoBinaryDsl
+interface ActionScope {
+    fun staticSkiaLibs(vararg libs: String)
+    fun directStaticSkiaLibs(vararg libs: String)
+    fun dynamicSystemLibs(vararg libs: String)
+    fun linkFlags(vararg flags: String)
+    fun frameworks(vararg frameworks: String)
+}
+
+@SkikoBinaryDsl
+class ArchScope internal constructor(
+    private val registry: BinaryRegistry,
+    private val env: TargetEnv,
+    private val os: OS,
+    private val arch: Arch
+) : ActionScope {
+
+    override fun staticSkiaLibs(vararg libs: String) =
+        registry.on(os, env, Linkage.STATIC, *libs, arch = arch)
+
+    override fun directStaticSkiaLibs(vararg libs: String) =
+        registry.on(os, env, Linkage.DIRECT_STATIC, *libs, arch = arch)
+
+    override fun dynamicSystemLibs(vararg libs: String) =
+        registry.on(os, env, Linkage.DYNAMIC, *libs, arch = arch)
+
+    override fun linkFlags(vararg flags: String) =
+        registry.linkFlags(os, env, *flags, arch = arch)
+
+    override fun frameworks(vararg frameworks: String) =
+        registry.frameworks(os, env, *frameworks, arch = arch)
+}
+
+@SkikoBinaryDsl
+class OSScope internal constructor(
+    private val registry: BinaryRegistry,
+    private val env: TargetEnv,
+    private val os: OS
+) : ActionScope {
+
+    fun x64(configure: ArchScope.() -> Unit) = ArchScope(registry, env, os, Arch.X64).configure()
+    fun arm64(configure: ArchScope.() -> Unit) = ArchScope(registry, env, os, Arch.Arm64).configure()
+    fun wasm(configure: ArchScope.() -> Unit) = ArchScope(registry, env, os, Arch.Wasm).configure()
+
+    override fun staticSkiaLibs(vararg libs: String) =
+        registry.on(os, env, Linkage.STATIC, *libs, arch = null)
+
+    override fun directStaticSkiaLibs(vararg libs: String) =
+        registry.on(os, env, Linkage.DIRECT_STATIC, *libs, arch = null)
+
+    override fun dynamicSystemLibs(vararg libs: String) =
+        registry.on(os, env, Linkage.DYNAMIC, *libs, arch = null)
+
+    override fun linkFlags(vararg flags: String) =
+        registry.linkFlags(os, env, *flags, arch = null)
+
+    override fun frameworks(vararg frameworks: String) =
+        registry.frameworks(os, env, *frameworks, arch = null)
+}
+
+@SkikoBinaryDsl
+class EnvScope internal constructor(
+    private val registry: BinaryRegistry,
+    private val env: TargetEnv
+) : ActionScope {
+
+    //  Silently ignores combinations that don't make sense (e.g., jvm { ios { } })
+    fun linux(configure: OSScope.() -> Unit) = applyIfValid(OS.Linux, configure)
+    fun macos(configure: OSScope.() -> Unit) = applyIfValid(OS.MacOS, configure)
+    fun windows(configure: OSScope.() -> Unit) = applyIfValid(OS.Windows, configure)
+    fun android(configure: OSScope.() -> Unit) = applyIfValid(OS.Android, configure)
+    fun ios(configure: OSScope.() -> Unit) = applyIfValid(OS.IOS, configure)
+    fun tvos(configure: OSScope.() -> Unit) = applyIfValid(OS.TVOS, configure)
+    fun wasm(configure: OSScope.() -> Unit) = applyIfValid(OS.Wasm, configure)
+
+    private fun applyIfValid(os: OS, configure: OSScope.() -> Unit) {
+        if (env in os.validEnvs) {
+            OSScope(registry, env, os).configure()
+        }
+    }
+
+    private fun forEachValidOs(action: (OS) -> Unit) {
+        OS.values().filter { env in it.validEnvs }.forEach(action)
+    }
+
+    // ActionScope implementation (applies to all valid OSs for this Env, arch = null)
+    override fun staticSkiaLibs(vararg libs: String) = forEachValidOs { os ->
+        registry.on(os, env, Linkage.STATIC, *libs, arch = null)
+    }
+
+    override fun directStaticSkiaLibs(vararg libs: String) = forEachValidOs { os ->
+        registry.on(os, env, Linkage.DIRECT_STATIC, *libs, arch = null)
+    }
+
+    override fun dynamicSystemLibs(vararg libs: String) = forEachValidOs { os ->
+        registry.on(os, env, Linkage.DYNAMIC, *libs, arch = null)
+    }
+
+    override fun linkFlags(vararg flags: String) = forEachValidOs { os ->
+        registry.linkFlags(os, env, *flags, arch = null)
+    }
+
+    override fun frameworks(vararg frameworks: String) = forEachValidOs { os ->
+        registry.frameworks(os, env, *frameworks, arch = null)
+    }
+}
+
+@SkikoBinaryDsl
+class TargetScope internal constructor(
+    private val registry: BinaryRegistry
+) {
+    fun all(configure: EnvScope.() -> Unit) {
+        TargetEnv.values().forEach { env -> EnvScope(registry, env).configure() }
+    }
+
+    fun jvm(configure: EnvScope.() -> Unit) = EnvScope(registry, TargetEnv.JVM).configure()
+    fun native(configure: EnvScope.() -> Unit) = EnvScope(registry, TargetEnv.NATIVE).configure()
+    fun wasm(configure: EnvScope.() -> Unit) = EnvScope(registry, TargetEnv.WASM).configure()
+}
+
+@SkikoBinaryDsl
+class SkikoDependencyScope internal constructor(
+    private val registry: BinaryRegistry
+) {
+    internal var dependsOnCore: Boolean = false
+        private set
+
+    fun dependsOnCore() {
+        dependsOnCore = true
+    }
+
+    fun targets(configure: TargetScope.() -> Unit) {
+        TargetScope(registry).configure()
+    }
+
+    fun binary(configure: BinaryRegistry.() -> Unit) {
+        registry.configure()
+    }
+}

--- a/skiko/buildSrc/src/main/kotlin/properties.kt
+++ b/skiko/buildSrc/src/main/kotlin/properties.kt
@@ -270,29 +270,37 @@ object SkikoGradleProperties {
     const val NATIVE_LINUX = "skiko.native.linux.enabled"
 }
 
-object SkikoArtifacts {
-    val groupId = "org.jetbrains.skiko"
+class SkikoArtifacts(
+    val artifactIdPrefix: String = DEFAULT_ARTIFACT_ID_PREFIX,
+    val displayName: String = "Skiko",
+    val pomDescription: String = "Kotlin Skia bindings",
+) {
     // names are also used in samples, e.g. samples/SkijaInjectSample/build.gradle
-    val commonArtifactId = "skiko"
-    val jvmArtifactId = "skiko-awt"
-    val jvmRuntimeArtifactId = "skiko-awt-runtime"
+    val commonArtifactId = artifactIdPrefix
+    val jvmArtifactId = "$artifactIdPrefix-awt"
+    val jvmRuntimeArtifactId = "$artifactIdPrefix-awt-runtime"
     // an artifact (klib) for k/js targets
-    val jsArtifactId = "skiko-js"
+    val jsArtifactId = "$artifactIdPrefix-js"
     // an artifact (klib) for k/wasm targets
-    val wasmArtifactId = "skiko-wasm-js"
+    val wasmArtifactId = "$artifactIdPrefix-wasm-js"
     // an artifact with skiko.wasm and supporting js code - jar
-    val jsWasmArtifactId = "skiko-js-wasm-runtime"
+    val jsWasmArtifactId = "$artifactIdPrefix-js-wasm-runtime"
     fun jvmRuntimeArtifactIdFor(os: OS, arch: Arch) =
         if (os == OS.Android)
-            "skiko-android-runtime-${arch.id}"
+            "$artifactIdPrefix-android-runtime-${arch.id}"
         else
-            "skiko-awt-runtime-${targetId(os, arch)}"
+            "$artifactIdPrefix-awt-runtime-${targetId(os, arch)}"
     fun jvmAdditionalRuntimeArtifactIdFor(name: String, os: OS, arch: Arch) =
-        "skiko-awt-runtime-$name-${os.id}-${arch.id}"
-    // Using custom name like skiko-<Os>-<Arch> (with a dash)
+        "$artifactIdPrefix-awt-runtime-$name-${os.id}-${arch.id}"
+    // Using a custom name like skiko-<Os>-<Arch> (with a dash)
     // does not seem possible (at least without adding a dash to a target's tasks),
     // so we're using the default naming pattern instead.
     // See https://youtrack.jetbrains.com/issue/KT-50001.
     fun nativeArtifactIdFor(os: OS, arch: Arch, isUikitSim: Boolean = false) =
-        "skiko-${os.id + if (isUikitSim) "simulator" else ""}${arch.id}"
+        "$artifactIdPrefix-${os.id + if (isUikitSim) "simulator" else ""}${arch.id}"
+
+    companion object {
+        const val DEFAULT_ARTIFACT_ID_PREFIX = "skiko"
+        const val DEFAULT_GROUP_ID = "org.jetbrains.skiko"
+    }
 }

--- a/skiko/buildSrc/src/main/kotlin/publishing.kt
+++ b/skiko/buildSrc/src/main/kotlin/publishing.kt
@@ -30,6 +30,7 @@ private class SkikoPublishingContext(
     val project = projectContext.project
     val kotlin = projectContext.kotlin
     val skiko = projectContext.skiko
+    val skikoArtifacts = projectContext.artifacts
     val additionalRuntimeLibraries = projectContext.additionalRuntimeLibraries
 
     val pomNameForPublication: MutableMap<String, String> = HashMap()
@@ -94,21 +95,21 @@ private fun SkikoPublishingContext.configurePublishingRepositories() {
 }
 
 private fun SkikoPublishingContext.configurePublicationDefaults() {
-    pomNameForPublication["kotlinMultiplatform"] = "Skiko KMP"
+    pomNameForPublication["kotlinMultiplatform"] = "${skikoArtifacts.displayName} KMP"
     kotlin.targets.forEach {
-        pomNameForPublication[it.name] = "Skiko ${toTitleCase(it.name)}"
+        pomNameForPublication[it.name] = "${skikoArtifacts.displayName} ${toTitleCase(it.name)}"
     }
 
     publishing {
         publications.configureEach {
             this as MavenPublication
-            groupId = SkikoArtifacts.groupId
+            groupId = SkikoArtifacts.DEFAULT_GROUP_ID
 
             // Necessary for publishing to Maven Central
             artifact(emptyJavadocJar)
 
             pom {
-                description.set("Kotlin Skia bindings")
+                description.set(skikoArtifacts.pomDescription)
                 licenses {
                     license {
                         name.set("The Apache License, Version 2.0")
@@ -140,8 +141,8 @@ private fun SkikoPublishingContext.configureAllJvmRuntimeJarPublications() = pub
         val os = entry.key.first
         val arch = entry.key.second
         create("skikoJvmRuntime${toTitleCase(os.id)}${toTitleCase(arch.id)}", MavenPublication::class.java) {
-            pomNameForPublication[name] = "Skiko JVM Runtime for ${os.name} ${arch.name}"
-            artifactId = SkikoArtifacts.jvmRuntimeArtifactIdFor(os, arch)
+            pomNameForPublication[name] = "${skikoArtifacts.displayName} JVM Runtime for ${os.name} ${arch.name}"
+            artifactId = skikoArtifacts.jvmRuntimeArtifactIdFor(os, arch)
             project.afterEvaluate {
                 artifact(entry.value.map { it.archiveFile.get() })
                 artifact(emptySourcesJar)
@@ -149,8 +150,8 @@ private fun SkikoPublishingContext.configureAllJvmRuntimeJarPublications() = pub
             pom.withXml {
                 asNode().appendNode("dependencies")
                     .appendNode("dependency").apply {
-                        appendNode("groupId", SkikoArtifacts.groupId)
-                        appendNode("artifactId", SkikoArtifacts.jvmArtifactId)
+                        appendNode("groupId", SkikoArtifacts.DEFAULT_GROUP_ID)
+                        appendNode("artifactId", skikoArtifacts.jvmArtifactId)
                         appendNode("version", "[${skiko.deployVersion}]")
                         appendNode("scope", "compile")
                     }
@@ -235,8 +236,8 @@ private fun SkikoPublishingContext.configureAwtRuntimeJarPublication() {
              */
             dependencies.add(
                 project.dependencies.create(
-                    SkikoArtifacts.groupId,
-                    SkikoArtifacts.jvmRuntimeArtifactIdFor(os, arch),
+                    SkikoArtifacts.DEFAULT_GROUP_ID,
+                    skikoArtifacts.jvmRuntimeArtifactIdFor(os, arch),
                     skiko.deployVersion
                 )
             )
@@ -255,9 +256,9 @@ private fun SkikoPublishingContext.configureAwtRuntimeJarPublication() {
     publications {
         create("awtRuntimeElements", MavenPublication::class.java) {
             from(component)
-            pomNameForPublication[name] = "Skiko JVM Runtime"
-            groupId = SkikoArtifacts.groupId
-            artifactId = SkikoArtifacts.jvmRuntimeArtifactId
+            pomNameForPublication[name] = "${skikoArtifacts.displayName} JVM Runtime"
+            groupId = SkikoArtifacts.DEFAULT_GROUP_ID
+            artifactId = skikoArtifacts.jvmRuntimeArtifactId
             version = skiko.deployVersion
 
             /*
@@ -295,7 +296,7 @@ private fun SkikoPublishingContext.configureAwtPublicationConstraints() {
             // Add constraint for the uber runtime artifact
             config.dependencyConstraints.add(
                 project.dependencies.constraints.create(
-                    "${SkikoArtifacts.groupId}:${SkikoArtifacts.jvmRuntimeArtifactId}:${skiko.deployVersion}!!"
+                    "${SkikoArtifacts.DEFAULT_GROUP_ID}:${skikoArtifacts.jvmRuntimeArtifactId}:${skiko.deployVersion}!!"
                 )
             )
             
@@ -303,7 +304,7 @@ private fun SkikoPublishingContext.configureAwtPublicationConstraints() {
             awtRuntimeTargets.forEach { (os, arch) ->
                 config.dependencyConstraints.add(
                     project.dependencies.constraints.create(
-                        "${SkikoArtifacts.groupId}:${SkikoArtifacts.jvmRuntimeArtifactIdFor(os, arch)}:${skiko.deployVersion}!!"
+                        "${SkikoArtifacts.DEFAULT_GROUP_ID}:${skikoArtifacts.jvmRuntimeArtifactIdFor(os, arch)}:${skiko.deployVersion}!!"
                     )
                 )
             }
@@ -320,8 +321,8 @@ private fun SkikoPublishingContext.configureAdditionalRuntimeLibrariesPublicatio
 private fun SkikoPublishingContext.configureWebPublication() = publications {
     if (!project.supportWeb) return@publications
     create("skikoWasmRuntime", MavenPublication::class.java) {
-        pomNameForPublication[name] = "Skiko WASM Runtime"
-        artifactId = SkikoArtifacts.jsWasmArtifactId
+        pomNameForPublication[name] = "${skikoArtifacts.displayName} WASM Runtime"
+        artifactId = skikoArtifacts.jsWasmArtifactId
         artifact(project.tasks.named("skikoWasmJar").get())
         artifact(emptySourcesJar)
     }
@@ -329,7 +330,7 @@ private fun SkikoPublishingContext.configureWebPublication() = publications {
 
 private fun SkikoPublishingContext.configureAndroidPublication() = publications {
     if (!project.supportAndroid) return@publications
-    pomNameForPublication["androidRelease"] = "Skiko Android Runtime"
+    pomNameForPublication["androidRelease"] = "${skikoArtifacts.displayName} Android Runtime"
 }
 
 private fun SkikoPublishingContext.configurePomNames() = publications {

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/JvmTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/JvmTasksConfiguration.kt
@@ -9,6 +9,7 @@ import OS
 import SealAndSignSharedLibraryTask
 import SkiaBuildType
 import SkikoProjectContext
+import dsl.TargetEnv
 import compilerForTarget
 import dynamicLibExt
 import hostArch
@@ -135,7 +136,7 @@ fun SkikoProjectContext.createCompileJvmBindingsTask(
     flags.set(
         listOf(
             *skiaPreprocessorFlags(targetOs, buildType),
-            *osFlags
+            *osFlags,
         )
     )
 }
@@ -229,26 +230,16 @@ fun SkikoProjectContext.createLinkJvmBindings(
     val target = targetId(targetOs, targetArch)
     val skiaBinSubdir = "out/${buildType.id}-$target"
     val skiaBinDir = skiaJvmBindingsDir.get().absolutePath + "/" + skiaBinSubdir
+    val resolvedBinaryInputs = resolveBinaryInputs(targetOs, targetArch, TargetEnv.JVM, skiaBinDir)
     val osFlags: Array<String>
 
-    libFiles = project.fileTree(skiaJvmBindingsDir.map { it.resolve(skiaBinSubdir) }) {
-        val fileExtension = if (targetOs.isWindows) "lib" else "a"
-        val filePrefix = if (targetOs.isWindows) "" else "lib"
-        val excludedLibs = listOf(
-            "skia_graphite_ext",
-            "skia_graphite_dawn_ext",
-            "dawn_combined"
-        )
-        include("*.$fileExtension")
-
-        exclude(excludedLibs.map { "$filePrefix$it.$fileExtension" })
-    }
+    libFiles = project.files((resolvedBinaryInputs.staticArchivePaths).distinct())
 
     dependsOn(compileTask)
     objectFiles = project.fileTree(compileTask.map { it.outDir.get() }) {
         include("**/*.o")
     }
-    val libNamePrefix = if (targetOs.isWindows) "skiko" else "libskiko"
+    val libNamePrefix = if (targetOs.isWindows) libBaseName else "lib$libBaseName"
     libOutputFileName.set("$libNamePrefix-${targetOs.id}-${targetArch.id}${targetOs.dynamicLibExt}")
     buildTargetOS.set(targetOs)
     buildSuffix.set("jvm")
@@ -267,19 +258,10 @@ fun SkikoProjectContext.createLinkJvmBindings(
                 "-arch", if (targetArch == Arch.Arm64) "arm64" else "x86_64",
                 "-shared",
                 "-dead_strip",
-                "-lobjc",
                 "-install_name", "./${libOutputFileName.get()}",
                 "-current_version", skiko.planeDeployVersion,
-                "-framework", "AppKit",
-                "-framework", "CoreFoundation",
-                "-framework", "CoreGraphics",
-                "-framework", "CoreServices",
-                "-framework", "CoreText",
-                "-framework", "Foundation",
-                "-framework", "IOKit",
-                "-framework", "Metal",
-                "-framework", "OpenGL",
-                "-framework", "QuartzCore" // for CoreAnimation
+                *resolvedBinaryInputs.linkFlags.toTypedArray(),
+                *resolvedBinaryInputs.frameworks.toTypedArray()
             )
         }
         OS.Linux -> {
@@ -290,25 +272,14 @@ fun SkikoProjectContext.createLinkJvmBindings(
                         // `libstdc++.so.6.*` binaries are forward-compatible and used from GCC 3.4 to 16+,
                         // so do not use `-static-libstdc++` to avoid issues with complex setup.
                         "-static-libgcc",
-                        "-lGL",
-                        "-lX11",
-                        "-lfontconfig",
                         // Enforce immediate symbol resolution at library load time to prevent
                         // lazy-binding issues and make GOT read-only afterwards.
                         "-Wl,-z,relro,-z,now",
-                        // Hack to fix problem with linker not always finding certain declarations.
-                        "$skiaBinDir/libsksg.a",
-                        "$skiaBinDir/libskia.a",
-                        "$skiaBinDir/libskia_ganesh_ext.a",
-                        "$skiaBinDir/libskunicode_core.a",
-                        "$skiaBinDir/libskunicode_icu.a",
-                        "$skiaBinDir/libskshaper.a",
-                        "$skiaBinDir/libjsonreader.a"
                     )
                 )
-                if (targetArch == Arch.Arm64) {
-                    add("-lEGL")
-                }
+                addAll(resolvedBinaryInputs.dynamicLibNames.map { "-l$it" })
+                addAll(resolvedBinaryInputs.directStaticArchivePaths)
+                addAll(resolvedBinaryInputs.linkFlags)
             }.toTypedArray()
         }
         OS.Windows -> {
@@ -337,21 +308,22 @@ fun SkikoProjectContext.createLinkJvmBindings(
                     )
                 )
                 if (buildType == SkiaBuildType.DEBUG) add("dxgi.lib")
+                addAll(resolvedBinaryInputs.dynamicLibNames.map { "$it.lib" })
+                addAll(resolvedBinaryInputs.linkFlags)
             }.toTypedArray()
         }
         OS.Android -> {
-            osFlags = arrayOf(
+            val androidFlags = mutableListOf(
                 "-shared",
                 "-static-libstdc++",
-                "-lGLESv3",
-                "-lEGL",
                 "-llog",
                 "-landroid",
                 "-latomic",
-                // Hack to fix problem with linker not always finding certain declarations.
-                "$skiaBinDir/libskia.a",
-                "$skiaBinDir/libskia_ganesh_ext.a"
             )
+            androidFlags.addAll(resolvedBinaryInputs.dynamicLibNames.map { "-l$it" })
+            androidFlags.addAll(resolvedBinaryInputs.directStaticArchivePaths)
+            androidFlags.addAll(resolvedBinaryInputs.linkFlags)
+            osFlags = androidFlags.toTypedArray()
             linker.set(project.androidClangFor(targetArch))
         }
         OS.Wasm, OS.IOS, OS.TVOS -> {

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/NativeTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/NativeTasksConfiguration.kt
@@ -8,10 +8,10 @@ import SkiaBuildType
 import SkikoProjectContext
 import WriteCInteropDefFile
 import compilerForTarget
+import dsl.TargetEnv
 import hostArch
 import isCompatibleWithHost
 import joinToTitleCamelCase
-import listOfFrameworks
 import mutableListOfLinkerOptions
 import org.gradle.api.GradleException
 import org.gradle.api.Project
@@ -176,7 +176,7 @@ fun configureCinterop(
     val taskNameSuffix = joinToTitleCamelCase(os.idWithSuffix(isUikitSim = target.isUikitSimulator()), arch.id)
     val writeCInteropDef = tasks.register("writeCInteropDef$taskNameSuffix", WriteCInteropDefFile::class.java) {
         this.linkerOpts.set(linkerOpts)
-        outputFile.set(project.layout.buildDirectory.file("cinterop/$targetString/skiko.def"))
+        outputFile.set(project.layout.buildDirectory.file("cinterop/$targetString/$cinteropName.def"))
     }
     tasks.withType(CInteropProcess::class.java).configureEach {
         if (konanTarget == target.konanTarget) {
@@ -187,35 +187,6 @@ fun configureCinterop(
         cinterops.create(cinteropName).apply {
             definitionFile.set(writeCInteropDef.flatMap { it.outputFile })
         }
-    }
-}
-
-fun skiaStaticLibraries(skiaDir: String, targetString: String, buildType: SkiaBuildType): List<String> {
-    val skiaBinSubdir = "$skiaDir/out/${buildType.id}-$targetString"
-    return listOf(
-        "libskresources.a",
-        "libskparagraph.a",
-        "libskia.a",
-        "libskia_ganesh_ext.a",
-        "libicu.a",
-        "libjsonreader.a",
-        "libskottie.a",
-        "libsvg.a",
-        "libpng.a",
-        "libwebp_sse41.a",
-        "libsksg.a",
-        "libskunicode_core.a",
-        "libskunicode_icu.a",
-        "libwebp.a",
-        "libdng_sdk.a",
-        "libpiex.a",
-        "libharfbuzz.a",
-        "libexpat.a",
-        "libzlib.a",
-        "libjpeg.a",
-        "libskshaper.a"
-    ).map {
-        "$skiaBinSubdir/$it"
     }
 }
 
@@ -231,7 +202,7 @@ fun SkikoProjectContext.configureNativeTarget(os: OS, arch: Arch, target: Kotlin
     val unpackedSkia = unzipper.get()
     val skiaDir = unpackedSkia.absolutePath
 
-    val bridgesLibrary = layout.buildDirectory.file("nativeBridges/static/$targetString/skiko-native-bridges-$targetString.a")
+    val bridgesLibrary = layout.buildDirectory.file("nativeBridges/static/$targetString/$nativeBridgesLibPrefix-$targetString.a")
     val bridgesLibraryPath = bridgesLibrary.get().asFile.absolutePath
 
     // For iOS/tvOS we patch every library so that public Skia symbols are
@@ -242,54 +213,42 @@ fun SkikoProjectContext.configureNativeTarget(os: OS, arch: Arch, target: Kotlin
     val requiresSymbolPatching = os == OS.IOS || os == OS.TVOS
     val patchedLibsDir = layout.buildDirectory.dir("nativeBridges/patched/$targetString").get().asFile
 
+    val skiaBinDir = "$skiaDir/out/${buildType.id}-$targetString"
+    val resolvedBinaryInputs = resolveBinaryInputs(os, arch, TargetEnv.NATIVE, skiaBinDir)
+    val nativeArchives = resolvedBinaryInputs.staticArchivePaths.distinct()
     val allLibraries = if (requiresSymbolPatching) {
-        skiaStaticLibraries(skiaDir, targetString, buildType).map { lib ->
+        nativeArchives.map { lib ->
             "${patchedLibsDir.absolutePath}/${File(lib).name}"
-        } + "${patchedLibsDir.absolutePath}/skiko-native-bridges-$targetString.a"
+        } + "${patchedLibsDir.absolutePath}/$nativeBridgesLibPrefix-$targetString.a"
     } else {
-        skiaStaticLibraries(skiaDir, targetString, buildType) + bridgesLibraryPath
+        nativeArchives + bridgesLibraryPath
     }
 
-    val skiaBinDir = "$skiaDir/out/${buildType.id}-$targetString"
     val linkerFlags = when (os) {
         OS.MacOS -> {
-            val macFrameworks = listOfFrameworks("Metal", "CoreGraphics", "CoreText", "CoreServices")
-            configureCinterop("skiko", os, arch, target, targetString, macFrameworks)
-            mutableListOfLinkerOptions(macFrameworks)
+            configureCinterop(cinteropName, os, arch, target, targetString, resolvedBinaryInputs.frameworks)
+            mutableListOfLinkerOptions(resolvedBinaryInputs.frameworks + resolvedBinaryInputs.linkFlags)
         }
         OS.IOS -> {
-            val iosFrameworks = listOfFrameworks("Metal", "CoreGraphics", "CoreText", "UIKit")
             // list of linker options to be included into klib, which are needed for skiko consumers
             // https://github.com/JetBrains/compose-multiplatform/issues/3178
             // Important! Removing or renaming cinterop-uikit publication might cause compile error
             // for projects depending on older Compose/Skiko transitively https://youtrack.jetbrains.com/issue/KT-60399
-            configureCinterop("uikit", os, arch, target, targetString, iosFrameworks)
-            mutableListOfLinkerOptions(iosFrameworks)
+            configureCinterop("uikit", os, arch, target, targetString, resolvedBinaryInputs.frameworks)
+            mutableListOfLinkerOptions(resolvedBinaryInputs.frameworks + resolvedBinaryInputs.linkFlags)
         }
         OS.TVOS -> {
-            val tvosFrameworks = listOfFrameworks("Metal", "CoreGraphics", "CoreText", "UIKit")
-            configureCinterop("uikit", os, arch, target, targetString, tvosFrameworks)
-            mutableListOfLinkerOptions(tvosFrameworks)
+            configureCinterop("uikit", os, arch, target, targetString, resolvedBinaryInputs.frameworks)
+            mutableListOfLinkerOptions(resolvedBinaryInputs.frameworks + resolvedBinaryInputs.linkFlags)
         }
         OS.Linux -> {
             val options = mutableListOf(
                 "-L/usr/lib64",
                 "-L/usr/lib/${if (arch == Arch.Arm64) "aarch64" else "x86_64"}-linux-gnu",
-                "-lfontconfig",
-                "-lGL",
-                // TODO: an ugly hack, Linux linker searches only unresolved symbols.
-                "$skiaBinDir/libskottie.a",
-                "$skiaBinDir/libjsonreader.a",
-                "$skiaBinDir/libsksg.a",
-                "$skiaBinDir/libskshaper.a",
-                "$skiaBinDir/libskunicode_core.a",
-                "$skiaBinDir/libskunicode_icu.a",
-                "$skiaBinDir/libskia.a",
-                "$skiaBinDir/libskia_ganesh_ext.a"
             )
-            if (arch == Arch.Arm64) {
-                options.add("-lEGL")
-            }
+            options.addAll(resolvedBinaryInputs.directStaticArchivePaths)
+            options.addAll(resolvedBinaryInputs.dynamicLibNames.map { "-l$it" })
+            options.addAll(resolvedBinaryInputs.linkFlags)
             // When cross-compiling for ARM64 from x64, use the ARM toolchain sysroot
             if (arch == Arch.Arm64 && hostArch != Arch.Arm64) {
                 // ARM GNU toolchain sysroot paths
@@ -336,7 +295,7 @@ fun SkikoProjectContext.configureNativeTarget(os: OS, arch: Arch, target: Kotlin
         }
         inputs.files(objectFiles)
         val outDir = layout.buildDirectory.dir("nativeBridges/static/$targetString").get().asFile
-        val staticLib = "skiko-native-bridges-$targetString.a"
+        val staticLib = "$nativeBridgesLibPrefix-$targetString.a"
         workingDir = outDir
         when (os) {
             OS.Linux -> {
@@ -360,7 +319,7 @@ fun SkikoProjectContext.configureNativeTarget(os: OS, arch: Arch, target: Kotlin
         project.registerSkikoTask<PatchSkiaSymbolsTask>(patchActionName, os, arch) {
             dependsOn(unzipper)
             dependsOn(linkTask)
-            skiaLibs.set(skiaStaticLibraries(skiaDir, targetString, buildType).map { File(it) })
+            skiaLibs.set(nativeArchives.map { File(it) })
             skikoBridge.set(File(bridgesLibraryPath))
             outputDir.set(patchedLibsDir)
         }

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/WasmTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/WasmTasksConfiguration.kt
@@ -7,6 +7,7 @@ import LinkSkikoWasmTask
 import OS
 import SkikoProjectContext
 import compilerForTarget
+import dsl.TargetEnv
 import linkerForTarget
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
@@ -41,7 +42,6 @@ fun SkikoProjectContext.declareWasmTasks() {
     val skiaWasmDir = registerOrGetSkiaDirProvider(OS.Wasm, Arch.Wasm, false)
     val compileWasm by project.tasks.registering(CompileSkikoCppTask::class) {
         dependsOn(skiaWasmDir)
-
         compiler.set(compilerForTarget(OS.Wasm, Arch.Wasm))
         buildTargetOS.set(OS.Wasm)
         buildTargetArch.set(Arch.Wasm)
@@ -70,17 +70,15 @@ fun SkikoProjectContext.declareWasmTasks() {
     fun LinkSkikoWasmTask.configureCommon(prefixPath: String) {
         dependsOn(compileWasm)
         dependsOn(skiaWasmDir)
+        val skiaBinDir = skiaWasmDir.get().resolve("out/${buildType.id}-wasm-wasm").absolutePath
+        val resolvedBinaryInputs = resolveBinaryInputs(OS.Wasm, Arch.Wasm, TargetEnv.WASM, skiaBinDir)
 
         linker.set(linkerForTarget(OS.Wasm, Arch.Wasm))
         buildTargetOS.set(OS.Wasm)
         buildTargetArch.set(Arch.Wasm)
         buildVariant.set(buildType)
 
-        libFiles = project.fileTree(skiaWasmDir.get()) {
-            include("**/*.wasm.a")
-            exclude("**/libskia_graphite_ext.wasm.a")
-            exclude("**/libskia_graphite_dawn_ext.wasm.a")
-        }
+        libFiles = project.files(resolvedBinaryInputs.staticArchivePaths.distinct())
         objectFiles = project.fileTree(compileWasm.map { it.outDir.get() }) {
             include("**/*.o")
         }
@@ -94,17 +92,10 @@ fun SkikoProjectContext.declareWasmTasks() {
         flags.addAll(buildList {
             addAll(
                 listOf(
-                    "-l", "GL",
-                    "-s", "MAX_WEBGL_VERSION=2",
-                    "-s", "MIN_WEBGL_VERSION=2",
                     "-s", "OFFSCREEN_FRAMEBUFFER=1",
                     "-s", "ALLOW_MEMORY_GROWTH=1", // TODO: Is there a better way? Should we use `-s INITIAL_MEMORY=X`?
                     "-s", "EXPORT_ES6=1",
-                    "-s", "MODULARIZE=1",
-                    "-s", "EXPORT_NAME=loadSkikoWASM",
-                    "-s", "EXPORTED_RUNTIME_METHODS=\"[GL, wasmExports]\"",
                     "-s", "SUPPORT_LONGJMP=wasm",
-                    "--bind",
                     // -O2 saves 800kB for the output file, and ~100kB for transferred size.
                     // -O3 breaks the exports in js/mjs files. skiko.wasm size is the same though
                     "-O2"
@@ -112,6 +103,7 @@ fun SkikoProjectContext.declareWasmTasks() {
             )
 
             if (skiko.isWasmBuildWithProfiling) add("--profiling")
+            addAll(resolvedBinaryInputs.linkFlags)
         })
 
         doLast {

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/WasmTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/WasmTasksConfiguration.kt
@@ -204,7 +204,7 @@ abstract class AbstractImportGeneratorCompilerPluginSupportPlugin(
     override fun getCompilerPluginId() = "org.jetbrains.skiko.imports.generator"
 
     override fun getPluginArtifact(): SubpluginArtifact =
-        SubpluginArtifact(SkikoArtifacts.groupId, IMPORT_GENERATOR)
+        SubpluginArtifact(SkikoArtifacts.DEFAULT_GROUP_ID, IMPORT_GENERATOR)
 
     override fun isApplicable(kotlinCompilation: KotlinCompilation<*>): Boolean {
         return ((kotlinCompilation.platformType == KotlinPlatformType.wasm) || (kotlinCompilation.platformType == KotlinPlatformType.js))
@@ -242,7 +242,7 @@ fun KotlinJsTargetDsl.setupImportsGeneratorPlugin() {
         // By default, it will try to use the same version as kotlin, because we use version=null in getPluginArtifact.
         // But we don't publish the artifact, therefore we substitute it for project dependency.
         it.configurations.pluginConfiguration.resolutionStrategy.dependencySubstitution {
-            substitute(module("${SkikoArtifacts.groupId}:$IMPORT_GENERATOR"))
+            substitute(module("${SkikoArtifacts.DEFAULT_GROUP_ID}:$IMPORT_GENERATOR"))
                 .using(project(":import-generator"))
         }
     }

--- a/skiko/buildSrc/src/main/kotlin/utils.kt
+++ b/skiko/buildSrc/src/main/kotlin/utils.kt
@@ -45,9 +45,6 @@ fun Task.projectDirs(vararg relativePaths: String): List<Directory> {
     return relativePaths.map { path -> projectDir.dir(path) }
 }
 
-fun listOfFrameworks(vararg frameworks: String): List<String> =
-    frameworks.toList().addElementBeforeEach("-framework")
-
 fun mutableListOfLinkerOptions(options: Collection<String>): MutableList<String> =
     options.addElementBeforeEach("-linker-option")
 

--- a/skiko/ci/build.gradle.kts
+++ b/skiko/ci/build.gradle.kts
@@ -4,32 +4,33 @@ import org.jetbrains.compose.internal.publishing.*
 val skiko = SkikoProperties(project)
 val mavenCentral = MavenCentralProperties(project)
 val GITHUB_REPO = "JetBrains/skiko"
+val skikoArtifacts = SkikoArtifacts()
 
 val skikoArtifactIds: List<String> =
     listOf(
-        SkikoArtifacts.commonArtifactId,
-        SkikoArtifacts.jvmArtifactId,
-        SkikoArtifacts.jvmRuntimeArtifactIdFor(OS.Windows, Arch.X64),
-        SkikoArtifacts.jvmRuntimeArtifactIdFor(OS.Windows, Arch.Arm64),
-        SkikoArtifacts.jvmRuntimeArtifactIdFor(OS.Linux, Arch.X64),
-        SkikoArtifacts.jvmRuntimeArtifactIdFor(OS.Linux, Arch.Arm64),
-        SkikoArtifacts.jvmRuntimeArtifactIdFor(OS.MacOS, Arch.X64),
-        SkikoArtifacts.jvmRuntimeArtifactIdFor(OS.MacOS, Arch.Arm64),
-        SkikoArtifacts.jvmAdditionalRuntimeArtifactIdFor("angle", OS.Windows, Arch.X64),
-        SkikoArtifacts.jvmAdditionalRuntimeArtifactIdFor("angle", OS.Windows, Arch.Arm64),
-        SkikoArtifacts.jsWasmArtifactId,
-        SkikoArtifacts.jsArtifactId,
-        SkikoArtifacts.wasmArtifactId,
-        SkikoArtifacts.nativeArtifactIdFor(OS.Linux, Arch.X64),
-        SkikoArtifacts.nativeArtifactIdFor(OS.Linux, Arch.Arm64),
-        SkikoArtifacts.nativeArtifactIdFor(OS.MacOS, Arch.Arm64),
-        SkikoArtifacts.nativeArtifactIdFor(OS.MacOS, Arch.X64),
-        SkikoArtifacts.nativeArtifactIdFor(OS.IOS, Arch.X64),
-        SkikoArtifacts.nativeArtifactIdFor(OS.IOS, Arch.Arm64),
-        SkikoArtifacts.nativeArtifactIdFor(OS.IOS, Arch.Arm64, isUikitSim = true),
-        SkikoArtifacts.nativeArtifactIdFor(OS.TVOS, Arch.X64),
-        SkikoArtifacts.nativeArtifactIdFor(OS.TVOS, Arch.Arm64),
-        SkikoArtifacts.nativeArtifactIdFor(OS.TVOS, Arch.Arm64, isUikitSim = true),
+        skikoArtifacts.commonArtifactId,
+        skikoArtifacts.jvmArtifactId,
+        skikoArtifacts.jvmRuntimeArtifactIdFor(OS.Windows, Arch.X64),
+        skikoArtifacts.jvmRuntimeArtifactIdFor(OS.Windows, Arch.Arm64),
+        skikoArtifacts.jvmRuntimeArtifactIdFor(OS.Linux, Arch.X64),
+        skikoArtifacts.jvmRuntimeArtifactIdFor(OS.Linux, Arch.Arm64),
+        skikoArtifacts.jvmRuntimeArtifactIdFor(OS.MacOS, Arch.X64),
+        skikoArtifacts.jvmRuntimeArtifactIdFor(OS.MacOS, Arch.Arm64),
+        skikoArtifacts.jvmAdditionalRuntimeArtifactIdFor("angle", OS.Windows, Arch.X64),
+        skikoArtifacts.jvmAdditionalRuntimeArtifactIdFor("angle", OS.Windows, Arch.Arm64),
+        skikoArtifacts.jsWasmArtifactId,
+        skikoArtifacts.jsArtifactId,
+        skikoArtifacts.wasmArtifactId,
+        skikoArtifacts.nativeArtifactIdFor(OS.Linux, Arch.X64),
+        skikoArtifacts.nativeArtifactIdFor(OS.Linux, Arch.Arm64),
+        skikoArtifacts.nativeArtifactIdFor(OS.MacOS, Arch.Arm64),
+        skikoArtifacts.nativeArtifactIdFor(OS.MacOS, Arch.X64),
+        skikoArtifacts.nativeArtifactIdFor(OS.IOS, Arch.X64),
+        skikoArtifacts.nativeArtifactIdFor(OS.IOS, Arch.Arm64),
+        skikoArtifacts.nativeArtifactIdFor(OS.IOS, Arch.Arm64, isUikitSim = true),
+        skikoArtifacts.nativeArtifactIdFor(OS.TVOS, Arch.X64),
+        skikoArtifacts.nativeArtifactIdFor(OS.TVOS, Arch.Arm64),
+        skikoArtifacts.nativeArtifactIdFor(OS.TVOS, Arch.Arm64, isUikitSim = true),
 )
 
 val downloadSkikoArtifactsFromComposeDev by tasks.registering(DownloadFromSpaceMavenRepoTask::class) {
@@ -94,7 +95,7 @@ fun Project.skikoMavenModules(version: String): Provider<List<ModuleToUpload>> =
         val artifactsDir = layout.buildDirectory.dir("skiko-artifacts").get().asFile
 
         skikoArtifactIds.map { artifactId ->
-            val skikoGroupId = "org.jetbrains.skiko"
+            val skikoGroupId = SkikoArtifacts.DEFAULT_GROUP_ID
             ModuleToUpload(
                 groupId = skikoGroupId,
                 artifactId = artifactId,


### PR DESCRIPTION
Another PR preparing the Skiko config to allow easier registration of new modules

It consists of:

- A custom DSL for registering Skia archives and linker flags by:  Env (jvm/native/wasm), OS and Arch
- Extracting Skia library declarations and some core-specific linker flags from environment configuration tasks
- Parameterizing `SkikoArtifacts` to reuse the publication config

Fixes [SKIKO-1141](https://youtrack.jetbrains.com/issue/SKIKO-1141)