### PR TITLE
GitHub checks. Checking that AWT runtimes can be built

### DIFF
--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -137,7 +137,7 @@ jobs:
             -Pskiko.arch=arm64 \
             :skiko:publishToMavenLocal
 
-      # Build Arm64 separately (arm64 is built in publishToMavenLocal)
+      # Build x64 separately (arm64 is built in publishToMavenLocal)
       - shell: bash
         name: 'Publish AWT Runtime x64 Maven Local'
         run: |

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -62,26 +62,15 @@ jobs:
         name: 'Setup Prerequisites'
 
       - uses: ./.github/actions/docker-skiko-run
-        name: 'Publish KMP and AWT Maven Local'
+        name: 'Publish Maven Local x64'
         with:
           image_name: linux-compat
           command: |
             ./gradlew --no-daemon --stacktrace \
               -Pskiko.native.enabled=true \
               -Pskiko.awt.enabled=true \
-              :skiko:publishKotlinMultiplatformPublicationToMavenLocal \
-              :skiko:publishAwtPublicationToMavenLocal \
-              :skiko:publishAwtRuntimeElementsPublicationToMavenLocal
-
-      - uses: ./.github/actions/docker-skiko-run
-        name:  'Publish AWT Runtime x64 Maven Local'
-        with:
-          image_name: linux-compat
-          command: |
-            ./gradlew --no-daemon --stacktrace \
-              -Pskiko.awt.enabled=true \
-              :skiko:publishSkikoJvmRuntimeLinuxX64PublicationToMavenLocal \
-              -Pskiko.arch=x64
+              -Pskiko.arch=x64 \
+               :skiko:publishToMavenLocal
 
       - uses: ./.github/actions/docker-skiko-run
         name: 'Publish Native Maven Local'
@@ -112,6 +101,7 @@ jobs:
       - uses: ./.github/actions/setup-prerequisites
         name: 'Setup Prerequisites'
 
+      # We run it on a separate runner because cross-compilation on x64 fails
       - uses: ./.github/actions/docker-skiko-run
         name:  'Publish AWT Runtime Arm64 Maven Local'
         with:
@@ -139,12 +129,15 @@ jobs:
         name: 'Setup Prerequisites'
 
       - shell: bash
-        name: 'Publish Maven Local'
+        name: 'Publish Maven Local arm64'
         run: |
           ./gradlew --no-daemon --stacktrace \
             -Pskiko.native.enabled=true \
+            -Pskiko.awt.enabled=true \
+            -Pskiko.arch=arm64 \
             :skiko:publishToMavenLocal
 
+      # Build Arm64 separately (arm64 is built in publishToMavenLocal)
       - shell: bash
         name: 'Publish AWT Runtime x64 Maven Local'
         run: |
@@ -152,14 +145,6 @@ jobs:
             -Pskiko.awt.enabled=true \
             :skiko:publishSkikoJvmRuntimeMacosX64PublicationToMavenLocal \
             -Pskiko.arch=x64
-
-      - shell: bash
-        name: 'Publish AWT Runtime Arm64 Maven Local'
-        run: |
-          ./gradlew --no-daemon --stacktrace \
-            -Pskiko.awt.enabled=true \
-            :skiko:publishSkikoJvmRuntimeMacosArm64PublicationToMavenLocal \
-            -Pskiko.arch=arm64
 
       - shell: bash
         name: 'Check AWT Sample'
@@ -188,20 +173,15 @@ jobs:
         name: 'Setup Prerequisites'
 
       - shell: bash
-        name: 'Publish Maven Local'
+        name: 'Publish Maven Local x64'
         run: |
           ./gradlew --no-daemon --stacktrace \
             -Pskiko.native.enabled=true \
+            -Pskiko.awt.enabled=true \
+            -Pskiko.arch=x64 \
              :skiko:publishToMavenLocal
 
-      - shell: bash
-        name: 'Publish AWT Runtime x64 Maven Local'
-        run: |
-          ./gradlew --no-daemon --stacktrace \
-            -Pskiko.awt.enabled=true \
-            :skiko:publishSkikoJvmRuntimeWindowsX64PublicationToMavenLocal \
-            -Pskiko.arch=x64
-
+      # Build Arm64 separately (x64 is built in publishToMavenLocal)
       - shell: bash
         name: 'Publish AWT Runtime Arm64 Maven Local'
         run: |

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -103,7 +103,7 @@ jobs:
               :SkiaAwtSample:installDist
 
   LinuxArm:
