### PR TITLE
Convert non-enum classes to value classes to avoid allocations

### DIFF
--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt
@@ -610,7 +610,7 @@ actual open class SkiaLayer internal constructor(
 
         val pictureRecorder = pictureRecorder!!
         val canvas = pictureRecorder.beginRecording(0f, 0f, pictureWidth, pictureHeight).apply {
-            for (component in clipComponents) {
+            clipComponents.fastForEach { component ->
                 cutoutFromClip(component, contentScale)
             }
 

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/FontMetrics.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/FontMetrics.kt
@@ -21,14 +21,27 @@ value class FontMetrics(internal val metrics: FloatArray) {
         xMax: Float,
         xHeight: Float,
         capHeight: Float,
-        underlineThickness: Float,
-        underlinePosition: Float,
-        strikeoutThickness: Float,
-        strikeoutPosition: Float
+        underlineThickness: Float?,
+        underlinePosition: Float?,
+        strikeoutThickness: Float?,
+        strikeoutPosition: Float?
     ) : this(
         floatArrayOf(
-            top, ascent, descent, bottom, leading, avgCharWidth, maxCharWidth, xMin, xMax, xHeight, capHeight,
-            underlineThickness, underlinePosition, strikeoutThickness, strikeoutPosition
+            top,
+            ascent,
+            descent,
+            bottom,
+            leading,
+            avgCharWidth,
+            maxCharWidth,
+            xMin,
+            xMax,
+            xHeight,
+            capHeight,
+            underlineThickness ?: Float.NaN,
+            underlinePosition ?: Float.NaN,
+            strikeoutThickness ?: Float.NaN,
+            strikeoutPosition ?: Float.NaN
         )
     )
 

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/FontMetrics.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/FontMetrics.kt
@@ -8,7 +8,25 @@ import kotlin.jvm.JvmInline
 @JvmInline
 value class FontMetrics(internal val metrics: FloatArray) {
 
-    //Maintained for binary compatibility
+    /**
+     * Maintained for binary compatibility and previous construction with its named values
+     *
+     * @param top greatest extent above origin of any glyph bounding box, typically negative; deprecated with variable fonts
+     * @param ascent distance to reserve above baseline, typically negative
+     * @param descent distance to reserve below baseline, typically positive
+     * @param bottom greatest extent below origin of any glyph bounding box, typically positive; deprecated with variable fonts
+     * @param leading distance to add between lines, typically positive or zero
+     * @param avgCharWidth average character width, zero if unknown
+     * @param maxCharWidth maximum character width, zero if unknown
+     * @param xMin greatest extent to left of origin of any glyph bounding box, typically negative; deprecated with variable fonts
+     * @param xMax greatest extent to right of origin of any glyph bounding box, typically positive; deprecated with variable fonts
+     * @param xHeight height of lower-case 'x', zero if unknown, typically negative
+     * @param capHeight height of an upper-case letter, zero if unknown, typically negative
+     * @param underlineThickness underline thickness
+     * @param underlinePosition distance from baseline to top of stroke, typically positive
+     * @param strikeoutThickness strikeout thickness
+     * @param strikeoutPosition distance from baseline to bottom of stroke, typically negative
+     */
     constructor(
         top: Float,
         ascent: Float,
@@ -54,7 +72,7 @@ value class FontMetrics(internal val metrics: FloatArray) {
      * distance to reserve above baseline, typically negative
      */
     val ascent: Float
-         get() = metrics[1]
+        get() = metrics[1]
     /**
      * distance to reserve below baseline, typically positive
      */

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/FontMetrics.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/FontMetrics.kt
@@ -3,157 +3,113 @@ package org.jetbrains.skia
 import org.jetbrains.skia.impl.InteropPointer
 import org.jetbrains.skia.impl.InteropScope
 import org.jetbrains.skia.impl.withResult
+import kotlin.jvm.JvmInline
 
-class FontMetrics(
+@JvmInline
+value class FontMetrics(internal val metrics: FloatArray) {
+
+    //Maintained for binary compatibility
+    constructor(
+        top: Float,
+        ascent: Float,
+        descent: Float,
+        bottom: Float,
+        leading: Float,
+        avgCharWidth: Float,
+        maxCharWidth: Float,
+        xMin: Float,
+        xMax: Float,
+        xHeight: Float,
+        capHeight: Float,
+        underlineThickness: Float,
+        underlinePosition: Float,
+        strikeoutThickness: Float,
+        strikeoutPosition: Float
+    ) : this(
+        floatArrayOf(
+            top, ascent, descent, bottom, leading, avgCharWidth, maxCharWidth, xMin, xMax, xHeight, capHeight,
+            underlineThickness, underlinePosition, strikeoutThickness, strikeoutPosition
+        )
+    )
+
     /**
      * greatest extent above origin of any glyph bounding box, typically negative; deprecated with variable fonts
      */
-    val top: Float,
+    val top: Float
+        get() = metrics[0]
     /**
      * distance to reserve above baseline, typically negative
      */
-    val ascent: Float,
+    val ascent: Float
+         get() = metrics[1]
     /**
      * distance to reserve below baseline, typically positive
      */
-    val descent: Float,
+    val descent: Float
+        get() = metrics[2]
     /**
      * greatest extent below origin of any glyph bounding box, typically positive; deprecated with variable fonts
      */
-    val bottom: Float,
+    val bottom: Float
+        get() = metrics[3]
     /**
      * distance to add between lines, typically positive or zero
      */
-    val leading: Float,
+    val leading: Float
+        get() = metrics[4]
     /**
      * average character width, zero if unknown
      */
-    val avgCharWidth: Float,
+    val avgCharWidth: Float
+        get() = metrics[5]
     /**
      * maximum character width, zero if unknown
      */
-    val maxCharWidth: Float,
+    val maxCharWidth: Float
+        get() = metrics[6]
     /**
      * greatest extent to left of origin of any glyph bounding box, typically negative; deprecated with variable fonts
      */
-    val xMin: Float,
+    val xMin: Float
+        get() = metrics[7]
     /**
      * greatest extent to right of origin of any glyph bounding box, typically positive; deprecated with variable fonts
      */
-    val xMax: Float,
+    val xMax: Float
+        get() = metrics[8]
     /**
      * height of lower-case 'x', zero if unknown, typically negative
      */
-    val xHeight: Float,
+    val xHeight: Float
+        get() = metrics[9]
     /**
      * height of an upper-case letter, zero if unknown, typically negative
      */
-    val capHeight: Float,
+    val capHeight: Float
+        get() = metrics[10]
     /**
      * underline thickness
      */
-    val underlineThickness: Float?,
+    val underlineThickness: Float?
+        get() = metrics[11].asNumberOrNull()
     /**
      * distance from baseline to top of stroke, typically positive
      */
-    val underlinePosition: Float?,
+    val underlinePosition: Float?
+        get() = metrics[12].asNumberOrNull()
     /**
      * strikeout thickness
      */
-    val strikeoutThickness: Float?,
+    val strikeoutThickness: Float?
+        get() = metrics[13].asNumberOrNull()
     /**
      * distance from baseline to bottom of stroke, typically negative
      */
     val strikeoutPosition: Float?
-) {
-    /**
-     * greatest extent above origin of any glyph bounding box, typically negative; deprecated with variable fonts
-     */
-    /**
-     * distance to reserve above baseline, typically negative
-     */
-    /**
-     * distance to reserve below baseline, typically positive
-     */
-    /**
-     * greatest extent below origin of any glyph bounding box, typically positive; deprecated with variable fonts
-     */
-    /**
-     * distance to add between lines, typically positive or zero
-     */
-    /**
-     * average character width, zero if unknown
-     */
-    /**
-     * maximum character width, zero if unknown
-     */
-    /**
-     * greatest extent to left of origin of any glyph bounding box, typically negative; deprecated with variable fonts
-     */
-    /**
-     * greatest extent to right of origin of any glyph bounding box, typically positive; deprecated with variable fonts
-     */
-    /**
-     * height of lower-case 'x', zero if unknown, typically negative
-     */
-    /**
-     * height of an upper-case letter, zero if unknown, typically negative
-     */
-    /**
-     * underline thickness
-     */
-    /**
-     * distance from baseline to top of stroke, typically positive
-     */
-    /**
-     * strikeout thickness
-     */
-    /**
-     * distance from baseline to bottom of stroke, typically negative
-     */
+        get() = metrics[14].asNumberOrNull()
+
     val height: Float
         get() = descent - ascent
-
-    override fun equals(other: Any?): Boolean {
-        if (other === this) return true
-        if (other !is FontMetrics) return false
-        if (top.compareTo(other.top) != 0) return false
-        if (ascent.compareTo(other.ascent) != 0) return false
-        if (descent.compareTo(other.descent) != 0) return false
-        if (bottom.compareTo(other.bottom) != 0) return false
-        if (leading.compareTo(other.leading) != 0) return false
-        if (avgCharWidth.compareTo(other.avgCharWidth) != 0) return false
-        if (maxCharWidth.compareTo(other.maxCharWidth) != 0) return false
-        if (xMin.compareTo(other.xMin) != 0) return false
-        if (xMax.compareTo(other.xMax) != 0) return false
-        if (xHeight.compareTo(other.xHeight) != 0) return false
-        if (capHeight.compareTo(other.capHeight) != 0) return false
-        if (if (this.underlineThickness == null) other.underlineThickness != null else this.underlineThickness != other.underlineThickness) return false
-        if (if (this.underlinePosition == null) other.underlinePosition != null else this.underlinePosition != other.underlinePosition) return false
-        if (if (this.strikeoutThickness == null) other.strikeoutThickness != null else this.strikeoutThickness != other.strikeoutThickness) return false
-        return !if (this.strikeoutPosition == null) other.strikeoutPosition != null else this.strikeoutPosition != other.strikeoutPosition
-    }
-
-    override fun hashCode(): Int {
-        val PRIME = 59
-        var result = 1
-        result = result * PRIME + top.toBits()
-        result = result * PRIME + ascent.toBits()
-        result = result * PRIME + descent.toBits()
-        result = result * PRIME + bottom.toBits()
-        result = result * PRIME + leading.toBits()
-        result = result * PRIME + avgCharWidth.toBits()
-        result = result * PRIME + maxCharWidth.toBits()
-        result = result * PRIME + xMin.toBits()
-        result = result * PRIME + xMax.toBits()
-        result = result * PRIME + xHeight.toBits()
-        result = result * PRIME + capHeight.toBits()
-        result = result * PRIME + underlineThickness.hashCode()
-        result = result * PRIME + underlinePosition.hashCode()
-        result = result * PRIME + strikeoutThickness.hashCode()
-        result = result * PRIME + strikeoutPosition.hashCode()
-        return result
-    }
 
     override fun toString(): String {
         return "FontMetrics(_top=$top, _ascent=$ascent, _descent=$descent, _bottom=$bottom, _leading=$leading, _avgCharWidth=$avgCharWidth, _maxCharWidth=$maxCharWidth, _xMin=$xMin, _xMax=$xMax, _xHeight=$xHeight, _capHeight=$capHeight, _underlineThickness=$underlineThickness, _underlinePosition=$underlinePosition, _strikeoutThickness=$strikeoutThickness, _strikeoutPosition=$strikeoutPosition)"
@@ -165,23 +121,4 @@ class FontMetrics(
 @Suppress("NOTHING_TO_INLINE")
 private inline fun Float.asNumberOrNull(): Float? = if (isNaN()) null else this
 
-private fun FontMetrics.Companion.fromRawData(rawData: FloatArray) = FontMetrics(
-        rawData[0],
-        rawData[1],
-        rawData[2],
-        rawData[3],
-        rawData[4],
-        rawData[5],
-        rawData[6],
-        rawData[7],
-        rawData[8],
-        rawData[9],
-        rawData[10],
-        rawData[11].asNumberOrNull(),
-        rawData[12].asNumberOrNull(),
-        rawData[13].asNumberOrNull(),
-        rawData[14].asNumberOrNull()
-    )
-
-
-internal fun FontMetrics.Companion.fromInteropPointer(block: InteropScope.(InteropPointer) -> Unit) = fromRawData(withResult(FloatArray(15), block))
+internal fun FontMetrics.Companion.fromInteropPointer(block: InteropScope.(InteropPointer) -> Unit) = FontMetrics(withResult(FloatArray(15), block))

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/FontStyle.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/FontStyle.kt
@@ -1,28 +1,23 @@
 package org.jetbrains.skia
 
-class FontStyle {
-    val _value: Int
+import kotlin.jvm.JvmInline
 
-    constructor(weight: Int, width: Int, slant: FontSlant) {
-        _value = weight and 65535 or (width and 255 shl 16) or (slant.ordinal shl 24)
-    }
-
-    internal constructor(value: Int) {
-        _value = value
-    }
-
-    val weight: Int
-        get() = _value and 65535
+@JvmInline
+value class FontStyle internal constructor(val _value: Int) {
+    constructor(weight: FontWeight, width: FontWidth, slant: FontSlant) : this(weight.value and 65535 or (width.value and 255 shl 16) or (slant.ordinal shl 24))
+    constructor (weight: Int, width: Int, slant: FontSlant) : this(FontWeight(weight), FontWidth(width), slant)
+    inline val weight: FontWeight
+        get() = FontWeight(_value and 65535)
 
     fun withWeight(weight: Int): FontStyle {
-        return FontStyle(weight, width, slant)
+        return FontStyle(FontWeight(weight), width, slant)
     }
 
-    val width: Int
-        get() = _value shr 16 and 255
+    inline val width: FontWidth
+        get() = FontWidth(_value shr 16 and 255)
 
     fun withWidth(width: Int): FontStyle {
-        return FontStyle(weight, width, slant)
+        return FontStyle(weight, FontWidth(width), slant)
     }
 
     val slant: FontSlant
@@ -33,19 +28,6 @@ class FontStyle {
     }
 
     override fun toString(): String = "FontStyle(weight=$weight, width=$width, slant=$slant)"
-
-    override fun equals(other: Any?): Boolean {
-        if (other === this) return true
-        if (other !is FontStyle) return false
-        return _value == other._value
-    }
-
-    override fun hashCode(): Int {
-        val PRIME = 59
-        var result = 1
-        result = result * PRIME + _value
-        return result
-    }
 
     companion object {
         val NORMAL = FontStyle(FontWeight.NORMAL, FontWidth.NORMAL, FontSlant.UPRIGHT)

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/FontStyle.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/FontStyle.kt
@@ -5,7 +5,6 @@ import kotlin.jvm.JvmInline
 @JvmInline
 value class FontStyle internal constructor(val _value: Int) {
     constructor(weight: FontWeight, width: FontWidth, slant: FontSlant) : this(weight.value and 65535 or (width.value and 255 shl 16) or (slant.ordinal shl 24))
-    constructor (weight: Int, width: Int, slant: FontSlant) : this(FontWeight(weight), FontWidth(width), slant)
     inline val weight: FontWeight
         get() = FontWeight(_value and 65535)
 

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/FontWeight.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/FontWeight.kt
@@ -1,17 +1,23 @@
 package org.jetbrains.skia
 
-interface FontWeight {
+import kotlin.jvm.JvmInline
+
+@JvmInline
+value class FontWeight(val value: Int) {
+
+    operator fun compareTo(other: FontWeight): Int = value.compareTo(other.value)
+
     companion object {
-        const val INVISIBLE = 0
-        const val THIN = 100
-        const val EXTRA_LIGHT = 200
-        const val LIGHT = 300
-        const val NORMAL = 400
-        const val MEDIUM = 500
-        const val SEMI_BOLD = 600
-        const val BOLD = 700
-        const val EXTRA_BOLD = 800
-        const val BLACK = 900
-        const val EXTRA_BLACK = 1000
+        val INVISIBLE = FontWeight(0)
+        val THIN = FontWeight(100)
+        val EXTRA_LIGHT = FontWeight(200)
+        val LIGHT = FontWeight(300)
+        val NORMAL = FontWeight(400)
+        val MEDIUM = FontWeight(500)
+        val SEMI_BOLD = FontWeight(600)
+        val BOLD = FontWeight(700)
+        val EXTRA_BOLD = FontWeight(800)
+        val BLACK = FontWeight(900)
+        val EXTRA_BLACK = FontWeight(1000)
     }
 }

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/FontWidth.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/FontWidth.kt
@@ -1,15 +1,20 @@
 package org.jetbrains.skia
 
-interface FontWidth {
+import kotlin.jvm.JvmInline
+
+@JvmInline
+value class FontWidth(val value: Int) {
+
+    operator fun compareTo(other: FontWeight): Int = value.compareTo(other.value)
     companion object {
-        const val ULTRA_CONDENSED = 1
-        const val EXTRA_CONDENSED = 2
-        const val CONDENSED = 3
-        const val SEMI_CONDENSED = 4
-        const val NORMAL = 5
-        const val SEMI_EXPANDED = 6
-        const val EXPANDED = 7
-        const val EXTRA_EXPANDED = 8
-        const val ULTRA_EXPANDED = 9
+        val ULTRA_CONDENSED = FontWidth(1)
+        val EXTRA_CONDENSED = FontWidth(2)
+        val CONDENSED = FontWidth(3)
+        val SEMI_CONDENSED = FontWidth(4)
+        val NORMAL = FontWidth(5)
+        val SEMI_EXPANDED = FontWidth(6)
+        val EXPANDED = FontWidth(7)
+        val EXTRA_EXPANDED = FontWidth(8)
+        val ULTRA_EXPANDED = FontWidth(9)
     }
 }

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/paragraph/StrutStyle.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/paragraph/StrutStyle.kt
@@ -63,7 +63,7 @@ class StrutStyle internal constructor(ptr: NativePointer) : Managed(ptr, _Finali
             val fontStyleData = withResult(IntArray(3)) {
                 _nGetFontStyle(_ptr, it)
             }
-            FontStyle(fontStyleData[0], fontStyleData[1], FontSlant.entries[fontStyleData[2]])
+            FontStyle(FontWeight(fontStyleData[0]), FontWidth(fontStyleData[1]), FontSlant.entries[fontStyleData[2]])
         } finally {
             reachabilityBarrier(this)
         }

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skiko/RendezvousBroadcastChannel.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skiko/RendezvousBroadcastChannel.kt
@@ -2,6 +2,7 @@ package org.jetbrains.skiko
 
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.suspendCancellableCoroutine
+import org.jetbrains.skiko.internal.fastForEach
 import kotlin.coroutines.*
 
 /**
@@ -29,7 +30,7 @@ internal class RendezvousBroadcastChannel<T> {
         }
 
         // Safe to touch `suspendedCopy` without lock because receive will now add to `suspended`.
-        for (cont in suspendedCopy) {
+        suspendedCopy.fastForEach { cont ->
             cont.resume(value)
         }
         suspendedCopy.clear()

--- a/skiko/src/commonTest/kotlin/org/jetbrains/skia/StrutStyleTests.kt
+++ b/skiko/src/commonTest/kotlin/org/jetbrains/skia/StrutStyleTests.kt
@@ -12,11 +12,11 @@ class StrutStyleTests {
     @Test
     fun strutStyleTest() {
         StrutStyle().use { strutStyle ->
-            assertEquals(FontStyle(FontWeight(400), FontWidth(5), FontSlant.UPRIGHT), strutStyle.fontStyle)
+            assertEquals(FontStyle(FontWeight.NORMAL, FontWidth.NORMAL, FontSlant.UPRIGHT), strutStyle.fontStyle)
 
-            strutStyle.fontStyle = FontStyle(FontWeight(300), FontWidth(4), FontSlant.ITALIC)
+            strutStyle.fontStyle = FontStyle(FontWeight.LIGHT, FontWidth.SEMI_CONDENSED, FontSlant.ITALIC)
 
-            assertEquals(FontStyle(FontWeight(300), FontWidth(4), FontSlant.ITALIC), strutStyle.fontStyle)
+            assertEquals(FontStyle(FontWeight.LIGHT, FontWidth.SEMI_CONDENSED, FontSlant.ITALIC), strutStyle.fontStyle)
 
 
             strutStyle.setFontFamilies(arrayOf("MonacoShmonaco"))

--- a/skiko/src/commonTest/kotlin/org/jetbrains/skia/StrutStyleTests.kt
+++ b/skiko/src/commonTest/kotlin/org/jetbrains/skia/StrutStyleTests.kt
@@ -12,11 +12,11 @@ class StrutStyleTests {
     @Test
     fun strutStyleTest() {
         StrutStyle().use { strutStyle ->
-            assertEquals(FontStyle(400, 5, FontSlant.UPRIGHT), strutStyle.fontStyle)
+            assertEquals(FontStyle(FontWeight(400), FontWidth(5), FontSlant.UPRIGHT), strutStyle.fontStyle)
 
-            strutStyle.fontStyle = FontStyle(300, 4, FontSlant.ITALIC)
+            strutStyle.fontStyle = FontStyle(FontWeight(300), FontWidth(4), FontSlant.ITALIC)
 
-            assertEquals(FontStyle(300, 4, FontSlant.ITALIC), strutStyle.fontStyle)
+            assertEquals(FontStyle(FontWeight(300), FontWidth(4), FontSlant.ITALIC), strutStyle.fontStyle)
 
 
             strutStyle.setFontFamilies(arrayOf("MonacoShmonaco"))

--- a/skiko/src/webMain/kotlin/org/jetbrains/skiko/Actuals.web.kt
+++ b/skiko/src/webMain/kotlin/org/jetbrains/skiko/Actuals.web.kt
@@ -1,12 +1,11 @@
 package org.jetbrains.skiko
 
-import kotlinx.browser.window
 import org.w3c.dom.HTMLElement
 
 internal actual inline fun <R> maybeSynchronized(lock: Any, block: () -> R): R =
     block()
 
-actual fun currentNanoTime(): Long = (window.performance.now() * 1_000_000).toLong()
+actual fun currentNanoTime(): Long = currentNanoTimeWindowPerformance().toLong()
 
 internal actual fun loadOpenGLLibrary() {
    // Nothing to do here
@@ -15,5 +14,9 @@ internal actual fun loadOpenGLLibrary() {
 internal actual fun loadAngleLibrary() {
     // Nothing to do here
 }
+
+private fun currentNanoTimeWindowPerformance() : Double =
+    //language=JavaScript
+    js("window.performance.now() * 1000000")
 
 annotation class WebImport(val name : String)

--- a/skiko/src/webMain/kotlin/org/jetbrains/skiko/CanvasRenderer.kt
+++ b/skiko/src/webMain/kotlin/org/jetbrains/skiko/CanvasRenderer.kt
@@ -35,6 +35,17 @@ internal abstract class CanvasRenderer(
         initCanvas()
     }
 
+    private val onFrame: (Double) -> Unit = { timestamp: Double ->
+        redrawScheduled = false
+        GL.makeContextCurrent(contextPointer)
+        // `clear` and `resetMatrix` make canvas not accumulate previous effects
+        canvas?.clear(Color.WHITE)
+        canvas?.resetMatrix()
+        drawFrame(timestamp)
+        surface?.flushAndSubmit()
+        context.flush()
+    }
+
     fun initCanvas() {
         disposeCanvas()
 
@@ -74,16 +85,7 @@ internal abstract class CanvasRenderer(
             return
         }
         redrawScheduled = true
-        window.requestAnimationFrame { timestamp ->
-            redrawScheduled = false
-            GL.makeContextCurrent(contextPointer)
-            // `clear` and `resetMatrix` make canvas not accumulate previous effects
-            canvas?.clear(Color.WHITE)
-            canvas?.resetMatrix()
-            drawFrame(timestamp)
-            surface?.flushAndSubmit()
-            context.flush()
-        }
+        window.requestAnimationFrame(onFrame)
     }
 }
 

--- a/skiko/src/webMain/kotlin/org/jetbrains/skiko/CanvasRenderer.kt
+++ b/skiko/src/webMain/kotlin/org/jetbrains/skiko/CanvasRenderer.kt
@@ -35,7 +35,7 @@ internal abstract class CanvasRenderer(
         initCanvas()
     }
 
-    private val onFrame: (Double) -> Unit = { timestamp: Double ->
+    private fun onFrame(timestamp: Double) {
         redrawScheduled = false
         GL.makeContextCurrent(contextPointer)
         // `clear` and `resetMatrix` make canvas not accumulate previous effects
@@ -44,6 +44,11 @@ internal abstract class CanvasRenderer(
         drawFrame(timestamp)
         surface?.flushAndSubmit()
         context.flush()
+    }
+
+    @OptIn(ExperimentalWasmJsInterop::class)
+    private val rAfCallback = rAfCallbackToJs {
+        onFrame(it)
     }
 
     fun initCanvas() {
@@ -80,14 +85,25 @@ internal abstract class CanvasRenderer(
     /**
      * Schedules a call to [drawFrame] to the appropriate moment.
      */
+    @OptIn(ExperimentalWasmJsInterop::class)
     fun needRedraw() {
         if (redrawScheduled) {
             return
         }
         redrawScheduled = true
-        window.requestAnimationFrame(onFrame)
+        windowRequestAnimationFrame(rAfCallback)
     }
 }
+
+@OptIn(ExperimentalWasmJsInterop::class)
+private fun windowRequestAnimationFrame(callback: JsAny) : Int =
+    //language=JavaScript
+    js("window.requestAnimationFrame(callback)")
+
+@OptIn(ExperimentalWasmJsInterop::class)
+private fun rAfCallbackToJs(callback: (Double) -> Unit): JsAny =
+    //language=JavaScript
+    js("(timestamp) => callback(timestamp)")
 
 internal external interface GLInterface {
     fun createContext(context: HTMLCanvasElement, contextAttributes: ContextAttributes): NativePointer

--- a/skiko/src/webMain/kotlin/org/jetbrains/skiko/CanvasRenderer.kt
+++ b/skiko/src/webMain/kotlin/org/jetbrains/skiko/CanvasRenderer.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.skiko
 
-import kotlinx.browser.window
 import org.jetbrains.skia.*
 import org.jetbrains.skia.impl.NativePointer
 import org.jetbrains.skiko.wasm.ContextAttributes
@@ -35,7 +34,7 @@ internal abstract class CanvasRenderer(
         initCanvas()
     }
 
-    private fun onFrame(timestamp: Double) {
+    private val requestAnimationFrameCallback: (timestamp: Double) -> Unit = { timestamp ->
         redrawScheduled = false
         GL.makeContextCurrent(contextPointer)
         // `clear` and `resetMatrix` make canvas not accumulate previous effects
@@ -44,11 +43,6 @@ internal abstract class CanvasRenderer(
         drawFrame(timestamp)
         surface?.flushAndSubmit()
         context.flush()
-    }
-
-    @OptIn(ExperimentalWasmJsInterop::class)
-    private val rAfCallback = rAfCallbackToJs {
-        onFrame(it)
     }
 
     fun initCanvas() {
@@ -91,19 +85,15 @@ internal abstract class CanvasRenderer(
             return
         }
         redrawScheduled = true
-        windowRequestAnimationFrame(rAfCallback)
+        windowRequestAnimationFrame(requestAnimationFrameCallback)
     }
 }
 
 @OptIn(ExperimentalWasmJsInterop::class)
-private fun windowRequestAnimationFrame(callback: JsAny) : Int =
+private fun windowRequestAnimationFrame(callback: (Double) -> Unit) : Int =
     //language=JavaScript
     js("window.requestAnimationFrame(callback)")
 
-@OptIn(ExperimentalWasmJsInterop::class)
-private fun rAfCallbackToJs(callback: (Double) -> Unit): JsAny =
-    //language=JavaScript
-    js("(timestamp) => callback(timestamp)")
 
 internal external interface GLInterface {
     fun createContext(context: HTMLCanvasElement, contextAttributes: ContextAttributes): NativePointer


### PR DESCRIPTION
Fixes [SKIKO-1143](https://youtrack.jetbrains.com/issue/SKIKO-1143/Convert-class-FontStyle-interface-FontWeight-interface-FontWidth-and-interface-PathSegmentMask-to-value-classes)

Non-enum classes (interfaces or bare classes) can be optimized if they're just a wrapper of a primitive by using value classes.
Convert also FontMetrics, which in the boundary layer already uses FloatArray under the hood so transforming it into value class wrapping that same FloatArray, saves a few allocations (class allocation, since array is reused)

For more info about the approach of this PR, see issue (I explain what the changes are and the why of it)