### PR TITLE
Native Linux SkiaLayer: Wayland/EGL and X11/GLX backends behind a windowing seam

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,10 +23,13 @@ jobs:
       - uses: ./.github/actions/setup-prerequisites
         name: 'Setup Prerequisites'
 
+      # linux-amd64 rather than linux-compat: with skiko.native.enabled the Linux
+      # targets run cinterop tasks, which need a glibc newer than compat's 2.26
+      # (Konan's libclang requires GLIBC_2.29) plus the X11/Wayland dev headers.
       - uses: ./.github/actions/docker-skiko-run
         name: 'Build Dokka Documentation'
         with:
-          image_name: linux-compat
+          image_name: linux-amd64
           command: |
             ./gradlew --no-daemon --stacktrace \
               -Pskiko.native.enabled=true \

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -61,13 +61,16 @@ jobs:
       - uses: ./.github/actions/setup-prerequisites
         name: 'Setup Prerequisites'
 
+      # No -Pskiko.native.enabled here: the Linux native targets carry cinterops,
+      # and cinterop tasks cannot run in linux-compat (its glibc 2.26 predates the
+      # GLIBC_2.29 required by Konan's bundled libclang). The native publications
+      # are produced by the next step in the linux-amd64 image instead.
       - uses: ./.github/actions/docker-skiko-run
         name: 'Publish x64 Maven Local'
         with:
           image_name: linux-compat
           command: |
             ./gradlew --no-daemon --stacktrace \
-              -Pskiko.native.enabled=true \
               -Pskiko.awt.enabled=true \
               -Pskiko.arch=x64 \
                :skiko:publishToMavenLocal

--- a/skiko/build.gradle.kts
+++ b/skiko/build.gradle.kts
@@ -304,7 +304,11 @@ kotlin {
         skikoProjectContext.configureNativeTarget(OS.MacOS, Arch.X64, macosX64())
         skikoProjectContext.configureNativeTarget(OS.MacOS, Arch.Arm64, macosArm64())
     }