-    name: 'Linux Publish Dry Run'
+    name: 'Linux Arm Publish Dry Run'
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -109,8 +109,8 @@ jobs:
           command: |
             ./gradlew --no-daemon --stacktrace \
               -Pskiko.awt.enabled=true \
-              :skiko:publishSkikoJvmRuntimeLinuxArm64PublicationToMavenLocal \
-              -Pskiko.arch=arm64
+              -Pskiko.arch=arm64 \
+              :skiko:publishSkikoJvmRuntimeLinuxArm64PublicationToMavenLocal
 
   macOS:
     name: 'macOS Publish Dry Run'

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -143,8 +143,8 @@ jobs:
         run: |
           ./gradlew --no-daemon --stacktrace \
             -Pskiko.awt.enabled=true \
-            :skiko:publishSkikoJvmRuntimeMacosX64PublicationToMavenLocal \
-            -Pskiko.arch=x64
+            -Pskiko.arch=x64 \
+            :skiko:publishSkikoJvmRuntimeMacosX64PublicationToMavenLocal
 
       - shell: bash
         name: 'Check AWT Sample'

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -62,16 +62,23 @@ jobs:
         name: 'Setup Prerequisites'
 
       - uses: ./.github/actions/docker-skiko-run
-        name: 'Publish KMP and AWT Maven Local'
+        name: 'Publish KMP Maven Local'
         with:
           image_name: linux-compat
           command: |
             ./gradlew --no-daemon --stacktrace \
               -Pskiko.native.enabled=true \
               -Pskiko.awt.enabled=true \
-              :skiko:publishKotlinMultiplatformPublicationToMavenLocal \
-              :skiko:publishAwtPublicationToMavenLocal \
-              :skiko:publishAwtRuntimeElementsPublicationToMavenLocal
+              :skiko:publishKotlinMultiplatformPublicationToMavenLocal
+
+      - uses: ./.github/actions/docker-skiko-run
+        name:  'Publish AWT Maven Local'
+        with:
+          image_name: linux-compat
+          command: |
+            ./gradlew --no-daemon --stacktrace \
+              -Pskiko.awt.enabled=true \
+              :skiko:publishToMavenLocal
 
       - uses: ./.github/actions/docker-skiko-run
         name: 'Publish Native Maven Local'
@@ -116,6 +123,13 @@ jobs:
             :skiko:publishToMavenLocal
 
       - shell: bash
+        name: 'Publish AWT Maven Local'
+        run: |
+          ./gradlew --no-daemon --stacktrace \
+            -Pskiko.awt.enabled=true \
+            :skiko:publishToMavenLocal
+
+      - shell: bash
         name: 'Check AWT Sample'
         run: |
           ./gradlew --no-daemon --stacktrace \
@@ -147,6 +161,13 @@ jobs:
           ./gradlew --no-daemon --stacktrace \
             -Pskiko.native.enabled=true \
              :skiko:publishToMavenLocal
+
+      - shell: bash
+        name: 'Publish AWT Maven Local'
+        run: |
+          ./gradlew --no-daemon --stacktrace \
+            -Pskiko.awt.enabled=true \
+            :skiko:publishToMavenLocal
 
       - shell: bash
         name: 'Check AWT Sample'

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -52,7 +52,7 @@ jobs:
               :skiko:publishToMavenLocal
 
   Linux:
-    name: 'Linux Publish Dry Run'
+    name: 'Linux x64 Publish Dry Run'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -62,7 +62,7 @@ jobs:
         name: 'Setup Prerequisites'
 
       - uses: ./.github/actions/docker-skiko-run
-        name: 'Publish Maven Local x64'
+        name: 'Publish x64 Maven Local'
         with:
           image_name: linux-compat
           command: |
@@ -92,7 +92,7 @@ jobs:
               :SkiaAwtSample:installDist
 
   LinuxArm:
