### PR TITLE
Fix memory leak in drawVertices JNI call

### DIFF
--- a/skiko/src/jvmMain/cpp/common/Canvas.cc
+++ b/skiko/src/jvmMain/cpp/common/Canvas.cc
@@ -177,6 +177,9 @@ extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_CanvasKt__1nDrawVertic
         env->ReleaseFloatArrayElements(texCoordsArr, texCoords, 0);
     if (colors != nullptr)
         env->ReleaseIntArrayElements(colorsArr, colors, 0);
+    if (indices != nullptr) {
+        env->ReleaseShortArrayElements(indexArr, const_cast<jshort*>(indices), 0);
+    }
     env->ReleaseFloatArrayElements(positionsArr, positions, 0);
 }
 


### PR DESCRIPTION
**What and why**
This PR fixes a memory leak in the `Canvas.drawVertices` JNI implementation. The `indexArr` elements were accessed via `GetShortArrayElements` but were never released, which could lead to pinned arrays or memory exhaustion over time.

**Testing**
Successfully built the native C++ libraries locally on Windows x64. Ran tests — all passed except `TextLineTest.emojiTest`, which seems to be a local Windows environment issue unrelated to Canvas bindings.

**Release Notes**
* Fixed a JNI memory leak in `Canvas.drawVertices`.

**Issue:**
https://youtrack.jetbrains.com/issue/SKIKO-1149/Memory-leak-pinned-array-in-Canvas.drawVertices-JNI-due-to-missing-ReleaseShortArrayElements