### PR TITLE
Avoid JNI calls inside primitive array critical regions

### DIFF
--- a/skiko/src/jvmMain/cpp/common/RuntimeShaderBuilder.cc
+++ b/skiko/src/jvmMain/cpp/common/RuntimeShaderBuilder.cc
@@ -1,4 +1,5 @@
 #include <jni.h>
+#include <vector>
 
 #include "SkRuntimeEffect.h"
 #include "interop.hh"
@@ -86,19 +87,21 @@ extern "C" JNIEXPORT void JNICALL
 Java_org_jetbrains_skia_RuntimeShaderBuilderKt__1nUniformFloatArray
   (JNIEnv* env, jclass jclass, jlong builderPtr, jstring uniformName, jfloatArray uniformFloatArray, jint length) {
     SkRuntimeShaderBuilder* runtimeShaderBuilder = jlongToPtr<SkRuntimeShaderBuilder*>(builderPtr);
-    jfloat* floatArray = static_cast<jfloat*>(env->GetPrimitiveArrayCritical(uniformFloatArray, 0));
-    runtimeShaderBuilder->uniform(skString(env, uniformName).c_str()).set(floatArray, length);
-    env->ReleasePrimitiveArrayCritical(uniformFloatArray, floatArray, 0);
+    SkString name = skString(env, uniformName);
+    std::vector<jfloat> floatArray(length);
+    env->GetFloatArrayRegion(uniformFloatArray, 0, length, floatArray.data());
+    runtimeShaderBuilder->uniform(name.c_str()).set(floatArray.data(), length);
 }
 
 extern "C" JNIEXPORT void JNICALL
 Java_org_jetbrains_skia_RuntimeShaderBuilderKt__1nUniformFloatMatrix22
   (JNIEnv* env, jclass jclass, jlong builderPtr, jstring uniformName, jfloatArray uniformMatrix22) {
     SkRuntimeShaderBuilder* runtimeShaderBuilder = jlongToPtr<SkRuntimeShaderBuilder*>(builderPtr);
-    jfloat* matrix22 = static_cast<jfloat*>(env->GetPrimitiveArrayCritical(uniformMatrix22, 0));
-    runtimeShaderBuilder->uniform(skString(env, uniformName).c_str()) =
+    SkString name = skString(env, uniformName);
+    jfloat matrix22[4];
+    env->GetFloatArrayRegion(uniformMatrix22, 0, 4, matrix22);
+    runtimeShaderBuilder->uniform(name.c_str()) =
         std::array<float, 4> {matrix22[0], matrix22[1], matrix22[2], matrix22[3]};
-    env->ReleasePrimitiveArrayCritical(uniformMatrix22, matrix22, 0);
 }
 
 extern "C" JNIEXPORT void JNICALL


### PR DESCRIPTION
## What and why

When using `RuntimeShaderBuilder` on Android to create a runtime shader, setting a float-array uniform again after creation consistently aborts under ART CheckJNI with the following error:

```text
JNI DETECTED ERROR IN APPLICATION: thread Thread[1,tid=4275,Runnable,Thread*=0x763892614c00,peer=0x75c0a9e8,"main"] using JNI after critical get
   in call to ReleaseStringChars
   from void org.jetbrains.skia.RuntimeShaderBuilderKt._nUniformFloatArray(long, java.lang.Object, java.lang.Object, int)
"main" prio=5 tid=1 Runnable
 | group="main" sCount=0 dsCount=0 flags=0 obj=0x75c0a9e8 self=0x763892614c00
 | sysTid=4275 nice=0 cgrp=default sched=0/0 handle=0x763917caf948
 | state=R schedstat=( 328750564 14889892 232 ) utm=30 stm=2 core=3 HZ=100
 | stack=0x7ffd2b749000-0x7ffd2b74b000 stackSize=8MB
 | held mutexes= "mutator lock"(shared held)
 native: #00 pc 00000000003eae62  /system/lib64/libart.so (art::DumpNativeStack(std::__1::basic_ostream<char, std::__1::char_traits<char>>&, int, BacktraceMap*, char const*, art::ArtMethod*, void*, bool)+210)
 native: #01 pc 00000000004cb270  /system/lib64/libart.so (art::Thread::DumpStack(std::__1::basic_ostream<char, std::__1::char_traits<char>>&, bool, BacktraceMap*, bool) const+320)
 native: #02 pc 000000000030cac3  /system/lib64/libart.so (art::JavaVMExt::JniAbort(char const*, char const*)+979)
 native: #03 pc 000000000030ce94  /system/lib64/libart.so (art::JavaVMExt::JniAbortV(char const*, char const*, __va_list_tag*)+68)
 native: #04 pc 00000000000fb3bf  /system/lib64/libart.so (art::(anonymous namespace)::ScopedCheck::AbortF(char const*, ...)+159)
 native: #05 pc 00000000000f9cbf  /system/lib64/libart.so (art::(anonymous namespace)::ScopedCheck::CheckPossibleHeapValue(art::ScopedObjectAccess&, char, art::(anonymous namespace)::JniValueType)+959)
 native: #06 pc 00000000000f9062  /system/lib64/libart.so (art::(anonymous namespace)::ScopedCheck::Check(art::ScopedObjectAccess&, bool, char const*, art::(anonymous namespace)::JniValueType*)+738)
 native: #07 pc 0000000000103681  /system/lib64/libart.so (art::(anonymous namespace)::CheckJNI::ReleaseStringCharsInternal(char const*, _JNIEnv*, _jstring*, void const*, bool, bool)+945)
 native: #08 pc 0000000000b7394b  /data/app/me.earzuchan.hiro.example.thirdparty-GpWHqrMeD2t0i9f93X8bwQ==/lib/x86_64/libskiko-android-x64.so (offset b6a000) (SkijaDrawableImpl::onGetBounds()+75)
 native: #09 pc 0000000000b898f1  /data/app/me.earzuchan.hiro.example.thirdparty-GpWHqrMeD2t0i9f93X8bwQ==/lib/x86_64/libskiko-android-x64.so (offset b6a000) (Java_org_jetbrains_skia_FontMgrKt__1nLegacyMakeTypeface+1)
 native: #10 pc 00000000000a4923  /dev/ashmem/dalvik-main space (region space) (deleted) (offset 300000) (???)
 at org.jetbrains.skia.RuntimeShaderBuilderKt._nUniformFloatArray(Native method)
 at org.jetbrains.skia.RuntimeShaderBuilderKt.access$_nUniformFloatArray(RuntimeShaderBuilder.kt:1)
 at org.jetbrains.skia.RuntimeShaderBuilder.uniform(RuntimeShaderBuilder.kt:86)
 at com.kyant.backdrop.SkikoRuntimeShader.setFloatUniform(RuntimeShader.kt:43)
```

I reproduced the same failure at this call site on:

- Android 9 AVD
- Android 14 AVD
- Xiaomi 15 Ultra running Android 16

`_nUniformFloatArray` calls `GetPrimitiveArrayCritical` and then calls `skString` before releasing the critical array. `skString` performs JNI calls including `GetStringLength`, `GetStringChars`, and `ReleaseStringChars`. JNI does not permit arbitrary JNI calls while a primitive array critical region is active, which is why ART aborts at `ReleaseStringChars` with `using JNI after critical get`.

`_nUniformFloatMatrix22` contains the same invalid call sequence, so it is fixed at the same time.

The issue is not necessarily Android-specific because the affected implementation is shared JVM JNI code, but ART CheckJNI makes the violation reliably observable on Android.

The fix converts the uniform name before reading the array and uses `GetFloatArrayRegion` to copy the values into native storage. This avoids keeping a primitive array critical region active while converting the string or calling into Skia. With this change applied to locally built Android libraries, updating the uniforms works normally and the CheckJNI failure no longer occurs. I have also used the patched Android libraries for an extended period without seeing the failure recur.

## Testing

- Reproduced before the fix on Android 9 and Android 14 AVDs, and a Xiaomi 15 Ultra running Android 16.
- Verified in the same application with locally built patched Android x64 and arm64 libraries; uniforms can be updated without a CheckJNI abort.
- No separate test project is included because the failure is directly diagnosed by ART CheckJNI at the affected JNI call site.

## Release Notes

### Fixes - JVM/Android

- Fixed a CheckJNI abort when setting float-array and 2x2 matrix uniforms through `RuntimeShaderBuilder`.