-    name: 'Linux Arm Publish Dry Run'
+    name: 'Linux arm64 Publish Dry Run'
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
@@ -103,7 +103,7 @@ jobs:
 
       # We run it on a separate runner because cross-compilation on x64 fails
       - uses: ./.github/actions/docker-skiko-run
-        name:  'Publish AWT Runtime Arm64 Maven Local'
+        name:  'Publish AWT Runtime arm64 Maven Local'
         with:
           image_name: linux-compat
           command: |
@@ -129,7 +129,7 @@ jobs:
         name: 'Setup Prerequisites'
 
       - shell: bash
-        name: 'Publish Maven Local arm64'
+        name: 'Publish arm64 Maven Local'
         run: |
           ./gradlew --no-daemon --stacktrace \
             -Pskiko.native.enabled=true \
@@ -173,7 +173,7 @@ jobs:
         name: 'Setup Prerequisites'
 
       - shell: bash
-        name: 'Publish Maven Local x64'
+        name: 'Publish x64 Maven Local'
         run: |
           ./gradlew --no-daemon --stacktrace \
             -Pskiko.native.enabled=true \
@@ -183,7 +183,7 @@ jobs:
 
       # Build Arm64 separately (x64 is built in publishToMavenLocal)
       - shell: bash
-        name: 'Publish AWT Runtime Arm64 Maven Local'
+        name: 'Publish AWT Runtime arm64 Maven Local'
         run: |
           ./gradlew --no-daemon --stacktrace \
             -Pskiko.awt.enabled=true \

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -73,6 +73,16 @@ jobs:
                :skiko:publishToMavenLocal
 
       - uses: ./.github/actions/docker-skiko-run
+        name:  'Publish AWT Runtime arm64 Maven Local'
+        with:
+          image_name: linux-compat
+          command: |
+            ./gradlew --no-daemon --stacktrace \
+              -Pskiko.awt.enabled=true \
+              :skiko:publishSkikoJvmRuntimeLinuxArm64PublicationToMavenLocal \
+              -Pskiko.arch=arm64
+
+      - uses: ./.github/actions/docker-skiko-run
         name: 'Publish Native Maven Local'
         with:
           image_name: linux-amd64

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -84,16 +84,6 @@ jobs:
               -Pskiko.arch=x64
 
       - uses: ./.github/actions/docker-skiko-run
-        name:  'Publish AWT Runtime Arm64 Maven Local'
-        with:
-          image_name: linux-compat
-          command: |
-            ./gradlew --no-daemon --stacktrace \
-              -Pskiko.awt.enabled=true \
-              :skiko:publishSkikoJvmRuntimeLinuxArm64PublicationToMavenLocal \
-              -Pskiko.arch=arm64
-
-      - uses: ./.github/actions/docker-skiko-run
         name: 'Publish Native Maven Local'
         with:
           image_name: linux-amd64
@@ -111,6 +101,26 @@ jobs:
           command: |
             ./gradlew --no-daemon --stacktrace \
               :SkiaAwtSample:installDist
+
+  LinuxArm:
+    name: 'Linux Publish Dry Run'
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+        name: 'Check out code'
+
+      - uses: ./.github/actions/setup-prerequisites
+        name: 'Setup Prerequisites'
+
+      - uses: ./.github/actions/docker-skiko-run
+        name:  'Publish AWT Runtime Arm64 Maven Local'
+        with:
+          image_name: linux-compat
+          command: |
+            ./gradlew --no-daemon --stacktrace \
+              -Pskiko.awt.enabled=true \
+              :skiko:publishSkikoJvmRuntimeLinuxArm64PublicationToMavenLocal \
+              -Pskiko.arch=arm64
 
   macOS:
     name: 'macOS Publish Dry Run'

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -73,16 +73,6 @@ jobs:
                :skiko:publishToMavenLocal
 
       - uses: ./.github/actions/docker-skiko-run
-        name:  'Publish AWT Runtime arm64 Maven Local'
-        with:
-          image_name: linux-compat
-          command: |
-            ./gradlew --no-daemon --stacktrace \
-              -Pskiko.awt.enabled=true \
-              :skiko:publishSkikoJvmRuntimeLinuxArm64PublicationToMavenLocal \
-              -Pskiko.arch=arm64
-
-      - uses: ./.github/actions/docker-skiko-run
         name: 'Publish Native Maven Local'
         with:
           image_name: linux-amd64

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -80,8 +80,8 @@ jobs:
           command: |
             ./gradlew --no-daemon --stacktrace \
               -Pskiko.awt.enabled=true \
