### PR TITLE
Set render-target usage on the Metal Swing offscreen texture

### DIFF
--- a/skiko/src/awtMain/objectiveC/macos/MetalSwingRedrawer.mm
+++ b/skiko/src/awtMain/objectiveC/macos/MetalSwingRedrawer.mm
@@ -38,6 +38,12 @@ JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_swing_MetalSwingRedrawer_makeMe
         if (oldTexture == nil || oldTexture.width != width || oldTexture.height != height) {
             id <MTLDevice> adapter = (__bridge id <MTLDevice>) (void *) adapterPtr;
             MTLTextureDescriptor *textureDescriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatBGRA8Unorm width:width height:height mipmapped:NO];
+            // Skia renders into this texture as a backend render target, then it
+            // is sampled when blitted back to Graphics2D via the shared texture.
+            // The default usage of a texture2DDescriptor is MTLTextureUsageShaderRead
+            // only, which trips GrMtlGpu::onWrapBackendRenderTarget's render-target
+            // usage assert on a debug Skia.
+            textureDescriptor.usage = MTLTextureUsageRenderTarget | MTLTextureUsageShaderRead;
             metalTexture = [adapter newTextureWithDescriptor:textureDescriptor];
         } else {
             metalTexture = oldTexture;


### PR DESCRIPTION
Fixes a crash in offscreen Metal Swing rendering (`SkiaSwingLayer`) when running against a Skia build with Metal API validation enabled.

`MetalSwingRedrawer.mm` (`makeMetalTexture`) creates the offscreen texture with `texture2DDescriptorWithPixelFormat:...`, which defaults `.usage` to `MTLTextureUsageShaderRead`. The same texture is then wrapped as a `GrBackendRenderTarget` and rendered into, so on a debug Skia `GrMtlGpu::onWrapBackendRenderTarget` asserts:

```
check(MTLTextureUsageRenderTarget & mtlTexture.usage)
```

and the process SIGTRAPs on the first paint. On a release Skia the assert is compiled out and Metal tolerates the missing flag, so the bug is latent there (and CI, which builds against release Skia, never sees it). Present since `MetalSwingRedrawer` was added (v0.144.6), unchanged on current `master`.

The fix sets the usage bits explicitly — `RenderTarget` because Skia renders into the texture, `ShaderRead` because it is then sampled when blitted back to `Graphics2D`:

```objc
textureDescriptor.usage = MTLTextureUsageRenderTarget | MTLTextureUsageShaderRead;
```

Repro (stock skiko + the published Debug Skia):

```
git clone --depth 1 --branch v0.144.6 https://github.com/JetBrains/skiko.git
./gradlew :skiko:publishToMavenLocal -Pskiko.debug=true
# paint any offscreen SkiaSwingLayer on macOS -> SIGTRAP on first paint
```

Validated: `:skiko:awtTest` green; a 2400-frame `SkiaSwingLayer` soak on the debug Skia runs leak-free (median frame 2.4 ms, RSS flat) where it previously crashed on frame 1. No behavior change on release builds — the change is descriptor-time only.

Release Notes - Fixes a crash in offscreen Metal Swing rendering (`SkiaSwingLayer`) when running against a Skia build with Metal API validation enabled.

Fixes [SKIKO-1144](https://youtrack.jetbrains.com/issue/SKIKO-1144)
