### PR TITLE
Fix BreakIterator.setText Android crash

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,9 @@ name: Skiko Tests
 on:
   workflow_call: # Allow being called by other workflows
 
+# TODO: Set up Android tests
+# Some tests can fail on Android while passing in other JVM targets.
+# Example: https://github.com/JetBrains/skiko/pull/1211
 jobs:
   macos:
     name: 'macOS'

--- a/skiko/src/jvmMain/cpp/common/BreakIterator.cc
+++ b/skiko/src/jvmMain/cpp/common/BreakIterator.cc
@@ -105,11 +105,11 @@ extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_BreakIteratorKt__1nGet
 }
 
 extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_BreakIteratorKt__1nSetText
-  (JNIEnv* env, jclass jclass, jlong ptr, jcharArray textArr, jint len, jintArray errorCode) {
+  (JNIEnv* env, jclass jclass, jlong ptr, jshortArray textArr, jint len, jintArray errorCode) {
     UBreakIterator* instance = reinterpret_cast<UBreakIterator*>(static_cast<uintptr_t>(ptr));
 
-    std::vector<jchar>* text = new std::vector<jchar>(len);
-    env->GetCharArrayRegion(textArr, 0, len, text->data());
+    std::vector<jshort>* text = new std::vector<jshort>(len);
+    env->GetShortArrayRegion(textArr, 0, len, text->data());
 
     UErrorCode errorCodes[1] = { U_ZERO_ERROR };
     ubrk_setText(instance, reinterpret_cast<UChar *>(text->data()), len, errorCodes);


### PR DESCRIPTION
Fixes:
```
03:57:36.872  A  java_vm_ext.cc:598] JNI DETECTED ERROR IN APPLICATION: incompatible array type short[] expected char[]: 0x7fd297fa00
                 java_vm_ext.cc:598]     in call to GetCharArrayRegion
                 java_vm_ext.cc:598]     from long org.jetbrains.skia.BreakIteratorKt._nSetText(long, java.lang.Object, int, java.lang.Object)
```