-              :skiko:publishSkikoJvmRuntimeLinuxArm64PublicationToComposeRepoRepository \
-              :skiko:publishSkikoJvmRuntimeLinuxX64PublicationToComposeRepoRepository
+              :skiko:publishSkikoJvmRuntimeLinuxArm64PublicationToMavenLocal \
+              :skiko:publishSkikoJvmRuntimeLinuxX64PublicationToMavenLocal
 
       - uses: ./.github/actions/docker-skiko-run
         name: 'Publish Native Maven Local'
@@ -130,8 +130,8 @@ jobs:
         run: |
           ./gradlew --no-daemon --stacktrace \
             -Pskiko.awt.enabled=true \
-            :skiko:publishSkikoJvmRuntimeMacosArm64PublicationToComposeRepoRepository \
-            :skiko:publishSkikoJvmRuntimeMacosX64PublicationToComposeRepoRepository
+            :skiko:publishSkikoJvmRuntimeMacosArm64PublicationToMavenLocal \
+            :skiko:publishSkikoJvmRuntimeMacosX64PublicationToMavenLocal
 
       - shell: bash
         name: 'Check AWT Sample'
@@ -171,8 +171,8 @@ jobs:
         run: |
           ./gradlew --no-daemon --stacktrace \
             -Pskiko.awt.enabled=true \
-            :skiko:publishSkikoJvmRuntimeWindowsArm64PublicationToComposeRepoRepository \
-            :skiko:publishSkikoJvmRuntimeWindowsX64PublicationToComposeRepoRepository
+            :skiko:publishSkikoJvmRuntimeWindowsArm64PublicationToMavenLocal \
+            :skiko:publishSkikoJvmRuntimeWindowsX64PublicationToMavenLocal
 
       - shell: bash
         name: 'Check AWT Sample'

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -62,23 +62,26 @@ jobs:
         name: 'Setup Prerequisites'
 
       - uses: ./.github/actions/docker-skiko-run
-        name: 'Publish KMP Maven Local'
+        name: 'Publish KMP and AWT Maven Local'
         with:
           image_name: linux-compat
           command: |
             ./gradlew --no-daemon --stacktrace \
               -Pskiko.native.enabled=true \
               -Pskiko.awt.enabled=true \
-              :skiko:publishKotlinMultiplatformPublicationToMavenLocal
+              :skiko:publishKotlinMultiplatformPublicationToMavenLocal \
+              :skiko:publishAwtPublicationToMavenLocal \
+              :skiko:publishAwtRuntimeElementsPublicationToMavenLocal
 
       - uses: ./.github/actions/docker-skiko-run
-        name:  'Publish AWT Maven Local'
+        name:  'Publish AWT Runtime Maven Local'
         with:
           image_name: linux-compat
           command: |
             ./gradlew --no-daemon --stacktrace \
               -Pskiko.awt.enabled=true \
-              :skiko:publishToMavenLocal
+              :skiko:publishSkikoJvmRuntimeLinuxArm64PublicationToComposeRepoRepository \
+              :skiko:publishSkikoJvmRuntimeLinuxX64PublicationToComposeRepoRepository
 
       - uses: ./.github/actions/docker-skiko-run
         name: 'Publish Native Maven Local'
@@ -123,11 +126,12 @@ jobs:
             :skiko:publishToMavenLocal
 
       - shell: bash
-        name: 'Publish AWT Maven Local'
+        name: 'Publish AWT Runtime Maven Local'
         run: |
           ./gradlew --no-daemon --stacktrace \
             -Pskiko.awt.enabled=true \
-            :skiko:publishToMavenLocal
+            :skiko:publishSkikoJvmRuntimeMacosArm64PublicationToComposeRepoRepository \
+            :skiko:publishSkikoJvmRuntimeMacosX64PublicationToComposeRepoRepository
 
       - shell: bash
         name: 'Check AWT Sample'
