### PR TITLE
Reduce binary size using dead-code stripping compile/link flags for windows, linux and android

### DIFF
--- a/skiko/buildSrc/src/main/kotlin/properties.kt
+++ b/skiko/buildSrc/src/main/kotlin/properties.kt
@@ -93,8 +93,8 @@ enum class SkiaBuildType(
         id = "Release",
         flags = arrayOf("-DNDEBUG"),
         clangFlags = arrayOf("-std=c++2a", "-O3"),
-        winCompilerFlags = arrayOf("/O2", "/std:c++20"),
-        winLinkerFlags = arrayOf("/DEBUG"),
+        winCompilerFlags = arrayOf("/O2", "/Zc:inline", "/std:c++20"),
+        winLinkerFlags = arrayOf("/DEBUG", "/OPT:ICF"),
     );
     override fun toString() = id
 }

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/JvmTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/JvmTasksConfiguration.kt
@@ -104,6 +104,8 @@ fun SkikoProjectContext.createCompileJvmBindingsTask(
                 "-fno-exceptions",
                 "-fvisibility=hidden",
                 "-fvisibility-inlines-hidden",
+                "-fdata-sections",
+                "-ffunction-sections",
                 *archFlags,
             )
         }
@@ -130,6 +132,8 @@ fun SkikoProjectContext.createCompileJvmBindingsTask(
                 "-fno-rtti",
                 "-fno-exceptions",
                 "-fvisibility=hidden",
+                "-fdata-sections",
+                "-ffunction-sections",
                 "-fPIC"
             )
         }
@@ -341,6 +345,7 @@ fun SkikoProjectContext.createLinkJvmBindings(
                         // Enforce immediate symbol resolution at library load time to prevent
                         // lazy-binding issues and make GOT read-only afterwards.
                         "-Wl,-z,relro,-z,now",
+                        "-Wl,--gc-sections",
                     )
                 )
                 addAll(resolvedBinaryInputs.dynamicLibNames.map { "-l$it" })
@@ -385,6 +390,7 @@ fun SkikoProjectContext.createLinkJvmBindings(
                 "-llog",
                 "-landroid",
                 "-latomic",
+                "-Wl,--gc-sections",
             )
             androidFlags.addAll(resolvedBinaryInputs.dynamicLibNames.map { "-l$it" })
             androidFlags.addAll(resolvedBinaryInputs.directStaticArchivePaths)


### PR DESCRIPTION
After looking into skia, I noticed that it uses some of the compile/link flags that we don't have currently in skiko:
https://github.com/google/skia/blob/71db7c06c5fedcba160f1d15f2b17decb1b6c32e/gn/skia/BUILD.gn#L716

Adding them slightly reduced binary sizes

Platform | Before | After
-- | -- | --
Linux x64 | 29.62 MB | 26.2 MB
Linux arm64 | 28.7 MB | 25.8 MB
Windows x64 | 14.07 MB | 12.9 MB
Windows arm64 | 11.7 MB | 10.9 MB
