### PR TITLE
Configure Dokka for multi-module documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
               -Pskiko.native.enabled=true \
               -Pskiko.wasm.enabled=true \
               -Pskiko.android.enabled=true \
-              :skiko:dokkaHtml
+              :skiko:docs:dokkaGeneratePublicationHtml
 
       - name: 'Publish Documentation'
         if: ${{ inputs.publish }}
@@ -40,4 +40,4 @@ jobs:
         with:
           ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
           BRANCH: gh-pages
-          FOLDER: ./skiko/build/dokka/html
+          FOLDER: ./skiko/docs/build/dokka/html

--- a/dependencies.toml
+++ b/dependencies.toml
@@ -6,7 +6,7 @@ coroutines = "1.8.0"
 jetbrainsRuntime-api = "1.5.0"
 
 androidGradlePlugin = "9.0.0"
-dokka = "1.9.10"
+dokka = "2.2.0"
 
 buildHelpers-publishing = "0.1.28"
 githubApi = "1.329"

--- a/skiko/docs/build.gradle.kts
+++ b/skiko/docs/build.gradle.kts
@@ -1,0 +1,20 @@
+plugins {
+    org.jetbrains.dokka
+}
+
+repositories {
+    mavenCentral {
+        url = uri("https://cache-redirector.jetbrains.com/maven-central")
+    }
+}
+
+dokka {
+    dokkaPublications.html {
+        moduleName.set("skiko")
+    }
+}
+
+dependencies {
+    dokka(project(":"))
+    dokka(project(":skiko-skottie"))
+}

--- a/skiko/settings.gradle.kts
+++ b/skiko/settings.gradle.kts
@@ -17,6 +17,7 @@ pluginManagement {
 }
 rootProject.name = "skiko"
 include("ci")
+include("docs")
 include("import-generator")
 include("test-utils")
 include("skiko-skottie")


### PR DESCRIPTION
Skiko is now modular, so our Dokka setup needs to be updated to support multi-module documentation generation.

This PR:
- bumps the Dokka version
- configures Dokka for multi-module documentation generation