### PR TITLE
Remove extra `layer.inDrawScope` call in AngleRedrawer.kt

### DIFF
--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/AngleRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/AngleRedrawer.kt
@@ -84,14 +84,12 @@ internal class AngleRedrawer(
         }
     }
 
-    private fun drawAndSwap(withVsync: Boolean) = synchronized(drawLock) {
+    private fun LayerDrawScope.drawAndSwap(withVsync: Boolean) = synchronized(drawLock) {
         if (isDisposed) {
             return
         }
         makeCurrent(device)
-        layer.inDrawScope {
-            contextHandler.draw()
-        }
+        contextHandler.draw()
         swapBuffers(device, withVsync)
     }
 


### PR DESCRIPTION
`AngleRedrawer.drawAndSwap` is already always wrapped in `AwtRedrawer.inDrawScope`, which calls `SkiaLayer.inDrawScope`.