### PR TITLE
Wasm texture adoption

### DIFF
--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Canvas.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Canvas.kt
@@ -55,6 +55,23 @@ open class Canvas internal constructor(ptr: NativePointer, managed: Boolean, int
         reachabilityBarrier(bitmap)
     }
 
+    /**
+     * Returns the recording context being used by this Canvas.
+     *
+     * The returned context is borrowed from the Canvas and must not be closed.
+     *
+     * @return the recording context, if available; null otherwise
+     */
+    val recordingContext: DirectContext?
+        get() = try {
+            Stats.onNativeCall()
+            val ptr = _nGetCanvasRecordingContext(_ptr)
+            if (ptr == NullPointer) null else DirectContext(ptr, managed = false)
+        } finally {
+            reachabilityBarrier(this)
+            reachabilityBarrier(_owner)
+        }
+
     fun drawPoint(x: Float, y: Float, paint: Paint): Canvas {
         Stats.onNativeCall()
         try {
@@ -1594,6 +1611,9 @@ private external fun Canvas_nGetFinalizer(): NativePointer
 
 @ExternalSymbolName("org_jetbrains_skia_Canvas__1nMakeFromBitmap")
 private external fun _nMakeFromBitmap(bitmapPtr: NativePointer, flags: Int, pixelGeometry: Int): NativePointer
+
+@ExternalSymbolName("org_jetbrains_skia_Canvas__1nGetRecordingContext")
+private external fun _nGetCanvasRecordingContext(ptr: NativePointer): NativePointer
 
 @ExternalSymbolName("org_jetbrains_skia_Canvas__1nDrawPoint")
 private external fun _nDrawPoint(ptr: NativePointer, x: Float, y: Float, paintPtr: NativePointer)

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/DirectContext.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/DirectContext.kt
@@ -5,7 +5,7 @@ import org.jetbrains.skia.impl.Library.Companion.staticLoad
 import org.jetbrains.skiko.RenderException
 import org.jetbrains.skiko.loadOpenGLLibrary
 
-class DirectContext internal constructor(ptr: NativePointer) : RefCnt(ptr) {
+class DirectContext internal constructor(ptr: NativePointer, managed: Boolean = true) : RefCnt(ptr, managed) {
     companion object {
         fun makeGL(): DirectContext {
             Stats.onNativeCall()

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Image.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Image.kt
@@ -176,6 +176,47 @@ class Image internal constructor(ptr: NativePointer) : RefCnt(ptr), IHasImageInf
             }
         }
 
+        /**
+         * Creates GPU-backed SkImage from backendTexture associated with context.
+         *
+         * Skia will assume ownership of the resource and will release it when no longer needed.
+         * A non-null Image is returned if format of backendTexture is recognized and supported.
+         * Recognized formats vary by GPU backend.
+         *
+         * @param context         GPU context
+         * @param backendTexture  texture residing on GPU
+         * @param origin          origin of backendTexture
+         * @param colorType       color type of the resulting Image
+         * @param alphaType       alpha type of the resulting Image
+         * @return                created Image
+         *
+         * @throws RuntimeException - if nullPtr is returned.
+         */
+        fun adoptTextureFrom(
+            context: DirectContext,
+            backendTexture: BackendTexture,
+            origin: SurfaceOrigin,
+            colorType: ColorType,
+            alphaType: ColorAlphaType,
+        ): Image {
+            return try {
+                Stats.onNativeCall()
+                val ptr = _nAdoptTextureFromAlphaType(
+                    getPtr(context),
+                    getPtr(backendTexture),
+                    origin.ordinal,
+                    colorType.ordinal,
+                    alphaType.ordinal,
+                )
+                if (ptr == NullPointer) throw RuntimeException("Failed to Image::makeFromTexture")
+                Image(ptr)
+            }
+            finally {
+                reachabilityBarrier(context)
+                reachabilityBarrier(backendTexture)
+            }
+        }
+
         init {
             staticLoad()
         }
@@ -484,9 +525,18 @@ private external fun _nReadPixelsBitmap(
 private external fun _nReadPixelsPixmap(ptr: NativePointer, pixmapPtr: NativePointer, srcX: Int, srcY: Int, cache: Boolean): Boolean
 
 @ExternalSymbolName("org_jetbrains_skia_Image__1nAdoptTextureFrom")
-external fun _nAdoptTextureFrom(
+private external fun _nAdoptTextureFrom(
     contextPtr: NativePointer,
     backendTexture: NativePointer,
     surfaceOrigin: Int,
     colorType: Int
+): NativePointer
+
+@ExternalSymbolName("org_jetbrains_skia_Image__1nAdoptTextureFromAlphaType")
+private external fun _nAdoptTextureFromAlphaType(
+    contextPtr: NativePointer,
+    backendTexture: NativePointer,
+    surfaceOrigin: Int,
+    colorType: Int,
+    alphaType: Int
 ): NativePointer

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Surface.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Surface.kt
@@ -629,13 +629,15 @@ class Surface : RefCnt {
      *
      * Returns the recording context being used by the Surface.
      *
+     * The returned context is borrowed from the Surface and must not be closed.
+     *
      * @return the recording context, if available; null otherwise
      */
     val recordingContext: DirectContext?
         get() = try {
             Stats.onNativeCall()
-            val ptr = _nGetRecordingContext(_ptr)
-            if (ptr == NullPointer) null else DirectContext(ptr)
+            val ptr = _nGetSurfaceRecordingContext(_ptr)
+            if (ptr == NullPointer) null else DirectContext(ptr, managed = false)
         } finally {
             reachabilityBarrier(this)
         }
@@ -1114,8 +1116,8 @@ private external fun _nGenerationId(ptr: NativePointer): Int
 @ExternalSymbolName("org_jetbrains_skia_Surface__1nNotifyContentWillChange")
 private external fun _nNotifyContentWillChange(ptr: NativePointer, mode: Int)
 
-@ExternalSymbolName("org_jetbrains_skia_Surface__1nGetRecordingContext")
-private external fun _nGetRecordingContext(ptr: NativePointer): NativePointer
+@ExternalSymbolName("org_jetbrains_skia_Surface__1nGetSurfaceRecordingContext")
+private external fun _nGetSurfaceRecordingContext(ptr: NativePointer): NativePointer
 
 @ExternalSymbolName("org_jetbrains_skia_Surface__1nGetCanvas")
 private external fun _nGetCanvas(ptr: NativePointer): NativePointer

--- a/skiko/src/commonTest/kotlin/org/jetbrains/skia/CanvasTest.kt
+++ b/skiko/src/commonTest/kotlin/org/jetbrains/skia/CanvasTest.kt
@@ -3,15 +3,53 @@
 package org.jetbrains.skia
 
 import org.jetbrains.skia.tests.makeFromResource
+import org.jetbrains.skia.impl.use
 import org.jetbrains.skia.util.assertContentSame
 import org.jetbrains.skia.util.imageFromIntArray
+import org.jetbrains.skiko.Arch
+import org.jetbrains.skiko.KotlinBackend
+import org.jetbrains.skiko.OS
+import org.jetbrains.skiko.hostArch
+import org.jetbrains.skiko.hostOs
+import org.jetbrains.skiko.kotlinBackend
+import org.jetbrains.skiko.tests.TestGlContext
 import org.jetbrains.skiko.tests.runTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
+import kotlin.test.assertFails
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 
 class CanvasTest {
+
+    @Test
+    fun recordingContextReturnsNullForRasterCanvas() {
+        Surface.makeRasterN32Premul(8, 8).use { surface ->
+            assertNull(surface.canvas.recordingContext)
+        }
+    }
+
+    @Test
+    fun recordingContextIsBorrowedForRenderTargetCanvas() {
+        if (!TestGlContext.isAvailable()) return
+
+        if (hostOs == OS.Linux && kotlinBackend == KotlinBackend.Native && hostArch == Arch.Arm64) {
+            // TODO: fix test on Linux arm64 using EGL
+            return
+        }
+
+        TestGlContext.run {
+            DirectContext.makeGL().useContext { ctx ->
+                val imageInfo = ImageInfo.makeN32Premul(16, 16)
+                val surface = Surface.makeRenderTarget(ctx, budgeted = false, imageInfo)
+                val canvasContext = surface.canvas.recordingContext
+                assertNotNull(canvasContext)
+                assertFails { canvasContext.close() }
+            }
+        }
+    }
 
     @Test
     fun drawVertices() {

--- a/skiko/src/commonTest/kotlin/org/jetbrains/skia/SurfaceTest.kt
+++ b/skiko/src/commonTest/kotlin/org/jetbrains/skia/SurfaceTest.kt
@@ -121,6 +121,9 @@ class SurfaceTest {
             DirectContext.makeGL().useContext { ctx ->
                 val imageInfo = ImageInfo.makeN32Premul(16, 16)
                 val surface = Surface.makeRenderTarget(ctx, budgeted = false, imageInfo)
+                val surfaceContext = surface.recordingContext
+                assertNotNull(surfaceContext)
+                assertFails { surfaceContext.close() }
 
                 surface.canvas.drawRect(
                     r = Rect(4f, 4f, 12f, 12f),

--- a/skiko/src/jvmMain/cpp/common/Canvas.cc
+++ b/skiko/src/jvmMain/cpp/common/Canvas.cc
@@ -23,6 +23,12 @@ extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_CanvasKt__1nMakeFromB
     return reinterpret_cast<jlong>(canvas);
 }
 
+extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_CanvasKt__1nGetCanvasRecordingContext
+  (JNIEnv* env, jclass jclass, jlong canvasPtr) {
+    SkCanvas* canvas = reinterpret_cast<SkCanvas*>(static_cast<uintptr_t>(canvasPtr));
+    return reinterpret_cast<jlong>(canvas->recordingContext());
+}
+
 extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_CanvasKt__1nDrawPoint
   (JNIEnv* env, jclass jclass, jlong canvasPtr, jfloat x, jfloat y, jlong paintPtr) {
     SkCanvas* canvas = reinterpret_cast<SkCanvas*>(static_cast<uintptr_t>(canvasPtr));

--- a/skiko/src/jvmMain/cpp/common/Image.cc
+++ b/skiko/src/jvmMain/cpp/common/Image.cc
@@ -177,3 +177,18 @@ extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_ImageKt__1nAdoptTextu
     );
     return reinterpret_cast<jlong>(image.release());
 }
+
+extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_ImageKt__1nAdoptTextureFromAlphaType
+  (JNIEnv* env, jclass jclass, jlong contextPtr, jlong backendTexturePtr, jint surfaceOrigin, jint colorType, jint alphaType) {
+    GrBackendTexture* backendTexture = reinterpret_cast<GrBackendTexture*>(static_cast<uintptr_t>(backendTexturePtr));
+    GrDirectContext* context = reinterpret_cast<GrDirectContext*>(static_cast<uintptr_t>(contextPtr));
+
+    sk_sp<SkImage> image = SkImages::AdoptTextureFrom(
+        static_cast<GrRecordingContext*>(context),
+        *backendTexture,
+        static_cast<GrSurfaceOrigin>(surfaceOrigin),
+        static_cast<SkColorType>(colorType),
+        static_cast<SkAlphaType>(alphaType)
+    );
+    return reinterpret_cast<jlong>(image.release());
+}

--- a/skiko/src/jvmMain/cpp/common/Surface.cc
+++ b/skiko/src/jvmMain/cpp/common/Surface.cc
@@ -269,7 +269,7 @@ extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_SurfaceKt__1nNotifyCon
     surface->notifyContentWillChange(static_cast<SkSurface::ContentChangeMode>(mode));
 }
 
-extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_SurfaceKt__1nGetRecordingContext
+extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_SurfaceKt__1nGetSurfaceRecordingContext
   (JNIEnv* env, jclass jclass, jlong ptr) {
     SkSurface* surface = reinterpret_cast<SkSurface*>(static_cast<uintptr_t>(ptr));
     return reinterpret_cast<jlong>(surface->recordingContext());

--- a/skiko/src/nativeJsMain/cpp/Canvas.cc
+++ b/skiko/src/nativeJsMain/cpp/Canvas.cc
@@ -22,6 +22,12 @@ SKIKO_EXPORT KNativePointer org_jetbrains_skia_Canvas__1nMakeFromBitmap
     return reinterpret_cast<KNativePointer>(canvas);
 }
 
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_Canvas__1nGetRecordingContext
+  (KNativePointer canvasPtr) {
+    SkCanvas* canvas = reinterpret_cast<SkCanvas*>((canvasPtr));
+    return reinterpret_cast<KNativePointer>(canvas->recordingContext());
+}
+
 SKIKO_EXPORT void org_jetbrains_skia_Canvas__1nDrawPoint
   (KNativePointer canvasPtr, KFloat x, KFloat y, KNativePointer paintPtr) {
     SkCanvas* canvas = reinterpret_cast<SkCanvas*>((canvasPtr));

--- a/skiko/src/nativeJsMain/cpp/Image.cc
+++ b/skiko/src/nativeJsMain/cpp/Image.cc
@@ -171,3 +171,19 @@ SKIKO_EXPORT KNativePointer org_jetbrains_skia_Image__1nAdoptTextureFrom
 
     return reinterpret_cast<KNativePointer>(image.release());
 }
+
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_Image__1nAdoptTextureFromAlphaType
+  (KNativePointer contextPtr, KNativePointer backendTexturePtr, KInt surfaceOrigin, KInt colorType, KInt alphaType) {
+    GrDirectContext* context = reinterpret_cast<GrDirectContext*>(contextPtr);
+    GrBackendTexture* backendTexture = reinterpret_cast<GrBackendTexture*>(backendTexturePtr);
+
+    sk_sp<SkImage> image = SkImages::AdoptTextureFrom(
+        static_cast<GrRecordingContext*>(context),
+        *backendTexture,
+        static_cast<GrSurfaceOrigin>(surfaceOrigin),
+        static_cast<SkColorType>(colorType),
+        static_cast<SkAlphaType>(alphaType)
+    );
+
+    return reinterpret_cast<KNativePointer>(image.release());
+}

--- a/skiko/src/nativeJsMain/cpp/Surface.cc
+++ b/skiko/src/nativeJsMain/cpp/Surface.cc
@@ -272,7 +272,7 @@ SKIKO_EXPORT void org_jetbrains_skia_Surface__1nNotifyContentWillChange
     surface->notifyContentWillChange(static_cast<SkSurface::ContentChangeMode>(mode));
 }
 
-SKIKO_EXPORT KNativePointer org_jetbrains_skia_Surface__1nGetRecordingContext
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_Surface__1nGetSurfaceRecordingContext
   (KNativePointer ptr) {
     SkSurface* surface = reinterpret_cast<SkSurface*>((ptr));
     return reinterpret_cast<KNativePointer>(surface->recordingContext());

--- a/skiko/src/wasmJsMain/kotlin/org/jetbrains/skiko/GLTexture.wasm.kt
+++ b/skiko/src/wasmJsMain/kotlin/org/jetbrains/skiko/GLTexture.wasm.kt
@@ -1,0 +1,46 @@
+@file:OptIn(kotlin.js.ExperimentalWasmJsInterop::class)
+
+package org.jetbrains.skiko
+
+import kotlin.js.JsAny
+
+@JsFun(
+    """(gl, texture) => {
+        const textureHandle = gl.getNewId(gl.textures);
+        gl.textures[textureHandle] = texture;
+        return textureHandle;
+    }"""
+)
+private external fun pushTexture(gl: GLInterface, texture: JsAny): Int
+
+@JsFun(
+    """(gl, textureId) => {
+        gl.textures[textureId] = null;
+    }"""
+)
+private external fun unregisterTexture(gl: GLInterface, textureId: Int)
+
+/**
+ * Registers an externally-created WebGLTexture in Emscripten's GL texture table.
+ *
+ * The returned id can be passed to Skia GL APIs that expect a numeric texture id, such as
+ * [org.jetbrains.skia.BackendTexture.makeGL]. The texture must belong to the same WebGL context
+ * that Skiko is using.
+ *
+ * This function only creates the Emscripten table entry. If the returned id is passed to a Skia
+ * API that takes ownership of the texture, Skia will delete the GL texture through Emscripten and
+ * the table entry will be cleared there. If ownership is not transferred to Skia, call
+ * [unregisterTexture] when the id is no longer needed to avoid leaking the table entry.
+ */
+@ExperimentalSkikoApi
+fun pushTexture(texture: JsAny): Int = pushTexture(GL, texture)
+
+/**
+ * Removes a texture table entry previously created with [pushTexture].
+ *
+ * This does not delete the underlying WebGLTexture; it only releases Skiko/Emscripten's numeric
+ * id mapping. Use it only when the id was not handed to a Skia API that takes ownership of the
+ * texture.
+ */
+@ExperimentalSkikoApi
+fun unregisterTexture(textureId: Int): Unit = unregisterTexture(GL, textureId)


### PR DESCRIPTION
This chain of commits enables adoption of external WebGL textures.

"Add Wasm texture registration helper" is required because skia expects a texture id, but on WebGL the textures don't have ids. The ids are provided to skia by emscripten. [Here](https://github.com/google/skia/blob/7c071bfb59ddcf6031d8e9d88db740c5bcd9440a/modules/canvaskit/webgl.js#L206-L224) is the same hack in skia sources.

"Expose borrowed recording contexts" is required to get `DirectContext` to pass into `adoptTextureFrom`. I also fixed ownership: the context returned by canvas/surface should be borrowed, since otherwise we will accidentally dispose of a context that is still being used for rendering.