@@ -163,11 +167,12 @@ jobs:
              :skiko:publishToMavenLocal
 
       - shell: bash
-        name: 'Publish AWT Maven Local'
+        name: 'Publish AWT Runtime Maven Local'
         run: |
           ./gradlew --no-daemon --stacktrace \
             -Pskiko.awt.enabled=true \
-            :skiko:publishToMavenLocal
+            :skiko:publishSkikoJvmRuntimeWindowsArm64PublicationToComposeRepoRepository \
+            :skiko:publishSkikoJvmRuntimeWindowsX64PublicationToComposeRepoRepository
 
       - shell: bash
         name: 'Check AWT Sample'

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -187,8 +187,8 @@ jobs:
         run: |
           ./gradlew --no-daemon --stacktrace \
             -Pskiko.awt.enabled=true \
-            :skiko:publishSkikoJvmRuntimeWindowsArm64PublicationToMavenLocal \
-            -Pskiko.arch=arm64
+            -Pskiko.arch=arm64 \
+            :skiko:publishSkikoJvmRuntimeWindowsArm64PublicationToMavenLocal
 
       - shell: bash
         name: 'Check AWT Sample'

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -74,14 +74,24 @@ jobs:
               :skiko:publishAwtRuntimeElementsPublicationToMavenLocal
 
       - uses: ./.github/actions/docker-skiko-run
-        name:  'Publish AWT Runtime Maven Local'
+        name:  'Publish AWT Runtime x64 Maven Local'
+        with:
+          image_name: linux-compat
+          command: |
+            ./gradlew --no-daemon --stacktrace \
+              -Pskiko.awt.enabled=true \
+              :skiko:publishSkikoJvmRuntimeLinuxX64PublicationToMavenLocal \
+              -Pskiko.arch=x64
+
+      - uses: ./.github/actions/docker-skiko-run
+        name:  'Publish AWT Runtime Arm64 Maven Local'
         with:
           image_name: linux-compat
           command: |
             ./gradlew --no-daemon --stacktrace \
               -Pskiko.awt.enabled=true \
               :skiko:publishSkikoJvmRuntimeLinuxArm64PublicationToMavenLocal \
-              :skiko:publishSkikoJvmRuntimeLinuxX64PublicationToMavenLocal
+              -Pskiko.arch=arm64
 
       - uses: ./.github/actions/docker-skiko-run
         name: 'Publish Native Maven Local'
@@ -126,12 +136,20 @@ jobs:
             :skiko:publishToMavenLocal
 
       - shell: bash
-        name: 'Publish AWT Runtime Maven Local'
+        name: 'Publish AWT Runtime x64 Maven Local'
+        run: |
+          ./gradlew --no-daemon --stacktrace \
+            -Pskiko.awt.enabled=true \
+            :skiko:publishSkikoJvmRuntimeMacosX64PublicationToMavenLocal \
+            -Pskiko.arch=x64
+
+      - shell: bash
+        name: 'Publish AWT Runtime Arm64 Maven Local'
         run: |
           ./gradlew --no-daemon --stacktrace \
             -Pskiko.awt.enabled=true \
             :skiko:publishSkikoJvmRuntimeMacosArm64PublicationToMavenLocal \
-            :skiko:publishSkikoJvmRuntimeMacosX64PublicationToMavenLocal
+            -Pskiko.arch=arm64
 
       - shell: bash
         name: 'Check AWT Sample'
@@ -167,12 +185,20 @@ jobs:
              :skiko:publishToMavenLocal
 
       - shell: bash
-        name: 'Publish AWT Runtime Maven Local'
+        name: 'Publish AWT Runtime x64 Maven Local'
+        run: |
+          ./gradlew --no-daemon --stacktrace \
+            -Pskiko.awt.enabled=true \
+            :skiko:publishSkikoJvmRuntimeWindowsX64PublicationToMavenLocal \
+            -Pskiko.arch=x64
+
+      - shell: bash
+        name: 'Publish AWT Runtime Arm64 Maven Local'
         run: |
           ./gradlew --no-daemon --stacktrace \
             -Pskiko.awt.enabled=true \
             :skiko:publishSkikoJvmRuntimeWindowsArm64PublicationToMavenLocal \