-    if (supportNativeLinux) {
+    // Unlike the Apple targets (whose platform libs ship with Konan on every host), the
+    // Linux targets carry custom cinterops (x11gl, waylandegl) that can only be processed
+    // where the system headers exist, so they are host-gated: metadata for linuxMain
+    // cannot compile on macOS/Windows hosts.
+    if (supportNativeLinux && hostOs.isLinux) {
         skikoProjectContext.configureNativeTarget(OS.Linux, Arch.X64, linuxX64())
         skikoProjectContext.configureNativeTarget(OS.Linux, Arch.Arm64, linuxArm64())
     }

--- a/skiko/buildSrc/src/main/kotlin/CompileSkikoCppTask.kt
+++ b/skiko/buildSrc/src/main/kotlin/CompileSkikoCppTask.kt
@@ -19,7 +19,7 @@ import kotlin.collections.HashSet
 
 abstract class CompileSkikoCppTask() : AbstractSkikoNativeToolTask() {
     @get:Internal
-    open val srcExtensions: Array<String> = arrayOf("cc", "cpp")
+    open val srcExtensions: Array<String> = arrayOf("cc", "cpp", "c")
 
     @get:Internal
     open val headerExtensions: Array<String> = arrayOf("h", "hh")
@@ -144,6 +144,9 @@ abstract class CompileSkikoCppTask() : AbstractSkikoNativeToolTask() {
             submittedWorks.add(workId)
 
             val workArgs = args.copy {
+                if (sourceFile.extension == "c") {
+                    arg("-x", "c")
+                }
                 // Replace slash for Windows paths
                 arg("-o", outputFile.absolutePath.replace("\\", "/"))
                 arg(value = sourceFile.absolutePath.replace("\\", "/"))

--- a/skiko/buildSrc/src/main/kotlin/GenerateWaylandProtocolsTask.kt
+++ b/skiko/buildSrc/src/main/kotlin/GenerateWaylandProtocolsTask.kt
@@ -1,0 +1,55 @@
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
+import javax.inject.Inject
+
+/**
+ * Generates Wayland protocol bindings from the protocol XML files shipped by `wayland-protocols`.
+ *
+ * For each input XML this runs `wayland-scanner` twice, producing
+ * `<protocol>-client-protocol.h` (client header, consumed by the `waylandegl` cinterop) and
+ * `<protocol>-protocol.cc` (interface marshalling code, compiled into the native bridges).
+ *
+ * The marshalling code is emitted with a `.cc` extension on purpose: [CompileSkikoCppTask] only
+ * picks up `cc`/`cpp` sources, and wayland-scanner output is valid C++ — the interface globals
+ * keep external linkage because the generated file declares them `extern` before defining them.
+ */
+abstract class GenerateWaylandProtocolsTask @Inject constructor(
+    private val execOperations: ExecOperations,
+) : DefaultTask() {
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val protocolXmlFiles: ConfigurableFileCollection
+
+    @get:OutputDirectory
+    abstract val outDir: DirectoryProperty
+
+    @TaskAction
+    fun run() {
+        val outDirFile = outDir.get().asFile
+        outDirFile.mkdirs()
+        for (xml in protocolXmlFiles.files) {
+            val name = xml.nameWithoutExtension
+            execOperations.exec {
+                commandLine(
+                    "wayland-scanner", "client-header",
+                    xml.absolutePath,
+                    outDirFile.resolve("$name-client-protocol.h").absolutePath,
+                )
+            }
+            execOperations.exec {
+                commandLine(
+                    "wayland-scanner", "private-code",
+                    xml.absolutePath,
+                    outDirFile.resolve("$name-protocol.cc").absolutePath,
+                )
+            }
+        }
+    }
+}

--- a/skiko/buildSrc/src/main/kotlin/GenerateWaylandProtocolsTask.kt
+++ b/skiko/buildSrc/src/main/kotlin/GenerateWaylandProtocolsTask.kt
@@ -1,3 +1,4 @@
+import javax.inject.Inject
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
@@ -7,18 +8,17 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecOperations
-import javax.inject.Inject
 
 /**
  * Generates Wayland protocol bindings from the protocol XML files shipped by `wayland-protocols`.
  *
  * For each input XML this runs `wayland-scanner` twice, producing
  * `<protocol>-client-protocol.h` (client header, consumed by the `waylandegl` cinterop) and
- * `<protocol>-protocol.cc` (interface marshalling code, compiled into the native bridges).
+ * `<protocol>-protocol.c` (interface marshalling code, compiled into the native bridges).
  *
- * The marshalling code is emitted with a `.cc` extension on purpose: [CompileSkikoCppTask] only
- * picks up `cc`/`cpp` sources, and wayland-scanner output is valid C++ — the interface globals
- * keep external linkage because the generated file declares them `extern` before defining them.
+ * The marshalling code is emitted with a `.c` extension on purpose: compiling it as a C file
+ * ensures the interface globals maintain external linkage (with hidden visibility) so they aren't
+ * optimized out by the C++ compiler's internal-linkage-for-const-globals rule.
  */
 abstract class GenerateWaylandProtocolsTask @Inject constructor(
     private val execOperations: ExecOperations,
@@ -38,16 +38,18 @@ abstract class GenerateWaylandProtocolsTask @Inject constructor(
             val name = xml.nameWithoutExtension
             execOperations.exec {
                 commandLine(
-                    "wayland-scanner", "client-header",
+                    "wayland-scanner",
+                    "client-header",
                     xml.absolutePath,
                     outDirFile.resolve("$name-client-protocol.h").absolutePath,
                 )
             }
             execOperations.exec {
                 commandLine(
-                    "wayland-scanner", "private-code",
+                    "wayland-scanner",
+                    "private-code",
                     xml.absolutePath,
-                    outDirFile.resolve("$name-protocol.cc").absolutePath,
+                    outDirFile.resolve("$name-protocol.c").absolutePath,
                 )
             }
         }

--- a/skiko/buildSrc/src/main/kotlin/WriteCInteropDefFile.kt
+++ b/skiko/buildSrc/src/main/kotlin/WriteCInteropDefFile.kt
@@ -7,6 +7,12 @@ import org.gradle.api.tasks.TaskAction
 
 abstract class WriteCInteropDefFile : DefaultTask() {
     @get:Input
+    abstract val headers: ListProperty<String>
+
+    @get:Input
+    abstract val compilerOpts: ListProperty<String>
+
+    @get:Input
     abstract val linkerOpts: ListProperty<String>
 
     @get:OutputFile
@@ -18,6 +24,14 @@ abstract class WriteCInteropDefFile : DefaultTask() {
         outputFile.parentFile.mkdirs()
 
         outputFile.bufferedWriter().use { writer ->
+            val headers = headers.get()
+            if (headers.isNotEmpty()) {
+                writer.appendLine("headers=${headers.joinToString(" ")}")
+            }
+            val compilerOpts = compilerOpts.get()
+            if (compilerOpts.isNotEmpty()) {
+                writer.appendLine("compilerOpts=${compilerOpts.joinToString(" ")}")
+            }
             val linkerOpts = linkerOpts.get()
             if (linkerOpts.isNotEmpty()) {
                 writer.appendLine("linkerOpts=${linkerOpts.joinToString(" ")}")

--- a/skiko/buildSrc/src/main/kotlin/internal/utils/SourceToOutputMapping.kt
+++ b/skiko/buildSrc/src/main/kotlin/internal/utils/SourceToOutputMapping.kt
@@ -38,7 +38,7 @@ internal fun mapSourceFilesToOutputFiles(
             if (sourceRoot == null) sourceFile.name
             else sourceFile.relativeTo(sourceRoot).path
 
-        val relativeOutputPath = relativeSourcePath.removeSuffix(sourceFileExt) + outputFileExt
+        val relativeOutputPath = relativeSourcePath.substringBeforeLast(".") + "." + outputFileExt.removePrefix(".")
         sourceToOutput[sourceFile] = outDir.resolve(relativeOutputPath)
     }
     return sourceToOutput

--- a/skiko/buildSrc/src/main/kotlin/pkgConfigTool.kt
+++ b/skiko/buildSrc/src/main/kotlin/pkgConfigTool.kt
@@ -20,3 +20,15 @@ fun runPkgConfig(
         .map { it.removePrefix("-I") }
         .map(::File)
 }
+
+fun runPkgConfigVariable(packageName: String, variable: String): String {
+    val process = ProcessBuilder(
+        "pkg-config", "--variable=$variable", packageName
+    ).start().also { it.waitFor(10, TimeUnit.SECONDS) }
+
+    if (process.exitValue() != 0) {
+        throw GradleException("Error executing pkg-config: ${process.errorStream.bufferedReader().readText()}")
+    }
+
+    return process.inputStream.bufferedReader().readText().trim()
+}

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/NativeTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/NativeTasksConfiguration.kt
@@ -2,7 +2,9 @@ package tasks.configuration
 
 import Arch
 import CompileSkikoCppTask
+import GenerateWaylandProtocolsTask
 import PatchSkiaSymbolsTask
+import runPkgConfigVariable
 import OS
 import SkiaBuildType
 import SkikoProjectContext
@@ -51,7 +53,8 @@ fun Project.findXcodeSdkRoot(): String {
 }
 
 fun SkikoProjectContext.compileNativeBridgesTask(
-    os: OS, arch: Arch, isUikitSim: Boolean
+    os: OS, arch: Arch, isUikitSim: Boolean,
+    waylandProtocols: TaskProvider<GenerateWaylandProtocolsTask>? = null,
 ): TaskProvider<CompileSkikoCppTask> = with (this.project) {
     val skiaNativeDir = registerOrGetSkiaDirProvider(os, arch, isUikitSim = isUikitSim)
 
@@ -166,6 +169,12 @@ fun SkikoProjectContext.compileNativeBridgesTask(
         val srcDirs = projectDirs("src/commonMain/cpp/common", "src/nativeNativeJs/cpp", "src/nativeJsMain/cpp") +
                 if (skiko.includeTestHelpers) projectDirs("src/nativeJsTest/cpp") else emptyList()
         sourceRoots.set(srcDirs)
+        if (waylandProtocols != null) {
+            dependsOn(waylandProtocols)
+            sourceRoots.add(waylandProtocols.flatMap { it.outDir })
+            // wayland-util.h comes from the host even when a cross-compilation sysroot is active
+            flags.add("-idirafter /usr/include")
+        }
 
         includeHeadersNonRecursive(projectDir.resolve("src/nativeJsMain/cpp"))
         includeHeadersNonRecursive(projectDir.resolve("src/commonMain/cpp/common/include"))
@@ -195,6 +204,77 @@ fun configureCinterop(
     }
     target.compilations.getByName("main") {
         cinterops.create(cinteropName).apply {
+            definitionFile.set(writeCInteropDef.flatMap { it.outputFile })
+        }
+    }
+}
+
+/**
+ * The Wayland protocols the Linux native backend binds beyond the core `wayland.xml`
+ * (which ships pre-generated in libwayland-client itself): `xdg-shell` for toplevel
+ * windowing, `viewporter` and `fractional-scale-v1` for HiDPI scale.
+ */
+private val waylandProtocolXmlPaths = listOf(
+    "stable/xdg-shell/xdg-shell.xml",
+    "stable/viewporter/viewporter.xml",
+    "staging/fractional-scale/fractional-scale-v1.xml",
+)
+
+fun SkikoProjectContext.registerGenerateWaylandProtocolsTask(
+    os: OS, arch: Arch, targetString: String
+): TaskProvider<GenerateWaylandProtocolsTask> = with(this.project) {
+    registerSkikoTask<GenerateWaylandProtocolsTask>("generateWaylandProtocols", os, arch) {
+        val protocolsRoot = runPkgConfigVariable("wayland-protocols", "pkgdatadir")
+        protocolXmlFiles.from(waylandProtocolXmlPaths.map { "$protocolsRoot/$it" })
+        outDir.set(layout.buildDirectory.dir("generated/wayland/$targetString"))
+    }
+}
+
+/**
+ * Registers the `waylandegl` cinterop: libwayland-client + wayland-egl + EGL plus the
+ * client headers codegen'd by [GenerateWaylandProtocolsTask]. The def file is generated
+ * per target because the generated-header include path points into the build directory.
+ */
+fun configureWaylandEglCinterop(
+    arch: Arch,
+    target: KotlinNativeTarget,
+    targetString: String,
+    generateProtocols: TaskProvider<GenerateWaylandProtocolsTask>,
+) {
+    val project = target.project
+    val gnuArch = if (arch == Arch.Arm64) "aarch64" else "x86_64"
+    val writeCInteropDef = project.tasks.register(
+        "writeWaylandEglCInteropDef${joinToTitleCamelCase(OS.Linux.id, arch.id)}",
+        WriteCInteropDefFile::class.java
+    ) {
+        headers.set(
+            listOf("wayland-client.h", "wayland-egl.h", "EGL/egl.h", "EGL/eglext.h") +
+                    waylandProtocolXmlPaths.map {
+                        "${File(it).nameWithoutExtension}-client-protocol.h"
+                    }
+        )
+        compilerOpts.set(generateProtocols.flatMap { it.outDir }.map {
+            listOf(
+                "-D_GNU_SOURCE",
+                "-I${it.asFile.absolutePath}",
+                // Host headers after the Konan sysroot, same reasoning as x11gl.def
+                "-idirafter", "/usr/include",
+                "-idirafter", "/usr/include/$gnuArch-linux-gnu",
+            )
+        })
+        linkerOpts.set(
+            listOf("-L/usr/lib/$gnuArch-linux-gnu", "-lwayland-client", "-lwayland-egl", "-lEGL")
+        )
+        outputFile.set(project.layout.buildDirectory.file("cinterop/$targetString/waylandegl.def"))
+    }
+    project.tasks.withType(CInteropProcess::class.java).configureEach {
+        if (konanTarget == target.konanTarget) {
+            dependsOn(writeCInteropDef)
+            dependsOn(generateProtocols)
+        }
+    }
+    target.compilations.getByName("main") {
+        cinterops.create("waylandegl").apply {
             definitionFile.set(writeCInteropDef.flatMap { it.outputFile })
         }
     }
@@ -255,6 +335,11 @@ fun SkikoProjectContext.configureNativeTarget(os: OS, arch: Arch, target: Kotlin
         outputFile.set(hiddenSymbolsFile)
     }
 
+    // Feeds both the waylandegl cinterop (client headers) and the native bridges
+    // compile (protocol marshalling code).
+    val waylandProtocolsTask =
+        if (os == OS.Linux) registerGenerateWaylandProtocolsTask(os, arch, targetString) else null
+
     val linkerFlags = when (os) {
         OS.MacOS -> {
             configureCinterop(cinteropName, os, arch, target, targetString, resolvedBinaryInputs.frameworks)
@@ -287,6 +372,7 @@ fun SkikoProjectContext.configureNativeTarget(os: OS, arch: Arch, target: Kotlin
                     definitionFile.set(project.file("src/nativeInterop/cinterop/x11gl.def"))
                 }
             }
+            configureWaylandEglCinterop(arch, target, targetString, waylandProtocolsTask!!)
             val options = mutableListOf(
                 "-L/usr/lib64",
                 "-L/usr/lib/${if (arch == Arch.Arm64) "aarch64" else "x86_64"}-linux-gnu",
@@ -310,6 +396,9 @@ fun SkikoProjectContext.configureNativeTarget(os: OS, arch: Arch, target: Kotlin
             OS.Linux -> listOf(
                 "-linker-option", "-lX11",
                 "-linker-option", "-lGLX",
+                "-linker-option", "-lwayland-client",
+                "-linker-option", "-lwayland-egl",
+                "-linker-option", "-lEGL",
             )
             else -> emptyList()
         })
@@ -329,7 +418,8 @@ fun SkikoProjectContext.configureNativeTarget(os: OS, arch: Arch, target: Kotlin
         }
     }
 
-    val crossCompileTask = compileNativeBridgesTask(os, arch, isUikitSim = isUikitSim)
+    val crossCompileTask =
+        compileNativeBridgesTask(os, arch, isUikitSim = isUikitSim, waylandProtocols = waylandProtocolsTask)
 
     // TODO: move to LinkSkikoTask.
     val actionName = "linkNativeBridges".withSuffix(isUikitSim = isUikitSim)

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/NativeTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/NativeTasksConfiguration.kt
@@ -269,7 +269,14 @@ fun configureWaylandEglCinterop(
             )
         })
         linkerOpts.set(
-            listOf("-L/usr/lib/$gnuArch-linux-gnu", "-lwayland-client", "-lwayland-egl", "-lEGL")
+            buildList {
+                add("-L/usr/lib/$gnuArch-linux-gnu")
+                // Distros without Debian multiarch (Arch, Fedora) keep the host libs in
+                // /usr/lib. x64 only: adding it under arm64 would leak host x64 libs into
+                // the cross-link, same reasoning as x11gl.def / xkbcommon.def.
+                if (arch != Arch.Arm64) add("-L/usr/lib")
+                addAll(listOf("-lwayland-client", "-lwayland-egl", "-lEGL"))
+            }
         )
         outputFile.set(project.layout.buildDirectory.file("cinterop/$targetString/waylandegl.def"))
     }

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/NativeTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/NativeTasksConfiguration.kt
@@ -274,6 +274,11 @@ fun SkikoProjectContext.configureNativeTarget(os: OS, arch: Arch, target: Kotlin
             ))
         }
         OS.Linux -> {
+            target.compilations.getByName("main") {
+                cinterops.create("x11gl").apply {
+                    definitionFile.set(project.file("src/nativeInterop/cinterop/x11gl.def"))
+                }
+            }
             val options = mutableListOf(
                 "-L/usr/lib64",
                 "-L/usr/lib/${if (arch == Arch.Arm64) "aarch64" else "x86_64"}-linux-gnu",

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/NativeTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/NativeTasksConfiguration.kt
@@ -377,6 +377,11 @@ fun SkikoProjectContext.configureNativeTarget(os: OS, arch: Arch, target: Kotlin
                 cinterops.create("x11gl").apply {
                     definitionFile.set(project.file("src/nativeInterop/cinterop/x11gl.def"))
                 }
+                // No Kotlin consumer inside skiko: the klib is published for the compose
+                // event pump's wl_keyboard keymap handling.
+                cinterops.create("xkbcommon").apply {
+                    definitionFile.set(project.file("src/nativeInterop/cinterop/xkbcommon.def"))
+                }
             }
             configureWaylandEglCinterop(arch, target, targetString, waylandProtocolsTask!!)
             val options = mutableListOf(

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/NativeTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/NativeTasksConfiguration.kt
@@ -6,7 +6,6 @@ import GenerateWaylandProtocolsTask
 import PatchSkiaSymbolsTask
 import runPkgConfigVariable
 import OS
-import SkiaBuildType
 import SkikoProjectContext
 import WriteCInteropDefFile
 import compilerForTarget

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/NativeTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/NativeTasksConfiguration.kt
@@ -148,7 +148,15 @@ fun SkikoProjectContext.compileNativeBridgesTask(
                 )
                 // Add sysroot for ARM64 cross-compilation
                 if (arch == Arch.Arm64 && hostArch != Arch.Arm64) {
-                    linuxFlags.add(0, "--sysroot=/opt/arm-gnu-toolchain/aarch64-none-linux-gnu/libc")
+                    val armToolchainSysroot = file("/opt/arm-gnu-toolchain/aarch64-none-linux-gnu/libc")
+                    if (armToolchainSysroot.exists()) {
+                        linuxFlags.add(0, "--sysroot=${armToolchainSysroot.absolutePath}")
+                    } else {
+                        // Distro cross toolchain (e.g. Ubuntu g++-aarch64-linux-gnu): libc comes
+                        // from the toolchain's own sysroot; arch-neutral X11/GL/fontconfig headers
+                        // are taken from the host after the sysroot search paths.
+                        linuxFlags.add("-idirafter /usr/include")
+                    }
                 }
                 flags.set(linuxFlags)
             }

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/NativeTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/NativeTasksConfiguration.kt
@@ -211,12 +211,19 @@ fun configureCinterop(
 /**
  * The Wayland protocols the Linux native backend binds beyond the core `wayland.xml`
  * (which ships pre-generated in libwayland-client itself): `xdg-shell` for toplevel
- * windowing, `viewporter` and `fractional-scale-v1` for HiDPI scale.
+ * windowing, `viewporter` and `fractional-scale-v1` for HiDPI scale,
+ * `xdg-decoration-unstable-v1` for server-side decorations, and — consumed by the
+ * compose event pump rather than skiko itself — `cursor-shape-v1` (with `tablet-v2`,
+ * whose generated code cursor-shape's references) and `text-input-unstable-v3`.
  */
 private val waylandProtocolXmlPaths = listOf(
     "stable/xdg-shell/xdg-shell.xml",
     "stable/viewporter/viewporter.xml",
+    "stable/tablet/tablet-v2.xml",
     "staging/fractional-scale/fractional-scale-v1.xml",
+    "staging/cursor-shape/cursor-shape-v1.xml",
+    "unstable/xdg-decoration/xdg-decoration-unstable-v1.xml",
+    "unstable/text-input/text-input-unstable-v3.xml",
 )
 
 fun SkikoProjectContext.registerGenerateWaylandProtocolsTask(

--- a/skiko/docker/linux-amd64/Dockerfile
+++ b/skiko/docker/linux-amd64/Dockerfile
@@ -71,6 +71,18 @@ RUN mkdir -p $ARM_TOOLCHAIN_SYSROOT/usr/include && \
         cp -r /usr/include/$dir $ARM_TOOLCHAIN_SYSROOT/usr/include/ || exit 1; \
     done
 
+# Android SDK for :skiko:dokkaHtml (skiko.android.enabled needs android.jar from
+# compileSdk 35). No NDK: the Android target declares no externalNativeBuild, so
+# docs generation never invokes it. Kept last so it doesn't invalidate the cache
+# of the layers above.
+ENV ANDROID_SDK_ROOT=/android/sdk
+RUN cd /tmp && \
+    wget -q https://dl.google.com/android/repository/commandlinetools-linux-13114758_latest.zip -O cmd-tools.zip && \
+    unzip -q cmd-tools.zip && rm cmd-tools.zip && \
+    yes | cmdline-tools/bin/sdkmanager --sdk_root=$ANDROID_SDK_ROOT --licenses && \
+    cmdline-tools/bin/sdkmanager --sdk_root=$ANDROID_SDK_ROOT "platforms;android-35" && \
+    rm -rf cmdline-tools
+
 # Use UTF-8 by default
 ENV LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8
 ENV JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF

--- a/skiko/docker/linux-amd64/Dockerfile
+++ b/skiko/docker/linux-amd64/Dockerfile
@@ -5,6 +5,7 @@ RUN apt update -y && \
     apt install binutils build-essential software-properties-common -y && \
     apt install zip unzip git python curl wget xvfb -y && \
     apt install fontconfig libfontconfig1-dev libglu1-mesa-dev libxrandr-dev libdbus-1-dev -y && \
+    apt install pkg-config libwayland-dev libegl1-mesa-dev libxkbcommon-dev -y && \
     apt install openjdk-21-jdk -y && \
     apt install gcc-10 g++-10 -y && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 --slave /usr/bin/g++ g++ /usr/bin/g++-10 && \
@@ -29,7 +30,26 @@ RUN dpkg --add-architecture arm64 && echo \
     sed -i -E "s/(deb)\ (http:.+)/\1\ [arch=amd64]\ \2/" /etc/apt/sources.list && \
     apt update -y && \
     apt install libfontconfig1-dev:arm64 libglu1-mesa-dev:arm64 libxrandr-dev:arm64 libdbus-1-dev:arm64 -y && \
+    apt install libwayland-dev:arm64 libegl1-mesa-dev:arm64 libxkbcommon-dev:arm64 -y && \
     rm -rf /var/lib/apt/lists/*
+
+# Vendor wayland-protocols: focal's package is 1.20, which predates the staging/
+# protocols the skiko Wayland backend binds (fractional-scale-v1 needs >= 1.31).
+# Only the XMLs and the pkg-config pkgdatadir variable are consumed (by skiko's
+# generateWaylandProtocols task), so install the data files and a .pc by hand
+# instead of pulling in meson for a full build.
+ENV WAYLAND_PROTOCOLS_VERSION=1.45
+RUN cd /tmp && \
+    wget -q https://gitlab.freedesktop.org/wayland/wayland-protocols/-/releases/$WAYLAND_PROTOCOLS_VERSION/downloads/wayland-protocols-$WAYLAND_PROTOCOLS_VERSION.tar.xz && \
+    tar -xf wayland-protocols-$WAYLAND_PROTOCOLS_VERSION.tar.xz && \
+    mkdir -p /usr/local/share/wayland-protocols /usr/local/share/pkgconfig && \
+    cp -r wayland-protocols-$WAYLAND_PROTOCOLS_VERSION/stable \
+          wayland-protocols-$WAYLAND_PROTOCOLS_VERSION/staging \
+          wayland-protocols-$WAYLAND_PROTOCOLS_VERSION/unstable \
+          /usr/local/share/wayland-protocols/ && \
+    printf 'prefix=/usr/local\ndatarootdir=${prefix}/share\npkgdatadir=${datarootdir}/wayland-protocols\n\nName: Wayland Protocols\nDescription: Wayland protocol files\nVersion: %s\n' "$WAYLAND_PROTOCOLS_VERSION" \
+        > /usr/local/share/pkgconfig/wayland-protocols.pc && \
+    rm -rf wayland-protocols-$WAYLAND_PROTOCOLS_VERSION*
 
 # Install cross-compilation toolchain for ARM64
 ENV ARM_TOOLCHAIN_VERSION=10.3-2021.07

--- a/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/Dispatchers.linux.kt
+++ b/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/Dispatchers.linux.kt
@@ -1,0 +1,41 @@
+package org.jetbrains.skiko
+
+import kotlinx.cinterop.*
+import kotlinx.coroutines.*
+import platform.posix.*
+import kotlin.coroutines.CoroutineContext
+
+object SkikoDispatchers {
+    val Main: CoroutineDispatcher = object : CoroutineDispatcher() {
+        override fun dispatch(context: CoroutineContext, block: Runnable) {
+            LinuxMainDispatcher.dispatch(block)
+        }
+    }
+}
+
+object LinuxMainDispatcher {
+    private val queue = ArrayDeque<Runnable>()
+    private val mutex = nativeHeap.alloc<pthread_mutex_t>()
+
+    init {
+        pthread_mutex_init(mutex.ptr, null)
+    }
+
+    private inline fun <T> withLock(block: () -> T): T {
+        pthread_mutex_lock(mutex.ptr)
+        return try {
+            block()
+        } finally {
+            pthread_mutex_unlock(mutex.ptr)
+        }
+    }
+
+    fun dispatch(block: Runnable) {
+        withLock { queue.addLast(block) }
+    }
+
+    fun drain() {
+        withLock { queue.toList().also { queue.clear() } }
+            .forEach { runCatching(it::run).onFailure(Throwable::printStackTrace) }
+    }
+}

--- a/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/GlContext.kt
+++ b/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/GlContext.kt
@@ -1,0 +1,32 @@
+package org.jetbrains.skiko
+
+import kotlinx.cinterop.*
+import x11gl.*
+
+class GlContext(private val win: X11Window) {
+    private val context: GLXContext = glXCreateContext(win.display, win.visualInfo, null, 1)
+        ?: throw RenderSetupException("glXCreateContext failed")
+
+    fun makeCurrent() {
+        if (glXMakeCurrent(win.display, win.window, context) == 0) {
+            throw RenderSetupException("glXMakeCurrent failed")
+        }
+    }
+
+    fun swapBuffers() {
+        glXSwapBuffers(win.display, win.window)
+    }
+
+    fun setSwapInterval(interval: Int) {
+        val proc = memScoped {
+            glXGetProcAddressARB("glXSwapIntervalEXT".cstr.ptr.reinterpret())
+        } ?: return
+        val swapIntervalExt = proc.reinterpret<CFunction<(CPointer<Display>?, GLXDrawable, Int) -> Unit>>()
+        swapIntervalExt(win.display, win.window, interval)
+    }
+
+    fun close() {
+        glXMakeCurrent(win.display, 0uL, null)
+        glXDestroyContext(win.display, context)
+    }
+}

--- a/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/LinuxWindow.kt
+++ b/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/LinuxWindow.kt
@@ -5,8 +5,11 @@ package org.jetbrains.skiko
  * concrete Linux display-server backend (X11/GLX today, Wayland/EGL landing alongside
  * it). Geometry is always physical pixels; [contentScale] is the separate factor that
  * feeds UI density, matching the model X11 already established.
+ *
+ * Public so consumers outside skiko (e.g. a compose-multiplatform-core event pump) can
+ * hold a window reference typed by this seam rather than the concrete backend class.
  */
-internal interface LinuxWindow {
+interface LinuxWindow {
     val width: Int
     val height: Int
     val contentScale: Float
@@ -34,9 +37,8 @@ internal interface LinuxWindow {
 
 /**
  * GL context bound to a [LinuxWindow]'s native surface (GLX context vs EGL
- * context/surface). Public only because implementers of the internal [LinuxWindow] seam
- * (e.g. [X11Window]) are themselves public classes whose `createGlContext()` return type
- * must not leak an internal type; there is no supported use of this type outside skiko.
+ * context/surface). There is no supported use of this type outside the call chain that
+ * creates it (`Redrawer` construction); it is public only because [LinuxWindow] is.
  */
 interface LinuxGlContext {
     fun makeCurrent()

--- a/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/LinuxWindow.kt
+++ b/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/LinuxWindow.kt
@@ -1,0 +1,49 @@
+package org.jetbrains.skiko
+
+/**
+ * Windowing seam between [SkiaLayer]/[org.jetbrains.skiko.redrawer.Redrawer] and the
+ * concrete Linux display-server backend (X11/GLX today, Wayland/EGL landing alongside
+ * it). Geometry is always physical pixels; [contentScale] is the separate factor that
+ * feeds UI density, matching the model X11 already established.
+ */
+internal interface LinuxWindow {
+    val width: Int
+    val height: Int
+    val contentScale: Float
+
+    fun show()
+
+    fun close()
+
+    /**
+     * Creates the GL context matching this window's native surface (GLX vs EGL). Public
+     * on the interface's implementers (e.g. [X11Window]) since those constructors are
+     * public API consumed outside this module; [LinuxGlContext] itself is a plain public
+     * type with no members meant for outside use beyond this call chain.
+     */
+    fun createGlContext(): LinuxGlContext
+
+    /**
+     * Registers a one-shot callback for the next compositor-paced frame, letting the
+     * redrawer replace timer-driven pacing with real vsync signalling where the backend
+     * supports it (Wayland's `wl_surface.frame`). Default is a no-op: X11 has no
+     * equivalent and keeps pacing itself via [glXSwapIntervalEXT]-driven vsync.
+     */
+    fun frameCallback(onFrame: () -> Unit) {}
+}
+
+/**
+ * GL context bound to a [LinuxWindow]'s native surface (GLX context vs EGL
+ * context/surface). Public only because implementers of the internal [LinuxWindow] seam
+ * (e.g. [X11Window]) are themselves public classes whose `createGlContext()` return type
+ * must not leak an internal type; there is no supported use of this type outside skiko.
+ */
+interface LinuxGlContext {
+    fun makeCurrent()
+
+    fun swapBuffers()
+
+    fun setSwapInterval(interval: Int)
+
+    fun close()
+}

--- a/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/RenderFactory.linux.kt
+++ b/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/RenderFactory.linux.kt
@@ -1,0 +1,12 @@
+package org.jetbrains.skiko
+
+import org.jetbrains.skiko.redrawer.LinuxOpenGLRedrawer
+import org.jetbrains.skiko.redrawer.Redrawer
+
+internal fun createNativeRedrawer(
+    layer: SkiaLayer,
+    renderApi: GraphicsApi
+): Redrawer = when (renderApi) {
+    GraphicsApi.OPENGL -> LinuxOpenGLRedrawer(layer)
+    else -> throw IllegalArgumentException("Unsupported API $renderApi")
+}

--- a/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/SkiaLayer.linux.kt
+++ b/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/SkiaLayer.linux.kt
@@ -34,11 +34,10 @@ actual open class SkiaLayer {
         check(!this::window.isInitialized) { "Already attached to another window" }
         check(container is LinuxWindow) { "container should be an instance of LinuxWindow (e.g. X11Window)" }
         window = container
-        redrawer =
-            createNativeRedrawer(this, renderApi).apply {
-                syncBounds()
-                needRender()
-            }
+        redrawer = createNativeRedrawer(this, renderApi).apply {
+            syncBounds()
+            needRender()
+        }
     }
 
     actual fun detach() {
@@ -60,20 +59,18 @@ actual open class SkiaLayer {
     private val pictureRecorder = PictureRecorder()
 
     internal fun update(nanoTime: Long) {
-        val width = window.width
-        val height = window.height
+        // LinuxWindow geometry is physical pixels (unlike macOS points), so the surface
+        // size is the window size as-is; contentScale only informs UI density.
+        val width = window.width.coerceAtLeast(0)
+        val height = window.height.coerceAtLeast(0)
 
-        val pictureWidth = (width * contentScale).coerceAtLeast(0.0f)
-        val pictureHeight = (height * contentScale).coerceAtLeast(0.0f)
-
-        val canvas =
-            pictureRecorder.beginRecording(0f, 0f, pictureWidth, pictureHeight).apply {
-                clear(Color.WHITE)
-            }
-        renderDelegate?.onRender(canvas, pictureWidth.toInt(), pictureHeight.toInt(), nanoTime)
+        val canvas = pictureRecorder.beginRecording(0f, 0f, width.toFloat(), height.toFloat()).apply {
+            clear(Color.WHITE)
+        }
+        renderDelegate?.onRender(canvas, width, height, nanoTime)
 
         val picture = pictureRecorder.finishRecordingAsPicture()
-        this.picture = PictureHolder(picture, pictureWidth.toInt(), pictureHeight.toInt())
+        this.picture = PictureHolder(picture, width, height)
     }
 
     internal actual fun draw(canvas: Canvas) {
@@ -85,13 +82,11 @@ actual open class SkiaLayer {
     actual val pixelGeometry: PixelGeometry
         get() = PixelGeometry.UNKNOWN
 
-    private fun createDrawScope() =
-        LayerDrawScope(
-            pixelGeometry = pixelGeometry,
-            layerWidth = window.width.toDouble(),
-            layerHeight = window.height.toDouble(),
-            scale = contentScale,
-        )
+    private fun createDrawScope() = LayerDrawScope(
+        pixelGeometry = pixelGeometry,
+        scaledLayerWidth = window.width.coerceAtLeast(0),
+        scaledLayerHeight = window.height.coerceAtLeast(0),
+    )
 
     internal fun inDrawScope(block: LayerDrawScope.() -> Unit) {
         createDrawScope().block()

--- a/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/SkiaLayer.linux.kt
+++ b/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/SkiaLayer.linux.kt
@@ -1,41 +1,98 @@
 package org.jetbrains.skiko
 
 import org.jetbrains.skia.Canvas
+import org.jetbrains.skia.Color
 import org.jetbrains.skia.PixelGeometry
+import org.jetbrains.skia.PictureRecorder
+import org.jetbrains.skiko.redrawer.Redrawer
 
-actual open class SkiaLayer  {
-    actual var renderApi: GraphicsApi
-        get() = TODO("Not yet implemented")
-        set(value) {}
+actual open class SkiaLayer {
+    actual var renderApi: GraphicsApi = GraphicsApi.OPENGL
+        set(value) {
+            if (value != GraphicsApi.OPENGL) {
+                throw IllegalArgumentException("$field is not supported in Linux native")
+            }
+            field = value
+        }
+
     actual val contentScale: Float
-        get() = TODO("Not yet implemented")
-    actual var fullscreen: Boolean
-        get() = TODO("Not yet implemented")
-        set(value) {}
+        get() = if (this::window.isInitialized) window.contentScale else 1.0f
+
+    actual var fullscreen: Boolean = false
+
+    lateinit var window: X11Window
+        private set
+
     actual val component: Any?
-        get() = TODO("Not yet implemented")
-    actual fun needRender(throttledToVsync: Boolean) {
-        TODO("unimplemented")
+        get() = if (this::window.isInitialized) window else null
+
+    actual var renderDelegate: SkikoRenderDelegate? = null
+
+    internal var redrawer: Redrawer? = null
+
+    actual fun attachTo(container: Any) {
+        check(!this::window.isInitialized) { "Already attached to another window" }
+        check(container is X11Window) { "container should be an instance of X11Window" }
+        window = container
+        redrawer = createNativeRedrawer(this, renderApi).apply {
+            syncBounds()
+            needRender()
+        }
     }
+
+    actual fun detach() {
+        redrawer?.dispose()
+        redrawer = null
+    }
+
+    actual fun needRender(throttledToVsync: Boolean) {
+        redrawer?.needRender(throttledToVsync)
+    }
+
     @Deprecated(
         message = "Use needRender() instead",
         replaceWith = ReplaceWith("needRender()")
     )
     actual fun needRedraw() = needRender()
-    actual fun attachTo(container: Any) {
-        TODO("unimplemented")
-    }
-    actual fun detach() {
-        TODO("unimplemented")
+
+    private var picture: PictureHolder? = null
+    private val pictureRecorder = PictureRecorder()
+
+    internal fun update(nanoTime: Long) {
+        val width = window.width
+        val height = window.height
+
+        val pictureWidth = (width * contentScale).coerceAtLeast(0.0f)
+        val pictureHeight = (height * contentScale).coerceAtLeast(0.0f)
+
+        val canvas = pictureRecorder.beginRecording(0f, 0f, pictureWidth, pictureHeight).apply {
+            clear(Color.WHITE)
+        }
+        renderDelegate?.onRender(canvas, pictureWidth.toInt(), pictureHeight.toInt(), nanoTime)
+
+        val picture = pictureRecorder.finishRecordingAsPicture()
+        this.picture = PictureHolder(picture, pictureWidth.toInt(), pictureHeight.toInt())
     }
 
     internal actual fun draw(canvas: Canvas) {
-        TODO("unimplemented")
+        picture?.also {
+            canvas.drawPicture(it.instance)
+        }
     }
 
-    actual var renderDelegate: SkikoRenderDelegate? = null
     actual val pixelGeometry: PixelGeometry
-        get() = TODO("Not yet implemented")
+        get() = PixelGeometry.UNKNOWN
+
+    private fun createDrawScope() = LayerDrawScope(
+        pixelGeometry = pixelGeometry,
+        layerWidth = window.width.toDouble(),
+        layerHeight = window.height.toDouble(),
+        scale = contentScale
+    )
+
+    internal fun inDrawScope(block: LayerDrawScope.() -> Unit) {
+        createDrawScope().block()
+    }
 }
 
 actual val currentSystemTheme: SystemTheme

--- a/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/SkiaLayer.linux.kt
+++ b/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/SkiaLayer.linux.kt
@@ -2,8 +2,8 @@ package org.jetbrains.skiko
 
 import org.jetbrains.skia.Canvas
 import org.jetbrains.skia.Color
-import org.jetbrains.skia.PixelGeometry
 import org.jetbrains.skia.PictureRecorder
+import org.jetbrains.skia.PixelGeometry
 import org.jetbrains.skiko.redrawer.Redrawer
 
 actual open class SkiaLayer {
@@ -20,7 +20,7 @@ actual open class SkiaLayer {
 
     actual var fullscreen: Boolean = false
 
-    lateinit var window: X11Window
+    internal lateinit var window: LinuxWindow
         private set
 
     actual val component: Any?
@@ -32,12 +32,13 @@ actual open class SkiaLayer {
 
     actual fun attachTo(container: Any) {
         check(!this::window.isInitialized) { "Already attached to another window" }
-        check(container is X11Window) { "container should be an instance of X11Window" }
+        check(container is LinuxWindow) { "container should be an instance of LinuxWindow (e.g. X11Window)" }
         window = container
-        redrawer = createNativeRedrawer(this, renderApi).apply {
-            syncBounds()
-            needRender()
-        }
+        redrawer =
+            createNativeRedrawer(this, renderApi).apply {
+                syncBounds()
+                needRender()
+            }
     }
 
     actual fun detach() {
@@ -51,7 +52,7 @@ actual open class SkiaLayer {
 
     @Deprecated(
         message = "Use needRender() instead",
-        replaceWith = ReplaceWith("needRender()")
+        replaceWith = ReplaceWith("needRender()"),
     )
     actual fun needRedraw() = needRender()
 
@@ -65,9 +66,10 @@ actual open class SkiaLayer {
         val pictureWidth = (width * contentScale).coerceAtLeast(0.0f)
         val pictureHeight = (height * contentScale).coerceAtLeast(0.0f)
 
-        val canvas = pictureRecorder.beginRecording(0f, 0f, pictureWidth, pictureHeight).apply {
-            clear(Color.WHITE)
-        }
+        val canvas =
+            pictureRecorder.beginRecording(0f, 0f, pictureWidth, pictureHeight).apply {
+                clear(Color.WHITE)
+            }
         renderDelegate?.onRender(canvas, pictureWidth.toInt(), pictureHeight.toInt(), nanoTime)
 
         val picture = pictureRecorder.finishRecordingAsPicture()
@@ -83,12 +85,13 @@ actual open class SkiaLayer {
     actual val pixelGeometry: PixelGeometry
         get() = PixelGeometry.UNKNOWN
 
-    private fun createDrawScope() = LayerDrawScope(
-        pixelGeometry = pixelGeometry,
-        layerWidth = window.width.toDouble(),
-        layerHeight = window.height.toDouble(),
-        scale = contentScale
-    )
+    private fun createDrawScope() =
+        LayerDrawScope(
+            pixelGeometry = pixelGeometry,
+            layerWidth = window.width.toDouble(),
+            layerHeight = window.height.toDouble(),
+            scale = contentScale,
+        )
 
     internal fun inDrawScope(block: LayerDrawScope.() -> Unit) {
         createDrawScope().block()

--- a/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/WaylandEglContext.kt
+++ b/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/WaylandEglContext.kt
@@ -1,0 +1,107 @@
+package org.jetbrains.skiko
+
+import cnames.structs.wl_egl_window
+import kotlinx.cinterop.*
+import waylandegl.*
+
+/**
+ * [LinuxGlContext] backed by EGL on a `wl_egl_window`, the Wayland sibling of
+ * [X11GlContext]. Creates a desktop OpenGL (not GLES) context, matching what
+ * `DirectContext.makeGL()` expects, with the same RGBA8/depth 24/stencil 8 config the
+ * GLX path requests.
+ */
+internal class WaylandEglContext(
+    private val win: WaylandWindow,
+) : LinuxGlContext {
+    private val eglDisplay: EGLDisplay =
+        eglGetPlatformDisplay(EGL_PLATFORM_WAYLAND_KHR.convert(), win.display, null)
+            ?: throw RenderSetupException("eglGetPlatformDisplay failed for the Wayland display")
+
+    private val eglConfig: EGLConfig
+    private val eglContext: EGLContext
+    private val eglWindow: CPointer<wl_egl_window>
+    private val eglSurface: EGLSurface
+
+    init {
+        memScoped {
+            val major = alloc<EGLintVar>()
+            val minor = alloc<EGLintVar>()
+            if (eglInitialize(eglDisplay, major.ptr, minor.ptr) == EGL_FALSE.toUInt()) {
+                throw RenderSetupException("eglInitialize failed")
+            }
+        }
+        if (eglBindAPI(EGL_OPENGL_API.convert()) == EGL_FALSE.toUInt()) {
+            throw RenderSetupException("eglBindAPI(EGL_OPENGL_API) failed; desktop GL unsupported")
+        }
+
+        eglConfig = memScoped {
+            val attribs = intArrayOf(
+                EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
+                EGL_RENDERABLE_TYPE, EGL_OPENGL_BIT,
+                EGL_RED_SIZE, 8,
+                EGL_GREEN_SIZE, 8,
+                EGL_BLUE_SIZE, 8,
+                EGL_ALPHA_SIZE, 8,
+                EGL_DEPTH_SIZE, 24,
+                EGL_STENCIL_SIZE, 8,
+                EGL_NONE,
+            )
+            val config = alloc<EGLConfigVar>()
+            val numConfigs = alloc<EGLintVar>()
+            val chosen = eglChooseConfig(
+                eglDisplay, attribs.toCValues().ptr, config.ptr, 1, numConfigs.ptr
+            )
+            if (chosen == EGL_FALSE.toUInt() || numConfigs.value < 1) {
+                throw RenderSetupException("No EGL config with RGBA8 + depth 24 + stencil 8")
+            }
+            config.value
+                ?: throw RenderSetupException("eglChooseConfig returned a null config")
+        }
+
+        eglContext = eglCreateContext(eglDisplay, eglConfig, null, null)
+            ?: throw RenderSetupException("eglCreateContext failed")
+
+        eglWindow = wl_egl_window_create(
+            win.surface,
+            win.width.coerceAtLeast(1),
+            win.height.coerceAtLeast(1),
+        ) ?: throw RenderSetupException("wl_egl_window_create failed")
+        win.onPhysicalResize = { width, height ->
+            wl_egl_window_resize(eglWindow, width.coerceAtLeast(1), height.coerceAtLeast(1), 0, 0)
+        }
+
+        eglSurface = eglCreateWindowSurface(eglDisplay, eglConfig, eglWindow, null)
+            ?: throw RenderSetupException("eglCreateWindowSurface failed")
+    }
+
+    override fun makeCurrent() {
+        if (eglMakeCurrent(eglDisplay, eglSurface, eglSurface, eglContext) == EGL_FALSE.toUInt()) {
+            throw RenderSetupException("eglMakeCurrent failed")
+        }
+    }
+
+    override fun swapBuffers() {
+        if (eglSwapBuffers(eglDisplay, eglSurface) == EGL_FALSE.toUInt()) {
+            val err = eglGetError()
+            println("eglSwapBuffers failed: error 0x${err.toString(16)}")
+        }
+    }
+
+    /**
+     * Deliberately forces interval 0 regardless of what is asked: frame pacing comes from
+     * `wl_surface.frame` (see [WaylandWindow.frameCallback]), and a non-zero EGL swap
+     * interval would make [swapBuffers] block forever while the surface is occluded.
+     */
+    override fun setSwapInterval(interval: Int) {
+        eglSwapInterval(eglDisplay, 0)
+    }
+
+    override fun close() {
+        win.onPhysicalResize = null
+        eglMakeCurrent(eglDisplay, null, null, null)
+        eglDestroySurface(eglDisplay, eglSurface)
+        wl_egl_window_destroy(eglWindow)
+        eglDestroyContext(eglDisplay, eglContext)
+        eglTerminate(eglDisplay)
+    }
+}

--- a/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/WaylandWindow.kt
+++ b/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/WaylandWindow.kt
@@ -49,6 +49,12 @@ class WaylandWindow(
     private val arena = Arena()
     private val self = StableRef.create(this)
 
+    /**
+     * The Wayland display connection. Owned by this window: consumers (e.g. the compose
+     * event pump binding its own `wl_registry` for `wl_seat` and friends) may create
+     * additional objects on it, but must not disconnect it and must do all their
+     * dispatching through this window's [dispatchPendingEvents].
+     */
     val display: CPointer<wl_display> =
         wl_display_connect(null)
             ?: throw RenderSetupException("Cannot connect to Wayland display; is WAYLAND_DISPLAY set?")
@@ -60,7 +66,12 @@ class WaylandWindow(
     private var decorationManager: CPointer<zxdg_decoration_manager_v1>? = null
     private var outputScale = 1
 
-    internal val surface: CPointer<wl_surface>
+    /**
+     * The window's `wl_surface`. Owned by this window: consumers may compare it against
+     * surfaces delivered in their own listeners (e.g. `wl_pointer.enter`) but must not
+     * destroy it or attach buffers to it.
+     */
+    val surface: CPointer<wl_surface>
     private val xdgSurface: CPointer<xdg_surface>
     private val toplevel: CPointer<xdg_toplevel>
     private var viewport: CPointer<wp_viewport>? = null

--- a/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/WaylandWindow.kt
+++ b/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/WaylandWindow.kt
@@ -13,6 +13,8 @@ import cnames.structs.wp_viewporter
 import cnames.structs.xdg_surface
 import cnames.structs.xdg_toplevel
 import cnames.structs.xdg_wm_base
+import cnames.structs.zxdg_decoration_manager_v1
+import cnames.structs.zxdg_toplevel_decoration_v1
 import kotlinx.cinterop.*
 import platform.posix.POLLIN
 import platform.posix.poll
@@ -55,6 +57,7 @@ class WaylandWindow(
     private var wmBase: CPointer<xdg_wm_base>? = null
     private var viewporter: CPointer<wp_viewporter>? = null
     private var fractionalScaleManager: CPointer<wp_fractional_scale_manager_v1>? = null
+    private var decorationManager: CPointer<zxdg_decoration_manager_v1>? = null
     private var outputScale = 1
 
     internal val surface: CPointer<wl_surface>
@@ -62,6 +65,7 @@ class WaylandWindow(
     private val toplevel: CPointer<xdg_toplevel>
     private var viewport: CPointer<wp_viewport>? = null
     private var fractionalScale: CPointer<wp_fractional_scale_v1>? = null
+    private var toplevelDecoration: CPointer<zxdg_toplevel_decoration_v1>? = null
 
     /** Logical (compositor-space) size; physical size is derived via [contentScale]. */
     private var logicalWidth = width
@@ -160,6 +164,14 @@ class WaylandWindow(
         }
     }
 
+    // The compositor may pick either mode; there is no client-side fallback yet
+    // (libdecor is deferred), so a client-side answer just leaves the window borderless.
+    private val toplevelDecorationListener = arena.alloc<zxdg_toplevel_decoration_v1_listener>().apply {
+        configure = staticCFunction {
+                _: COpaquePointer?, _: CPointer<zxdg_toplevel_decoration_v1>?, _: UInt ->
+        }
+    }
+
     private val frameListener = arena.alloc<wl_callback_listener>().apply {
         done = staticCFunction { data: COpaquePointer?, callback: CPointer<wl_callback>?, _: UInt ->
             callback?.let { wl_callback_destroy(it) }
@@ -190,6 +202,16 @@ class WaylandWindow(
             ?: throw RenderSetupException("xdg_surface_get_toplevel failed")
         xdg_toplevel_add_listener(toplevel, toplevelListener.ptr, self.asCPointer())
         xdg_toplevel_set_title(toplevel, title)
+
+        // Ask for server-side decorations where the compositor offers the choice (KWin,
+        // sway); GNOME does not advertise the manager and the window stays borderless.
+        decorationManager?.let { manager ->
+            toplevelDecoration =
+                zxdg_decoration_manager_v1_get_toplevel_decoration(manager, toplevel)?.also {
+                    zxdg_toplevel_decoration_v1_add_listener(it, toplevelDecorationListener.ptr, self.asCPointer())
+                    zxdg_toplevel_decoration_v1_set_mode(it, ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE)
+                }
+        }
 
         val fractionalScaleManager = fractionalScaleManager
         if (fractionalScaleManager != null && viewporter != null) {
@@ -226,6 +248,10 @@ class WaylandWindow(
             "wp_fractional_scale_manager_v1" ->
                 fractionalScaleManager =
                     wl_registry_bind(registry, name, wp_fractional_scale_manager_v1_interface.ptr, 1u)
+                        ?.reinterpret()
+            "zxdg_decoration_manager_v1" ->
+                decorationManager =
+                    wl_registry_bind(registry, name, zxdg_decoration_manager_v1_interface.ptr, 1u)
                         ?.reinterpret()
             "wl_output" -> {
                 val output = wl_registry_bind(registry, name, wl_output_interface.ptr, minOf(version, 2u))
@@ -307,6 +333,7 @@ class WaylandWindow(
         pendingFrame = null
         fractionalScale?.let { wp_fractional_scale_v1_destroy(it) }
         viewport?.let { wp_viewport_destroy(it) }
+        toplevelDecoration?.let { zxdg_toplevel_decoration_v1_destroy(it) }
         xdg_toplevel_destroy(toplevel)
         xdg_surface_destroy(xdgSurface)
         wl_surface_destroy(surface)

--- a/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/WaylandWindow.kt
+++ b/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/WaylandWindow.kt
@@ -1,0 +1,319 @@
+package org.jetbrains.skiko
+
+import cnames.structs.wl_callback
+import cnames.structs.wl_compositor
+import cnames.structs.wl_display
+import cnames.structs.wl_output
+import cnames.structs.wl_registry
+import cnames.structs.wl_surface
+import cnames.structs.wp_fractional_scale_manager_v1
+import cnames.structs.wp_fractional_scale_v1
+import cnames.structs.wp_viewport
+import cnames.structs.wp_viewporter
+import cnames.structs.xdg_surface
+import cnames.structs.xdg_toplevel
+import cnames.structs.xdg_wm_base
+import kotlinx.cinterop.*
+import platform.posix.POLLIN
+import platform.posix.poll
+import platform.posix.pollfd
+import waylandegl.*
+
+/**
+ * The fractional-scale-v1 protocol reports the preferred scale as a numerator over 120
+ * (e.g. 180 means 1.5).
+ */
+private const val FRACTIONAL_SCALE_DENOMINATOR = 120f
+
+/**
+ * [LinuxWindow] backed by a Wayland `xdg_toplevel` surface, the compositor-agnostic
+ * sibling of [X11Window].
+ *
+ * Geometry model matches the seam contract: [width]/[height] are physical pixels,
+ * [contentScale] feeds UI density. The compositor drives the logical size through
+ * `xdg_toplevel.configure` and the scale through `wp_fractional_scale_v1.preferred_scale`
+ * when the compositor supports it (falling back to the advertised `wl_output` integer
+ * scale otherwise); physical size is derived from both.
+ *
+ * The owner of the window is responsible for pumping the event queue by calling
+ * [dispatchPendingEvents] from its main loop, the Wayland equivalent of the
+ * `XPending`/`XNextEvent` loop an [X11Window] owner runs.
+ */
+class WaylandWindow(
+    title: String,
+    width: Int,
+    height: Int,
+) : LinuxWindow {
+    private val arena = Arena()
+    private val self = StableRef.create(this)
+
+    val display: CPointer<wl_display> =
+        wl_display_connect(null)
+            ?: throw RenderSetupException("Cannot connect to Wayland display; is WAYLAND_DISPLAY set?")
+
+    private var compositor: CPointer<wl_compositor>? = null
+    private var wmBase: CPointer<xdg_wm_base>? = null
+    private var viewporter: CPointer<wp_viewporter>? = null
+    private var fractionalScaleManager: CPointer<wp_fractional_scale_manager_v1>? = null
+    private var outputScale = 1
+
+    internal val surface: CPointer<wl_surface>
+    private val xdgSurface: CPointer<xdg_surface>
+    private val toplevel: CPointer<xdg_toplevel>
+    private var viewport: CPointer<wp_viewport>? = null
+    private var fractionalScale: CPointer<wp_fractional_scale_v1>? = null
+
+    /** Logical (compositor-space) size; physical size is derived via [contentScale]. */
+    private var logicalWidth = width
+    private var logicalHeight = height
+
+    private var configured = false
+
+    /** Set when the compositor asks the toplevel to close; the event loop owner decides. */
+    var closeRequested: Boolean = false
+        private set
+
+    override var contentScale: Float = 1f
+        private set
+
+    override val width: Int get() = (logicalWidth * contentScale).toInt()
+
+    override val height: Int get() = (logicalHeight * contentScale).toInt()
+
+    /** Lets the EGL context follow compositor-driven resizes; set by [WaylandEglContext]. */
+    internal var onPhysicalResize: ((width: Int, height: Int) -> Unit)? = null
+
+    private var pendingFrame: (() -> Unit)? = null
+
+    private val registryListener = arena.alloc<wl_registry_listener>().apply {
+        global = staticCFunction {
+                data: COpaquePointer?,
+                registry: CPointer<wl_registry>?,
+                name: UInt,
+                iface: CPointer<ByteVar>?,
+                version: UInt,
+            ->
+            if (data != null && registry != null && iface != null) {
+                data.asStableRef<WaylandWindow>().get().bindGlobal(registry, name, iface.toKString(), version)
+            }
+        }
+        global_remove = staticCFunction { _: COpaquePointer?, _: CPointer<wl_registry>?, _: UInt -> }
+    }
+
+    private val wmBaseListener = arena.alloc<xdg_wm_base_listener>().apply {
+        ping = staticCFunction { _: COpaquePointer?, wmBase: CPointer<xdg_wm_base>?, serial: UInt ->
+            xdg_wm_base_pong(wmBase, serial)
+        }
+    }
+
+    private val xdgSurfaceListener = arena.alloc<xdg_surface_listener>().apply {
+        configure = staticCFunction { data: COpaquePointer?, xdgSurface: CPointer<xdg_surface>?, serial: UInt ->
+            xdg_surface_ack_configure(xdgSurface, serial)
+            data?.asStableRef<WaylandWindow>()?.get()?.configured = true
+        }
+    }
+
+    private val toplevelListener = arena.alloc<xdg_toplevel_listener>().apply {
+        configure = staticCFunction {
+                data: COpaquePointer?,
+                _: CPointer<xdg_toplevel>?,
+                width: Int,
+                height: Int,
+                _: CPointer<wl_array>?,
+            ->
+            // 0x0 means the compositor defers to the client; keep the current size then.
+            if (data != null && width > 0 && height > 0) {
+                data.asStableRef<WaylandWindow>().get().onLogicalResize(width, height)
+            }
+        }
+        close = staticCFunction { data: COpaquePointer?, _: CPointer<xdg_toplevel>? ->
+            data?.asStableRef<WaylandWindow>()?.get()?.closeRequested = true
+        }
+    }
+
+    private val outputListener = arena.alloc<wl_output_listener>().apply {
+        geometry = staticCFunction {
+                _: COpaquePointer?, _: CPointer<wl_output>?,
+                _: Int, _: Int, _: Int, _: Int, _: Int,
+                _: CPointer<ByteVar>?, _: CPointer<ByteVar>?, _: Int,
+            ->
+        }
+        mode = staticCFunction {
+                _: COpaquePointer?, _: CPointer<wl_output>?, _: UInt, _: Int, _: Int, _: Int,
+            ->
+        }
+        done = staticCFunction { _: COpaquePointer?, _: CPointer<wl_output>? -> }
+        scale = staticCFunction { data: COpaquePointer?, _: CPointer<wl_output>?, factor: Int ->
+            if (data != null && factor > 0) {
+                val window = data.asStableRef<WaylandWindow>().get()
+                window.outputScale = maxOf(window.outputScale, factor)
+            }
+        }
+    }
+
+    private val fractionalScaleListener = arena.alloc<wp_fractional_scale_v1_listener>().apply {
+        preferred_scale = staticCFunction {
+                data: COpaquePointer?, _: CPointer<wp_fractional_scale_v1>?, scale: UInt,
+            ->
+            data?.asStableRef<WaylandWindow>()?.get()
+                ?.onPreferredScale(scale.toInt() / FRACTIONAL_SCALE_DENOMINATOR)
+        }
+    }
+
+    private val frameListener = arena.alloc<wl_callback_listener>().apply {
+        done = staticCFunction { data: COpaquePointer?, callback: CPointer<wl_callback>?, _: UInt ->
+            callback?.let { wl_callback_destroy(it) }
+            data?.asStableRef<WaylandWindow>()?.get()?.fireFrame()
+        }
+    }
+
+    init {
+        val registry = wl_display_get_registry(display)
+            ?: throw RenderSetupException("wl_display_get_registry failed")
+        wl_registry_add_listener(registry, registryListener.ptr, self.asCPointer())
+        // First roundtrip delivers the globals, second the events (e.g. wl_output.scale)
+        // sent in response to the binds the first one triggered.
+        wl_display_roundtrip(display)
+        wl_display_roundtrip(display)
+
+        val compositor = compositor
+            ?: throw RenderSetupException("Wayland compositor does not advertise wl_compositor")
+        val wmBase = wmBase
+            ?: throw RenderSetupException("Wayland compositor does not advertise xdg_wm_base")
+
+        surface = wl_compositor_create_surface(compositor)
+            ?: throw RenderSetupException("wl_compositor_create_surface failed")
+        xdgSurface = xdg_wm_base_get_xdg_surface(wmBase, surface)
+            ?: throw RenderSetupException("xdg_wm_base_get_xdg_surface failed")
+        xdg_surface_add_listener(xdgSurface, xdgSurfaceListener.ptr, self.asCPointer())
+        toplevel = xdg_surface_get_toplevel(xdgSurface)
+            ?: throw RenderSetupException("xdg_surface_get_toplevel failed")
+        xdg_toplevel_add_listener(toplevel, toplevelListener.ptr, self.asCPointer())
+        xdg_toplevel_set_title(toplevel, title)
+
+        val fractionalScaleManager = fractionalScaleManager
+        if (fractionalScaleManager != null && viewporter != null) {
+            fractionalScale =
+                wp_fractional_scale_manager_v1_get_fractional_scale(fractionalScaleManager, surface)?.also {
+                    wp_fractional_scale_v1_add_listener(it, fractionalScaleListener.ptr, self.asCPointer())
+                }
+        } else if (outputScale > 1) {
+            contentScale = outputScale.toFloat()
+            wl_surface_set_buffer_scale(surface, outputScale)
+        }
+
+        // Commit the (buffer-less) initial state and wait for the first configure;
+        // xdg-shell forbids attaching a buffer before it is acked.
+        wl_surface_commit(surface)
+        while (!configured) {
+            if (wl_display_dispatch(display) < 0) {
+                throw RenderSetupException("Wayland connection lost while waiting for xdg_surface.configure")
+            }
+        }
+    }
+
+    private fun bindGlobal(registry: CPointer<wl_registry>, name: UInt, iface: String, version: UInt) {
+        when (iface) {
+            "wl_compositor" ->
+                compositor = wl_registry_bind(registry, name, wl_compositor_interface.ptr, minOf(version, 4u))
+                    ?.reinterpret()
+            "xdg_wm_base" -> {
+                wmBase = wl_registry_bind(registry, name, xdg_wm_base_interface.ptr, 1u)?.reinterpret()
+                wmBase?.let { xdg_wm_base_add_listener(it, wmBaseListener.ptr, self.asCPointer()) }
+            }
+            "wp_viewporter" ->
+                viewporter = wl_registry_bind(registry, name, wp_viewporter_interface.ptr, 1u)?.reinterpret()
+            "wp_fractional_scale_manager_v1" ->
+                fractionalScaleManager =
+                    wl_registry_bind(registry, name, wp_fractional_scale_manager_v1_interface.ptr, 1u)
+                        ?.reinterpret()
+            "wl_output" -> {
+                val output = wl_registry_bind(registry, name, wl_output_interface.ptr, minOf(version, 2u))
+                    ?.reinterpret<wl_output>()
+                output?.let { wl_output_add_listener(it, outputListener.ptr, self.asCPointer()) }
+            }
+        }
+    }
+
+    private fun onLogicalResize(newWidth: Int, newHeight: Int) {
+        if (newWidth == logicalWidth && newHeight == logicalHeight) return
+        logicalWidth = newWidth
+        logicalHeight = newHeight
+        applyScale()
+        onPhysicalResize?.invoke(width, height)
+    }
+
+    private fun onPreferredScale(newScale: Float) {
+        if (newScale == contentScale || newScale <= 0f) return
+        contentScale = newScale
+        applyScale()
+        onPhysicalResize?.invoke(width, height)
+    }
+
+    /**
+     * With a fractional scale the buffer stays physical-sized and the viewport maps it to
+     * the logical size; without one the surface stays at scale 1 (or the integer
+     * buffer-scale chosen at init) and no viewport is needed.
+     */
+    private fun applyScale() {
+        if (fractionalScale == null || contentScale == 1f) return
+        val viewport = viewport
+            ?: wp_viewporter_get_viewport(viewporter, surface).also { viewport = it }
+            ?: return
+        wp_viewport_set_destination(viewport, logicalWidth, logicalHeight)
+    }
+
+    /**
+     * Non-blocking event pump for the owner's main loop: dispatches queued events, flushes
+     * requests, and reads whatever the compositor has already sent, per libwayland's
+     * `prepare_read`/`read_events` contract.
+     */
+    fun dispatchPendingEvents() {
+        while (wl_display_prepare_read(display) != 0) {
+            wl_display_dispatch_pending(display)
+        }
+        wl_display_flush(display)
+        memScoped {
+            val fds = alloc<pollfd>().apply {
+                fd = wl_display_get_fd(display)
+                events = POLLIN.toShort()
+            }
+            if (poll(fds.ptr, 1.convert(), 0) > 0) {
+                wl_display_read_events(display)
+            } else {
+                wl_display_cancel_read(display)
+            }
+        }
+        wl_display_dispatch_pending(display)
+    }
+
+    override fun frameCallback(onFrame: () -> Unit) {
+        pendingFrame = onFrame
+        val callback = wl_surface_frame(surface) ?: return
+        wl_callback_add_listener(callback, frameListener.ptr, self.asCPointer())
+        // The frame request rides the next commit (the eglSwapBuffers that follows).
+    }
+
+    private fun fireFrame() {
+        pendingFrame?.also { pendingFrame = null }?.invoke()
+    }
+
+    override fun show() {
+        wl_surface_commit(surface)
+        wl_display_flush(display)
+    }
+
+    override fun close() {
+        pendingFrame = null
+        fractionalScale?.let { wp_fractional_scale_v1_destroy(it) }
+        viewport?.let { wp_viewport_destroy(it) }
+        xdg_toplevel_destroy(toplevel)
+        xdg_surface_destroy(xdgSurface)
+        wl_surface_destroy(surface)
+        wl_display_disconnect(display)
+        arena.clear()
+        self.dispose()
+    }
+
+    override fun createGlContext(): LinuxGlContext = WaylandEglContext(this)
+}

--- a/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/X11GlContext.kt
+++ b/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/X11GlContext.kt
@@ -3,29 +3,33 @@ package org.jetbrains.skiko
 import kotlinx.cinterop.*
 import x11gl.*
 
-class GlContext(private val win: X11Window) {
-    private val context: GLXContext = glXCreateContext(win.display, win.visualInfo, null, 1)
-        ?: throw RenderSetupException("glXCreateContext failed")
+internal class X11GlContext(
+    private val win: X11Window,
+) : LinuxGlContext {
+    private val context: GLXContext =
+        glXCreateContext(win.display, win.visualInfo, null, 1)
+            ?: throw RenderSetupException("glXCreateContext failed")
 
-    fun makeCurrent() {
+    override fun makeCurrent() {
         if (glXMakeCurrent(win.display, win.window, context) == 0) {
             throw RenderSetupException("glXMakeCurrent failed")
         }
     }
 
-    fun swapBuffers() {
+    override fun swapBuffers() {
         glXSwapBuffers(win.display, win.window)
     }
 
-    fun setSwapInterval(interval: Int) {
-        val proc = memScoped {
-            glXGetProcAddressARB("glXSwapIntervalEXT".cstr.ptr.reinterpret())
-        } ?: return
+    override fun setSwapInterval(interval: Int) {
+        val proc =
+            memScoped {
+                glXGetProcAddressARB("glXSwapIntervalEXT".cstr.ptr.reinterpret())
+            } ?: return
         val swapIntervalExt = proc.reinterpret<CFunction<(CPointer<Display>?, GLXDrawable, Int) -> Unit>>()
         swapIntervalExt(win.display, win.window, interval)
     }
 
-    fun close() {
+    override fun close() {
         glXMakeCurrent(win.display, 0uL, null)
         glXDestroyContext(win.display, context)
     }

--- a/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/X11Window.kt
+++ b/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/X11Window.kt
@@ -1,0 +1,80 @@
+package org.jetbrains.skiko
+
+import kotlinx.cinterop.*
+import x11gl.*
+
+class X11Window(title: String, width: Int, height: Int) {
+    private val arena = Arena()
+
+    val display: CPointer<Display> = XOpenDisplay(null)
+        ?: throw RenderSetupException("Cannot open X11 display; is DISPLAY set?")
+    val screen: Int = XDefaultScreen(display)
+
+    val visualInfo: CPointer<XVisualInfo> = chooseVisual()
+        ?: throw RenderSetupException("No GLX visual with RGBA + double buffer + stencil")
+
+    val window: Window
+    val wmDeleteWindow: Atom
+
+    var width: Int = width
+    var height: Int = height
+
+    val contentScale: Float = readXftDpi()?.let { it / 96f } ?: 1f
+
+    init {
+        val root = XRootWindow(display, screen)
+        val visual = visualInfo.pointed.visual
+        val colormap = XCreateColormap(display, root, visual, AllocNone)
+
+        val attrs = arena.alloc<XSetWindowAttributes>().apply {
+            this.colormap = colormap
+            border_pixel = 0uL
+            event_mask = ExposureMask or StructureNotifyMask or
+                ButtonPressMask or ButtonReleaseMask or PointerMotionMask or
+                KeyPressMask or KeyReleaseMask
+        }
+        window = XCreateWindow(
+            display, root,
+            0, 0, width.toUInt(), height.toUInt(),
+            0u, visualInfo.pointed.depth, InputOutput.toUInt(), visual,
+            (CWColormap or CWBorderPixel or CWEventMask).toULong(), attrs.ptr,
+        )
+        XStoreName(display, window, title)
+
+        wmDeleteWindow = XInternAtom(display, "WM_DELETE_WINDOW", 0)
+        val protocols = arena.alloc<AtomVar>().apply { value = wmDeleteWindow }
+        XSetWMProtocols(display, window, protocols.ptr, 1)
+    }
+
+    private fun chooseVisual(): CPointer<XVisualInfo>? = memScoped {
+        val attribList = intArrayOf(
+            GLX_RGBA,
+            GLX_DOUBLEBUFFER,
+            GLX_DEPTH_SIZE, 24,
+            GLX_STENCIL_SIZE, 8,
+            None.toInt(),
+        )
+        glXChooseVisual(display, screen, attribList.toCValues().ptr)
+    }
+
+    private fun readXftDpi(): Float? = XResourceManagerString(display)
+        ?.toKString()
+        ?.lineSequence()
+        ?.firstOrNull { it.startsWith("Xft.dpi:") }
+        ?.substringAfter(':')
+        ?.trim()
+        ?.toFloatOrNull()
+
+    fun show() {
+        XMapWindow(display, window)
+        XFlush(display)
+    }
+
+    fun close() {
+        XDestroyWindow(display, window)
+        XCloseDisplay(display)
+        arena.clear()
+    }
+}
+
+class RenderSetupException(message: String) : RuntimeException(message)

--- a/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/X11Window.kt
+++ b/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/X11Window.kt
@@ -22,40 +22,45 @@ class X11Window(
     val window: Window
     val wmDeleteWindow: Atom
 
+    /**
+     * Scale factor derived from `Xft.dpi` (96 dpi = 1.0). X11 has no per-window backing
+     * scale: all geometry in this class is physical pixels. This factor converts the
+     * logical size requested by the constructor and feeds the UI density upstream.
+     */
     override val contentScale: Float = readXftDpi()?.let { it / 96f } ?: 1f
 
-    override var width: Int = width
+    /** Current width in physical pixels; the constructor argument is in logical units. */
+    override var width: Int = (width * contentScale).toInt()
 
-    override var height: Int = height
+    /** Current height in physical pixels; the constructor argument is in logical units. */
+    override var height: Int = (height * contentScale).toInt()
 
     init {
         val root = XRootWindow(display, screen)
         val visual = visualInfo.pointed.visual
         val colormap = XCreateColormap(display, root, visual, AllocNone)
 
-        val attrs =
-            arena.alloc<XSetWindowAttributes>().apply {
-                this.colormap = colormap
-                border_pixel = 0uL
-                event_mask = ExposureMask or StructureNotifyMask or
-                    ButtonPressMask or ButtonReleaseMask or PointerMotionMask or
-                    KeyPressMask or KeyReleaseMask
-            }
-        window =
-            XCreateWindow(
-                display,
-                root,
-                0,
-                0,
-                this.width.toUInt(),
-                this.height.toUInt(),
-                0u,
-                visualInfo.pointed.depth,
-                InputOutput.toUInt(),
-                visual,
-                (CWColormap or CWBorderPixel or CWEventMask).toULong(),
-                attrs.ptr,
-            )
+        val attrs = arena.alloc<XSetWindowAttributes>().apply {
+            this.colormap = colormap
+            border_pixel = 0uL
+            event_mask = ExposureMask or StructureNotifyMask or
+                ButtonPressMask or ButtonReleaseMask or PointerMotionMask or
+                KeyPressMask or KeyReleaseMask
+        }
+        window = XCreateWindow(
+            display,
+            root,
+            0,
+            0,
+            this.width.toUInt(),
+            this.height.toUInt(),
+            0u,
+            visualInfo.pointed.depth,
+            InputOutput.toUInt(),
+            visual,
+            (CWColormap or CWBorderPixel or CWEventMask).toULong(),
+            attrs.ptr,
+        )
         XStoreName(display, window, title)
 
         wmDeleteWindow = XInternAtom(display, "WM_DELETE_WINDOW", 0)
@@ -63,29 +68,26 @@ class X11Window(
         XSetWMProtocols(display, window, protocols.ptr, 1)
     }
 
-    private fun chooseVisual(): CPointer<XVisualInfo>? =
-        memScoped {
-            val attribList =
-                intArrayOf(
-                    GLX_RGBA,
-                    GLX_DOUBLEBUFFER,
-                    GLX_DEPTH_SIZE,
-                    24,
-                    GLX_STENCIL_SIZE,
-                    8,
-                    None.toInt(),
-                )
-            glXChooseVisual(display, screen, attribList.toCValues().ptr)
-        }
+    private fun chooseVisual(): CPointer<XVisualInfo>? = memScoped {
+        val attribList = intArrayOf(
+            GLX_RGBA,
+            GLX_DOUBLEBUFFER,
+            GLX_DEPTH_SIZE,
+            24,
+            GLX_STENCIL_SIZE,
+            8,
+            None.toInt(),
+        )
+        glXChooseVisual(display, screen, attribList.toCValues().ptr)
+    }
 
-    private fun readXftDpi(): Float? =
-        XResourceManagerString(display)
-            ?.toKString()
-            ?.lineSequence()
-            ?.firstOrNull { it.startsWith("Xft.dpi:") }
-            ?.substringAfter(':')
-            ?.trim()
-            ?.toFloatOrNull()
+    private fun readXftDpi(): Float? = XResourceManagerString(display)
+        ?.toKString()
+        ?.lineSequence()
+        ?.firstOrNull { it.startsWith("Xft.dpi:") }
+        ?.substringAfter(':')
+        ?.trim()
+        ?.toFloatOrNull()
 
     override fun show() {
         XMapWindow(display, window)

--- a/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/X11Window.kt
+++ b/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/X11Window.kt
@@ -3,42 +3,59 @@ package org.jetbrains.skiko
 import kotlinx.cinterop.*
 import x11gl.*
 
-class X11Window(title: String, width: Int, height: Int) {
+class X11Window(
+    title: String,
+    width: Int,
+    height: Int,
+) : LinuxWindow {
     private val arena = Arena()
 
-    val display: CPointer<Display> = XOpenDisplay(null)
-        ?: throw RenderSetupException("Cannot open X11 display; is DISPLAY set?")
+    val display: CPointer<Display> =
+        XOpenDisplay(null)
+            ?: throw RenderSetupException("Cannot open X11 display; is DISPLAY set?")
     val screen: Int = XDefaultScreen(display)
 
-    val visualInfo: CPointer<XVisualInfo> = chooseVisual()
-        ?: throw RenderSetupException("No GLX visual with RGBA + double buffer + stencil")
+    val visualInfo: CPointer<XVisualInfo> =
+        chooseVisual()
+            ?: throw RenderSetupException("No GLX visual with RGBA + double buffer + stencil")
 
     val window: Window
     val wmDeleteWindow: Atom
 
-    var width: Int = width
-    var height: Int = height
+    override val contentScale: Float = readXftDpi()?.let { it / 96f } ?: 1f
 
-    val contentScale: Float = readXftDpi()?.let { it / 96f } ?: 1f
+    override var width: Int = width
+
+    override var height: Int = height
 
     init {
         val root = XRootWindow(display, screen)
         val visual = visualInfo.pointed.visual
         val colormap = XCreateColormap(display, root, visual, AllocNone)
 
-        val attrs = arena.alloc<XSetWindowAttributes>().apply {
-            this.colormap = colormap
-            border_pixel = 0uL
-            event_mask = ExposureMask or StructureNotifyMask or
-                ButtonPressMask or ButtonReleaseMask or PointerMotionMask or
-                KeyPressMask or KeyReleaseMask
-        }
-        window = XCreateWindow(
-            display, root,
-            0, 0, width.toUInt(), height.toUInt(),
-            0u, visualInfo.pointed.depth, InputOutput.toUInt(), visual,
-            (CWColormap or CWBorderPixel or CWEventMask).toULong(), attrs.ptr,
-        )
+        val attrs =
+            arena.alloc<XSetWindowAttributes>().apply {
+                this.colormap = colormap
+                border_pixel = 0uL
+                event_mask = ExposureMask or StructureNotifyMask or
+                    ButtonPressMask or ButtonReleaseMask or PointerMotionMask or
+                    KeyPressMask or KeyReleaseMask
+            }
+        window =
+            XCreateWindow(
+                display,
+                root,
+                0,
+                0,
+                this.width.toUInt(),
+                this.height.toUInt(),
+                0u,
+                visualInfo.pointed.depth,
+                InputOutput.toUInt(),
+                visual,
+                (CWColormap or CWBorderPixel or CWEventMask).toULong(),
+                attrs.ptr,
+            )
         XStoreName(display, window, title)
 
         wmDeleteWindow = XInternAtom(display, "WM_DELETE_WINDOW", 0)
@@ -46,35 +63,44 @@ class X11Window(title: String, width: Int, height: Int) {
         XSetWMProtocols(display, window, protocols.ptr, 1)
     }
 
-    private fun chooseVisual(): CPointer<XVisualInfo>? = memScoped {
-        val attribList = intArrayOf(
-            GLX_RGBA,
-            GLX_DOUBLEBUFFER,
-            GLX_DEPTH_SIZE, 24,
-            GLX_STENCIL_SIZE, 8,
-            None.toInt(),
-        )
-        glXChooseVisual(display, screen, attribList.toCValues().ptr)
-    }
+    private fun chooseVisual(): CPointer<XVisualInfo>? =
+        memScoped {
+            val attribList =
+                intArrayOf(
+                    GLX_RGBA,
+                    GLX_DOUBLEBUFFER,
+                    GLX_DEPTH_SIZE,
+                    24,
+                    GLX_STENCIL_SIZE,
+                    8,
+                    None.toInt(),
+                )
+            glXChooseVisual(display, screen, attribList.toCValues().ptr)
+        }
 
-    private fun readXftDpi(): Float? = XResourceManagerString(display)
-        ?.toKString()
-        ?.lineSequence()
-        ?.firstOrNull { it.startsWith("Xft.dpi:") }
-        ?.substringAfter(':')
-        ?.trim()
-        ?.toFloatOrNull()
+    private fun readXftDpi(): Float? =
+        XResourceManagerString(display)
+            ?.toKString()
+            ?.lineSequence()
+            ?.firstOrNull { it.startsWith("Xft.dpi:") }
+            ?.substringAfter(':')
+            ?.trim()
+            ?.toFloatOrNull()
 
-    fun show() {
+    override fun show() {
         XMapWindow(display, window)
         XFlush(display)
     }
 
-    fun close() {
+    override fun close() {
         XDestroyWindow(display, window)
         XCloseDisplay(display)
         arena.clear()
     }
+
+    override fun createGlContext(): LinuxGlContext = X11GlContext(this)
 }
 
-class RenderSetupException(message: String) : RuntimeException(message)
+class RenderSetupException(
+    message: String,
+) : RuntimeException(message)

--- a/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/context/OpenGLContextHandler.linux.kt
+++ b/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/context/OpenGLContextHandler.linux.kt
@@ -1,0 +1,59 @@
+package org.jetbrains.skiko.context
+
+import kotlinx.cinterop.*
+import org.jetbrains.skia.*
+import org.jetbrains.skiko.LayerDrawScope
+import org.jetbrains.skiko.RenderException
+import org.jetbrains.skiko.SkiaLayer
+
+internal class LinuxOpenGLContextHandler(layer: SkiaLayer) : ContextHandler(layer, layer::draw) {
+    override fun initContext(): Boolean {
+        try {
+            if (context == null) {
+                context = DirectContext.makeGL()
+            }
+        } catch (_: Exception) {
+            println("Failed to create Skia OpenGL context!")
+            return false
+        }
+        return true
+    }
+
+    private var currentWidth = 0
+    private var currentHeight = 0
+    private fun isSizeChanged(width: Int, height: Int): Boolean {
+        if (width != currentWidth || height != currentHeight) {
+            currentWidth = width
+            currentHeight = height
+            return true
+        }
+        return false
+    }
+
+    override fun LayerDrawScope.initCanvas() {
+        val w = scaledLayerWidth
+        val h = scaledLayerHeight
+        if (isSizeChanged(w, h)) {
+            disposeCanvas()
+            renderTarget = BackendRenderTarget.makeGL(
+                w,
+                h,
+                0,
+                8,
+                0, // fbId = 0 (default framebuffer)
+                FramebufferFormat.GR_GL_RGBA8
+            )
+            surface = Surface.makeFromBackendRenderTarget(
+                context!!,
+                renderTarget!!,
+                SurfaceOrigin.BOTTOM_LEFT,
+                SurfaceColorFormat.RGBA_8888,
+                ColorSpace.sRGB,
+                SurfaceProps(pixelGeometry = layer.pixelGeometry)
+            ) ?: throw RenderException("Cannot create surface")
+
+            canvas = surface?.canvas
+                ?: error("Could not obtain Canvas from Surface")
+        }
+    }
+}

--- a/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/context/OpenGLContextHandler.linux.kt
+++ b/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/context/OpenGLContextHandler.linux.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.skiko.context
 
-import kotlinx.cinterop.*
 import org.jetbrains.skia.*
 import org.jetbrains.skiko.LayerDrawScope
 import org.jetbrains.skiko.RenderException
@@ -17,6 +16,15 @@ internal class LinuxOpenGLContextHandler(layer: SkiaLayer) : ContextHandler(laye
             return false
         }
         return true
+    }
+
+    override fun flush(scope: LayerDrawScope) {
+        val s = surface
+        if (s != null) {
+            context?.flush(s)
+        } else {
+            super.flush(scope)
+        }
     }
 
     private var currentWidth = 0

--- a/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/redrawer/LinuxOpenGLRedrawer.kt
+++ b/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/redrawer/LinuxOpenGLRedrawer.kt
@@ -1,27 +1,30 @@
 package org.jetbrains.skiko.redrawer
 
-import kotlinx.coroutines.*
-import org.jetbrains.skiko.*
+import org.jetbrains.skiko.FrameDispatcher
+import org.jetbrains.skiko.SkiaLayer
+import org.jetbrains.skiko.SkikoDispatchers
 import org.jetbrains.skiko.context.LinuxOpenGLContextHandler
 import kotlin.time.TimeSource
 
 internal class LinuxOpenGLRedrawer(
-    private val skiaLayer: SkiaLayer
+    private val skiaLayer: SkiaLayer,
 ) : Redrawer {
     private val contextHandler = LinuxOpenGLContextHandler(skiaLayer)
     override val renderInfo: String get() = contextHandler.rendererInfo()
 
     private val win = skiaLayer.window
-    private val gl = GlContext(win).apply {
-        makeCurrent()
-        setSwapInterval(1) // Vsync enabled
-    }
+    private val gl =
+        win.createGlContext().apply {
+            makeCurrent()
+            setSwapInterval(1) // Vsync enabled
+        }
 
     private val initialTime = TimeSource.Monotonic.markNow()
 
-    private val frameDispatcher = FrameDispatcher(SkikoDispatchers.Main) {
-        renderImmediately()
-    }
+    private val frameDispatcher =
+        FrameDispatcher(SkikoDispatchers.Main) {
+            renderImmediately()
+        }
 
     override fun dispose() {
         frameDispatcher.cancel()

--- a/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/redrawer/LinuxOpenGLRedrawer.kt
+++ b/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/redrawer/LinuxOpenGLRedrawer.kt
@@ -1,0 +1,51 @@
+package org.jetbrains.skiko.redrawer
+
+import kotlinx.coroutines.*
+import org.jetbrains.skiko.*
+import org.jetbrains.skiko.context.LinuxOpenGLContextHandler
+import kotlin.time.TimeSource
+
+internal class LinuxOpenGLRedrawer(
+    private val skiaLayer: SkiaLayer
+) : Redrawer {
+    private val contextHandler = LinuxOpenGLContextHandler(skiaLayer)
+    override val renderInfo: String get() = contextHandler.rendererInfo()
+
+    private val win = skiaLayer.window
+    private val gl = GlContext(win).apply {
+        makeCurrent()
+        setSwapInterval(1) // Vsync enabled
+    }
+
+    private val initialTime = TimeSource.Monotonic.markNow()
+
+    private val frameDispatcher = FrameDispatcher(SkikoDispatchers.Main) {
+        renderImmediately()
+    }
+
+    override fun dispose() {
+        frameDispatcher.cancel()
+        gl.makeCurrent()
+        contextHandler.dispose()
+        gl.close()
+    }
+
+    override fun needRender(throttledToVsync: Boolean) {
+        frameDispatcher.scheduleFrame()
+    }
+
+    override fun update(nanoTime: Long) {
+        skiaLayer.update(nanoTime)
+    }
+
+    override fun renderImmediately() {
+        gl.makeCurrent()
+        skiaLayer.update(initialTime.elapsedNow().inWholeNanoseconds)
+        skiaLayer.inDrawScope {
+            contextHandler.draw()
+        }
+        gl.swapBuffers()
+    }
+
+    override fun isTransparentBackgroundSupported() = false
+}

--- a/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/redrawer/LinuxOpenGLRedrawer.kt
+++ b/skiko/src/linuxMain/kotlin/org/jetbrains/skiko/redrawer/LinuxOpenGLRedrawer.kt
@@ -47,6 +47,9 @@ internal class LinuxOpenGLRedrawer(
         skiaLayer.inDrawScope {
             contextHandler.draw()
         }
+        // Requested before the swap because the frame request rides the commit that
+        // swapBuffers performs. No-op on X11, which paces via vsync-throttled swaps.
+        win.frameCallback { needRender(throttledToVsync = true) }
         gl.swapBuffers()
     }
 

--- a/skiko/src/nativeInterop/cinterop/x11gl.def
+++ b/skiko/src/nativeInterop/cinterop/x11gl.def
@@ -1,0 +1,9 @@
+headers = X11/Xlib.h X11/Xutil.h X11/Xatom.h X11/XKBlib.h X11/keysym.h GL/gl.h GL/glx.h
+# X11/GL headers are not part of the Konan sysroot; take them from the host via
+# -idirafter so the sysroot's per-arch glibc headers keep priority (a plain -I
+# breaks cross-compilation to linux_arm64 by shadowing glibc with host headers).
+compilerOpts.linux = -D_GNU_SOURCE -idirafter /usr/include
+compilerOpts.linux_x64 = -idirafter /usr/include/x86_64-linux-gnu
+compilerOpts.linux_arm64 = -idirafter /usr/include/aarch64-linux-gnu
+linkerOpts.linux_x64 = -L/usr/lib/x86_64-linux-gnu -lX11 -lGL -lfontconfig -lfreetype
+linkerOpts.linux_arm64 = -L/usr/lib/aarch64-linux-gnu -lX11 -lGL -lfontconfig -lfreetype

--- a/skiko/src/nativeInterop/cinterop/x11gl.def
+++ b/skiko/src/nativeInterop/cinterop/x11gl.def
@@ -5,5 +5,9 @@ headers = X11/Xlib.h X11/Xutil.h X11/Xatom.h X11/XKBlib.h X11/keysym.h GL/gl.h G
 compilerOpts.linux = -D_GNU_SOURCE -idirafter /usr/include
 compilerOpts.linux_x64 = -idirafter /usr/include/x86_64-linux-gnu
 compilerOpts.linux_arm64 = -idirafter /usr/include/aarch64-linux-gnu
-linkerOpts.linux_x64 = -L/usr/lib/x86_64-linux-gnu -lX11 -lGL -lfontconfig -lfreetype
-linkerOpts.linux_arm64 = -L/usr/lib/aarch64-linux-gnu -lX11 -lGL -lfontconfig -lfreetype
+# No -lfreetype here: skia's Linux archives bundle freetype statically, and linking
+# the shared library instead keeps those members out of the binary, which breaks the
+# --version-script link (its generated symbols.map marks every FT_* symbol local, and
+# lld rejects version-script entries for symbols the binary does not define).
+linkerOpts.linux_x64 = -L/usr/lib/x86_64-linux-gnu -lX11 -lGL -lfontconfig
+linkerOpts.linux_arm64 = -L/usr/lib/aarch64-linux-gnu -lX11 -lGL -lfontconfig

--- a/skiko/src/nativeInterop/cinterop/x11gl.def
+++ b/skiko/src/nativeInterop/cinterop/x11gl.def
@@ -9,5 +9,8 @@ compilerOpts.linux_arm64 = -idirafter /usr/include/aarch64-linux-gnu
 # the shared library instead keeps those members out of the binary, which breaks the
 # --version-script link (its generated symbols.map marks every FT_* symbol local, and
 # lld rejects version-script entries for symbols the binary does not define).
-linkerOpts.linux_x64 = -L/usr/lib/x86_64-linux-gnu -lX11 -lGL -lfontconfig
+# -L/usr/lib lets the same def link on distros without Debian multiarch (Arch,
+# Fedora); the multiarch dir stays first for the Ubuntu CI image. x64 only: adding
+# it under linux_arm64 would leak host x64 libs into the arm64 cross-link.
+linkerOpts.linux_x64 = -L/usr/lib/x86_64-linux-gnu -L/usr/lib -lX11 -lGL -lfontconfig
 linkerOpts.linux_arm64 = -L/usr/lib/aarch64-linux-gnu -lX11 -lGL -lfontconfig

--- a/skiko/src/nativeInterop/cinterop/xkbcommon.def
+++ b/skiko/src/nativeInterop/cinterop/xkbcommon.def
@@ -5,5 +5,8 @@ headers = xkbcommon/xkbcommon.h
 compilerOpts.linux = -D_GNU_SOURCE -idirafter /usr/include
 compilerOpts.linux_x64 = -idirafter /usr/include/x86_64-linux-gnu
 compilerOpts.linux_arm64 = -idirafter /usr/include/aarch64-linux-gnu
-linkerOpts.linux_x64 = -L/usr/lib/x86_64-linux-gnu -lxkbcommon
+# -L/usr/lib lets the same def link on distros without Debian multiarch (Arch,
+# Fedora); the multiarch dir stays first for the Ubuntu CI image. x64 only: adding
+# it under linux_arm64 would leak host x64 libs into the arm64 cross-link.
+linkerOpts.linux_x64 = -L/usr/lib/x86_64-linux-gnu -L/usr/lib -lxkbcommon
 linkerOpts.linux_arm64 = -L/usr/lib/aarch64-linux-gnu -lxkbcommon

--- a/skiko/src/nativeInterop/cinterop/xkbcommon.def
+++ b/skiko/src/nativeInterop/cinterop/xkbcommon.def
@@ -1,0 +1,9 @@
+headers = xkbcommon/xkbcommon.h
+# xkbcommon headers are not part of the Konan sysroot; take them from the host via
+# -idirafter so the sysroot's per-arch glibc headers keep priority (a plain -I
+# breaks cross-compilation to linux_arm64 by shadowing glibc with host headers).
+compilerOpts.linux = -D_GNU_SOURCE -idirafter /usr/include
+compilerOpts.linux_x64 = -idirafter /usr/include/x86_64-linux-gnu
+compilerOpts.linux_arm64 = -idirafter /usr/include/aarch64-linux-gnu
+linkerOpts.linux_x64 = -L/usr/lib/x86_64-linux-gnu -lxkbcommon
+linkerOpts.linux_arm64 = -L/usr/lib/aarch64-linux-gnu -lxkbcommon

--- a/skiko/src/nativeJsMain/cpp/DirectContext.cc
+++ b/skiko/src/nativeJsMain/cpp/DirectContext.cc
@@ -1,5 +1,6 @@
 #include "ganesh/GrDirectContext.h"
 #include "ganesh/gl/GrGLInterface.h"
+#include "ganesh/gl/GrGLAssembleInterface.h"
 #include "common.h"
 #include "ganesh/gl/GrGLDirectContext.h" // TODO: skia update: check if it's correct
 
@@ -13,8 +14,31 @@
 #include "ganesh/d3d/GrD3DDirectContext.h"
 #endif
 
+#ifdef __linux__
+#include <EGL/egl.h>
+#include <dlfcn.h>
+#endif
+
 SKIKO_EXPORT KNativePointer org_jetbrains_skia_DirectContext__1nMakeGL
   () {
+#ifdef __linux__
+    EGLContext eglCtx = eglGetCurrentContext();
+    if (eglCtx != EGL_NO_CONTEXT) {
+        sk_sp<const GrGLInterface> glInterface = GrGLMakeAssembledInterface(
+            nullptr,
+            [](void* ctx, const char name[]) -> GrGLFuncPtr {
+                GrGLFuncPtr proc = (GrGLFuncPtr) eglGetProcAddress(name);
+                if (!proc) {
+                    proc = (GrGLFuncPtr) dlsym(RTLD_DEFAULT, name);
+                }
+                return proc;
+            }
+        );
+        if (glInterface) {
+            return static_cast<KNativePointer>(GrDirectContexts::MakeGL(glInterface).release());
+        }
+    }
+#endif
     return static_cast<KNativePointer>(GrDirectContexts::MakeGL().release());
 }
 

--- a/skiko/test-utils/build.gradle.kts
+++ b/skiko/test-utils/build.gradle.kts
@@ -65,7 +65,9 @@ kotlin {
         macosX64()
         macosArm64()
     }
-    if (supportNativeLinux) {
+    // Host-gated like skiko itself: the Linux targets' custom cinterops only process on
+    // Linux hosts, and skiko publishes no Linux variants from other hosts to resolve.
+    if (supportNativeLinux && hostOs.isLinux) {
         linuxX64()
         linuxArm64()
     }


### PR DESCRIPTION
### Summary

Implements `SkiaLayer` for the native Linux targets (`linuxX64`, `linuxArm64`), replacing the TODO stubs in `SkiaLayer.linux.kt`. Rendering goes through a small windowing seam (`LinuxWindow`, `LinuxGlContext`) with two backends: Wayland/EGL as the primary path and X11/GLX for X-only environments. Review feedback on the companion Compose PR (compose-multiplatform-core#3189) asked that new Linux windowing not assume one display server; the seam keeps everything above it compositor-agnostic.

### Windowing seam

`SkiaLayer`, the GL context handler, and the redrawer talk only to `LinuxWindow`/`LinuxGlContext`. Backend selection is the consumer's: construct a `WaylandWindow` or an `X11Window` and attach the layer.

### Wayland/EGL backend

- `WaylandWindow`: xdg-shell toplevel. HiDPI uses `fractional-scale-v1` plus `viewporter`, falling back to the `wl_output` integer scale. Server-side decorations are requested through `xdg-decoration` where the compositor advertises the manager (KWin does; GNOME does not, so the window stays borderless there until a libdecor fallback lands). Frames are compositor-paced via `wl_callback`; close arrives as `xdg_toplevel.close`.
- `WaylandEglContext`: EGL context creation and buffer swap.
- `display` and `surface` are public with a documented ownership contract, so the Compose event pump can bind `wl_seat` and friends off the same connection without owning either object.

### X11/GLX backend

`X11Window` selects a double-buffered GLX visual, handles `WM_DELETE_WINDOW`, and reads scale from `Xft.dpi`; `GlContext` drives vsync through `glXSwapIntervalEXT`. `LinuxMainDispatcher` is a mutex-guarded work queue drained from the host event loop, since Kotlin/Native has no `Dispatchers.Main` on Linux.

### Build and cinterop

Three cinterops: `x11gl`, `waylandegl`, and `xkbcommon`. The `waylandegl` def file is generated per target because its include path points at build-time protocol codegen output. Protocol client code is generated with `wayland-scanner` from the system `wayland-protocols` for: xdg-shell, viewporter, fractional-scale-v1, xdg-decoration-unstable-v1, cursor-shape-v1 (plus tablet-v2, which its generated code references), and text-input-unstable-v3. The last three, like the xkbcommon klib, have no consumer inside skiko; they are published for the Compose event pump.

Host headers are added with `-idirafter` so the Konan sysroot's per-arch glibc headers keep priority when cross-compiling to `linuxArm64`. When `/opt/arm-gnu-toolchain` is absent, the build falls back to a distro `aarch64-linux-gnu-g++`.

### CI changes that need reviewer attention

1. Linux native targets are now registered only on Linux hosts (`build.gradle.kts`).
2. The Linux publish dry run drops `-Pskiko.native.enabled` in the `linux-compat` image. Cinterop tasks cannot run there: Konan's bundled libclang needs `GLIBC_2.29` and the image ships glibc 2.26 by design. The following step in `linux-amd64` already publishes both native targets.
3. The docs job moves to `linux-amd64` for the same reason.
4. The `linux-amd64` image gains `libwayland-dev`, `libegl1-mesa-dev`, `libxkbcommon-dev` (host and arm64) and vendors wayland-protocols 1.45 from the release tarball, because focal packages 1.20 and fractional-scale-v1 first shipped in 1.31.
5. `x11gl.def` no longer links `-lfreetype`. Skia's Linux archives bundle freetype statically; with the shared library on the link line those members never entered the test binary, and lld rejected the generated version script's `local: FT_*` entries as undefined. This is what failed `linkDebugTestLinuxArm64` in the previous CI run.

### Verification

- KDE Plasma Wayland session (KWin): a raw-`SkiaLayer` demo renders compositor-paced, gets a KWin titlebar through xdg-decoration, follows a compositor-driven resize from 800x600 to 1100x750, and exits 0 on close.
- X11 backend on the same machine via Xwayland: renders and exits 0 on `WM_DELETE_WINDOW`.
- `linkDebugTestLinuxArm64` (cross-compiled from x64) links against the same ARM GNU toolchain 10.3-2021.07 and focal arm64 libraries the CI image uses.
- `compileKotlinLinuxX64` and `compileKotlinLinuxArm64` are green; both native publications build to mavenLocal.