### PR TITLE
Apply `RenderNode.alpha` during draw

### DIFF
--- a/skiko/src/commonMain/cpp/common/node/RenderNode.cpp
+++ b/skiko/src/commonMain/cpp/common/node/RenderNode.cpp
@@ -1,5 +1,6 @@
 #include <SkNWayCanvas.h>
 #include <SkPathBuilder.h>
+#include <SkPaintFilterCanvas.h>
 #include <SkPicture.h>
 #include <SkShadowUtils.h>
 #include "node/RenderNode.h"
@@ -54,6 +55,25 @@ protected:
     void onDrawDrawable(SkDrawable* drawable, const SkMatrix* matrix) override {
         drawable->draw(this, matrix);
     }
+};
+
+class AlphaModulateFilterCanvas : public SkPaintFilterCanvas {
+public:
+    AlphaModulateFilterCanvas(SkCanvas* canvas, float alpha)
+        : SkPaintFilterCanvas(canvas), alpha(alpha) {}
+
+protected:
+    bool onFilter(SkPaint& paint) const override {
+        paint.setAlphaf(paint.getAlphaf() * alpha);
+        return true;
+    }
+
+    void onDrawDrawable(SkDrawable* drawable, const SkMatrix* matrix) override {
+        drawable->draw(this, matrix);
+    }
+
+private:
+    float alpha;
 };
 
 RenderNode::RenderNode(const sk_sp<RenderNodeContext>& context)
@@ -252,7 +272,12 @@ void RenderNode::onDraw(SkCanvas* canvas) {
         canvas->save();
     }
 
-    canvas->drawDrawable(this->contentCache.get());
+    if (this->alpha < 1.0f && !this->layerPaint) {
+        AlphaModulateFilterCanvas alphaCanvas(canvas, this->alpha);
+        alphaCanvas.drawDrawable(this->contentCache.get());
+    } else {
+        canvas->drawDrawable(this->contentCache.get());
+    }
 }
 
 SkRect RenderNode::onGetBounds() {

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skiko/node/RenderNode.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skiko/node/RenderNode.kt
@@ -28,6 +28,14 @@ class RenderNode internal constructor(ptr: NativePointer, managed: Boolean = tru
         Stats.onNativeCall()
     }
 
+    /**
+     * Optional paint used when compositing this RenderNode into an offscreen layer.
+     *
+     * When set, the paint alpha is applied to the composited layer content and therefore
+     * overrides [alpha] for content rendering semantics.
+     *
+     * This does not affect shadow opacity: shadows are still modulated by [alpha].
+     */
     var layerPaint: Paint?
         get() = try {
             Stats.onNativeCall()
@@ -73,6 +81,14 @@ class RenderNode internal constructor(ptr: NativePointer, managed: Boolean = tru
             reachabilityBarrier(this)
         }
 
+    /**
+     * Alpha multiplier for this RenderNode.
+     *
+     * When [layerPaint] is null, this alpha is applied during content replay. When [layerPaint]
+     * is set, content alpha is taken from [layerPaint] instead.
+     *
+     * Shadow opacity is always modulated by this alpha, regardless of [layerPaint].
+     */
     var alpha: Float
         get() = try {
             Stats.onNativeCall()


### PR DESCRIPTION
Copies HWUI approach: https://android.googlesource.com/platform/frameworks/base/+/1cdfff555f4a21f71ccc978290e2e212e2f8b168/libs/hwui/pipeline/skia/RenderNodeDrawable.cpp#200
Required to fix [CMP-10436](https://youtrack.jetbrains.com/issue/CMP-10436) [skiko/iOS] CompositingStrategy.ModulateAlpha bakes alpha into the recorded picture at record time; animating alpha leaves content invisible until next content invalidation

We have behavioral tests are only on compose side, so it's not included here 😢 