-            :skiko:publishSkikoJvmRuntimeWindowsX64PublicationToMavenLocal
+            -Pskiko.arch=arm64
 
       - shell: bash
         name: 'Check AWT Sample'

--- a/skiko/docker/linux-compat/Dockerfile
+++ b/skiko/docker/linux-compat/Dockerfile
@@ -84,7 +84,10 @@ ENV PATH=$DEPOT_TOOLS:$PATH
 RUN git clone 'https://chromium.googlesource.com/chromium/tools/depot_tools.git' $DEPOT_TOOLS
 
 # Install cross-compilation toolchain for ARM64
-:arm64
+# This cross-compilation setup is required because Kotlin/Native doesn't support
+# Linux ARM64 as a HOST platform (only as a target). When cross-compiling from x64 to ARM64,
+# Kotlin/Native's linker needs ARM64 versions of system libraries.
+# See: https://youtrack.jetbrains.com/issue/KT-36871
 ENV ARM_TOOLCHAIN_VERSION=10.3-2021.07
 ENV ARM_TOOLCHAIN_NAME=gcc-arm-${ARM_TOOLCHAIN_VERSION}-x86_64-aarch64-none-linux-gnu
 ENV ARM_TOOLCHAIN_PATH=/opt/arm-gnu-toolchain

--- a/skiko/docker/linux-compat/Dockerfile
+++ b/skiko/docker/linux-compat/Dockerfile
@@ -84,7 +84,10 @@ ENV PATH=$DEPOT_TOOLS:$PATH
 RUN git clone 'https://chromium.googlesource.com/chromium/tools/depot_tools.git' $DEPOT_TOOLS
 
 # Install cross-compilation toolchain for ARM64
-:arm64
+# This cross-compilation setup is required because Kotlin/Native doesn't support
+# Linux ARM64 as a HOST platform (only as a target). When cross-compiling from x64 to ARM64,
+# Kotlin/Native's linker needs ARM64 versions of system libraries.
+# See: https://youtrack.jetbrains.com/issue/KT-36871
 ENV ARM_TOOLCHAIN_VERSION=10.3-2021.07
 ENV ARM_TOOLCHAIN_NAME=gcc-arm-${ARM_TOOLCHAIN_VERSION}-x86_64-aarch64-none-linux-gnu
 ENV ARM_TOOLCHAIN_PATH=/opt/arm-gnu-toolchain
@@ -98,21 +101,6 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
     ln -s $ARM_TOOLCHAIN_PATH/bin/aarch64-none-linux-gnu-gcc /usr/local/bin/aarch64-linux-gnu-gcc && \
     ln -s $ARM_TOOLCHAIN_PATH/bin/aarch64-none-linux-gnu-ar /usr/local/bin/aarch64-linux-gnu-ar; \
     fi
-
-# Install ARM64 libraries for cross-compilation
-RUN dpkg --add-architecture arm64 && echo \
-        "deb [arch=arm64] http://ports.ubuntu.com/ focal main restricted\n" \
-        "deb [arch=arm64] http://ports.ubuntu.com/ focal-updates main restricted\n" \
-        "deb [arch=arm64] http://ports.ubuntu.com/ focal universe\n" \
-        "deb [arch=arm64] http://ports.ubuntu.com/ focal-updates universe\n" \
-        "deb [arch=arm64] http://ports.ubuntu.com/ focal multiverse\n" \
-        "deb [arch=arm64] http://ports.ubuntu.com/ focal-updates multiverse\n" \
-        "deb [arch=arm64] http://ports.ubuntu.com/ focal-backports main restricted universe multiverse" \
-    | tee /etc/apt/sources.list.d/arm-cross-compile-sources.list && \
-    sed -i -E "s/(deb)\ (http:.+)/\1\ [arch=amd64]\ \2/" /etc/apt/sources.list && \
-    apt update -y && \
-    apt install libfontconfig1-dev:arm64 libglu1-mesa-dev:arm64 libxrandr-dev:arm64 libdbus-1-dev:arm64 -y && \
-    rm -rf /var/lib/apt/lists/*
 
 # Copy development headers to ARM64 sysroot
 ENV ARM_SYSROOT_HEADERS="fontconfig freetype2 GL X11 KHR"

--- a/skiko/docker/linux-compat/Dockerfile
+++ b/skiko/docker/linux-compat/Dockerfile
@@ -84,10 +84,7 @@ ENV PATH=$DEPOT_TOOLS:$PATH
 RUN git clone 'https://chromium.googlesource.com/chromium/tools/depot_tools.git' $DEPOT_TOOLS
 
 # Install cross-compilation toolchain for ARM64
-# This cross-compilation setup is required because Kotlin/Native doesn't support
-# Linux ARM64 as a HOST platform (only as a target). When cross-compiling from x64 to ARM64,
-# Kotlin/Native's linker needs ARM64 versions of system libraries.
-# See: https://youtrack.jetbrains.com/issue/KT-36871
+:arm64
 ENV ARM_TOOLCHAIN_VERSION=10.3-2021.07
 ENV ARM_TOOLCHAIN_NAME=gcc-arm-${ARM_TOOLCHAIN_VERSION}-x86_64-aarch64-none-linux-gnu
 ENV ARM_TOOLCHAIN_PATH=/opt/arm-gnu-toolchain

--- a/skiko/docker/linux-compat/Dockerfile
+++ b/skiko/docker/linux-compat/Dockerfile
@@ -84,10 +84,7 @@ ENV PATH=$DEPOT_TOOLS:$PATH
 RUN git clone 'https://chromium.googlesource.com/chromium/tools/depot_tools.git' $DEPOT_TOOLS
 
 # Install cross-compilation toolchain for ARM64
-# This cross-compilation setup is required because Kotlin/Native doesn't support
-# Linux ARM64 as a HOST platform (only as a target). When cross-compiling from x64 to ARM64,
-# Kotlin/Native's linker needs ARM64 versions of system libraries.
-# See: https://youtrack.jetbrains.com/issue/KT-36871
+:arm64
 ENV ARM_TOOLCHAIN_VERSION=10.3-2021.07
 ENV ARM_TOOLCHAIN_NAME=gcc-arm-${ARM_TOOLCHAIN_VERSION}-x86_64-aarch64-none-linux-gnu
 ENV ARM_TOOLCHAIN_PATH=/opt/arm-gnu-toolchain
@@ -101,6 +98,21 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
     ln -s $ARM_TOOLCHAIN_PATH/bin/aarch64-none-linux-gnu-gcc /usr/local/bin/aarch64-linux-gnu-gcc && \
     ln -s $ARM_TOOLCHAIN_PATH/bin/aarch64-none-linux-gnu-ar /usr/local/bin/aarch64-linux-gnu-ar; \
     fi
+
+# Install ARM64 libraries for cross-compilation
+RUN dpkg --add-architecture arm64 && echo \
+        "deb [arch=arm64] http://ports.ubuntu.com/ focal main restricted\n" \
+        "deb [arch=arm64] http://ports.ubuntu.com/ focal-updates main restricted\n" \
+        "deb [arch=arm64] http://ports.ubuntu.com/ focal universe\n" \
+        "deb [arch=arm64] http://ports.ubuntu.com/ focal-updates universe\n" \
+        "deb [arch=arm64] http://ports.ubuntu.com/ focal multiverse\n" \
+        "deb [arch=arm64] http://ports.ubuntu.com/ focal-updates multiverse\n" \
+        "deb [arch=arm64] http://ports.ubuntu.com/ focal-backports main restricted universe multiverse" \
+    | tee /etc/apt/sources.list.d/arm-cross-compile-sources.list && \
+    sed -i -E "s/(deb)\ (http:.+)/\1\ [arch=amd64]\ \2/" /etc/apt/sources.list && \
+    apt update -y && \
+    apt install libfontconfig1-dev:arm64 libglu1-mesa-dev:arm64 libxrandr-dev:arm64 libdbus-1-dev:arm64 -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # Copy development headers to ARM64 sysroot
 ENV ARM_SYSROOT_HEADERS="fontconfig freetype2 GL X11 KHR"


### PR DESCRIPTION
Previously we didn't check JVM Linux x64/arm64, macOs x64, Windows arm64 AWT runtimes
