### PR TITLE
Eliminate background flash on first window show

### DIFF
--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt
@@ -7,8 +7,8 @@ import kotlinx.coroutines.launch
 import org.jetbrains.skia.*
 import org.jetbrains.skia.Canvas
 import org.jetbrains.skiko.internal.fastForEach
-import org.jetbrains.skiko.redrawer.AWTRedrawer
 import org.jetbrains.skiko.redrawer.Direct3DRedrawer
+import org.jetbrains.skiko.redrawer.Redrawer
 import org.jetbrains.skiko.redrawer.RedrawerManager
 import java.awt.*
 import java.awt.Color
@@ -32,7 +32,6 @@ import kotlin.math.floor
 actual open class SkiaLayer internal constructor(
     accessibleContextProvider: ((Component) -> AccessibleContext)? = null,
     val properties: SkiaLayerProperties,
-    /** Must produce [AWTRedrawer]s */
     private val renderFactory: RenderFactory = RenderFactory.Default,
     private val analytics: SkiaLayerAnalytics = SkiaLayerAnalytics.Empty,
     actual val pixelGeometry: PixelGeometry = PixelGeometry.UNKNOWN,
@@ -354,20 +353,20 @@ actual open class SkiaLayer internal constructor(
     @Volatile
     private var isDisposed = false
 
-    private val redrawerManager = RedrawerManager<AWTRedrawer>(
+    private val redrawerManager = RedrawerManager<Redrawer>(
         defaultRenderApi = properties.renderApi,
         redrawerFactory = { renderApi, oldRedrawer ->
             oldRedrawer?.dispose()
             renderFactory.createRedrawer(this, renderApi, analytics, properties).also {
                 it.syncBoundsFromPlatformComponent()
-            } as AWTRedrawer
+            }
         },
         onRenderApiChanged = {
             notifyChange(PropertyKind.Renderer)
         }
     )
 
-    internal val redrawer: AWTRedrawer? by redrawerManager::redrawer
+    internal val redrawer: Redrawer? by redrawerManager::redrawer
 
     actual var renderApi: GraphicsApi by redrawerManager::renderApi
 

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt
@@ -7,8 +7,8 @@ import kotlinx.coroutines.launch
 import org.jetbrains.skia.*
 import org.jetbrains.skia.Canvas
 import org.jetbrains.skiko.internal.fastForEach
+import org.jetbrains.skiko.redrawer.AWTRedrawer
 import org.jetbrains.skiko.redrawer.Direct3DRedrawer
-import org.jetbrains.skiko.redrawer.Redrawer
 import org.jetbrains.skiko.redrawer.RedrawerManager
 import java.awt.*
 import java.awt.Color
@@ -32,14 +32,16 @@ import kotlin.math.floor
 actual open class SkiaLayer internal constructor(
     accessibleContextProvider: ((Component) -> AccessibleContext)? = null,
     val properties: SkiaLayerProperties,
+    /** Must produce [AWTRedrawer]s */
     private val renderFactory: RenderFactory = RenderFactory.Default,
     private val analytics: SkiaLayerAnalytics = SkiaLayerAnalytics.Empty,
     actual val pixelGeometry: PixelGeometry = PixelGeometry.UNKNOWN,
     /**
-     * Whether this layer fills its entire host window. When true, platform-specific window-level
-     * optimizations may be used (e.g., on macOS, driving the interactive live-resize redraw from the
-     * window). Set to false when the layer is embedded as a Swing component somewhere in the window's
-     * hierarchy rather than covering the whole window, so those window-level paths are disabled.
+     * Whether this layer fills its entire host window.
+     *
+     * When true, platform-specific window-level optimizations may be used (e.g., on macOS, driving the interactive
+     * live-resize redraw from the window). Set to false when the layer is embedded as a Swing component somewhere in
+     * the window's hierarchy rather than covering the whole window, so those window-level paths are disabled.
      */
     internal val fillsWindow: Boolean = false,
 ) : JComponent(), Accessible {
@@ -124,7 +126,7 @@ actual open class SkiaLayer internal constructor(
                 @Suppress("DEPRECATION")
                 super.reshape(x, y, width, height)
 
-                redrawer?.onPlatformComponentResized()
+                redrawer?.onLayerComponentResized()
             }
 
             override fun getInputMethodRequests(): InputMethodRequests? {
@@ -352,20 +354,20 @@ actual open class SkiaLayer internal constructor(
     @Volatile
     private var isDisposed = false
 
-    private val redrawerManager = RedrawerManager<Redrawer>(
+    private val redrawerManager = RedrawerManager<AWTRedrawer>(
         defaultRenderApi = properties.renderApi,
         redrawerFactory = { renderApi, oldRedrawer ->
             oldRedrawer?.dispose()
             renderFactory.createRedrawer(this, renderApi, analytics, properties).also {
                 it.syncBoundsFromPlatformComponent()
-            }
+            } as AWTRedrawer
         },
         onRenderApiChanged = {
             notifyChange(PropertyKind.Renderer)
         }
     )
 
-    internal val redrawer: Redrawer? by redrawerManager::redrawer
+    internal val redrawer: AWTRedrawer? by redrawerManager::redrawer
 
     actual var renderApi: GraphicsApi by redrawerManager::renderApi
 

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt
@@ -9,10 +9,15 @@ import org.jetbrains.skiko.internal.fastForEach
 import org.jetbrains.skiko.redrawer.Direct3DRedrawer
 import org.jetbrains.skiko.redrawer.Redrawer
 import org.jetbrains.skiko.redrawer.RedrawerManager
+import org.jetbrains.skiko.redrawer.renderTime
+import org.jetbrains.skiko.swing.SoftwareSwingPainter
+import org.jetbrains.skiko.swing.SwingLayerProperties
 import java.awt.Color
 import java.awt.Component
 import java.awt.Dimension
 import java.awt.Graphics
+import java.awt.Graphics2D
+import java.awt.GraphicsConfiguration
 import java.awt.Point
 import java.awt.event.*
 import java.awt.geom.AffineTransform
@@ -108,6 +113,12 @@ actual open class SkiaLayer internal constructor(
                 Logger.debug { "Paint called on HardwareLayer $this" }
                 checkContentScale()
 
+                // Draw the picture into the heavyweight Canvas too, because sometimes it's visible for a frame before
+                // the native layer is visible.
+                onGraphicsPainter?.let {
+                    paintContentOnGraphics(g as Graphics2D, it)
+                }
+
                 // 1. JPanel.paint is not always called (in rare cases).
                 //    For example if we call 'jframe.isResizable = false` on Ubuntu
                 //
@@ -116,6 +127,39 @@ actual open class SkiaLayer internal constructor(
                 //
                 // 3. to avoid double paint in one single frame, use needRender instead of renderImmediately
                 redrawer?.needRender(throttledToVsync = false)
+            }
+
+            /**
+             * Software-renders the current content into [g].
+             *
+             * This is needed because the first frame is occasionally visible before the native layer is ready to draw,
+             * and when that happens, what is drawn on the screen is the [HardwareLayer]'s background, causing a visible
+             * flash.
+             */
+            private fun paintContentOnGraphics(g: Graphics2D, onGraphicsPainter: OnGraphicsPainter) {
+                if (!isInited || isDisposed) return
+                try {
+                    // Ensure we have a picture to blit. On the very first paint, before the render loop has
+                    // run (and before the heavyweight child has been laid out, so backedLayer.width may be 0),
+                    // record one at this component's own — reliably valid — size. Otherwise, reuse the picture
+                    // already recorded by the render loop (or by the other layer's paint), so we don't re-run
+                    // the render delegate more than once.
+                    if (picture == null) {
+                        val scale = contentScale
+                        val forcedSize = Dimension(
+                            (width * scale).toInt().coerceAtLeast(0),
+                            (height * scale).toInt().coerceAtLeast(0)
+                        )
+                        update(renderTime(), forcedSize = forcedSize)
+                    }
+                    lockPicture { picture ->
+                        if (picture.width <= 0 || picture.height <= 0) return@lockPicture
+                        onGraphicsPainter.paint(g, picture)
+                    }
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                    Logger.warn(e) { "Failed to software-render fallback frame for $this" }
+                }
             }
 
             @Suppress("OVERRIDE_DEPRECATION")
@@ -144,8 +188,8 @@ actual open class SkiaLayer internal constructor(
                 return canReceiveFocus(cause) && super.requestFocusInWindow(cause)
             }
 
-            private fun canReceiveFocus(cause: FocusEvent.Cause?) = cause != FocusEvent.Cause.MOUSE_EVENT ||
-                    isRequestFocusEnabled
+            private fun canReceiveFocus(cause: FocusEvent.Cause?) =
+                cause != FocusEvent.Cause.MOUSE_EVENT || isRequestFocusEnabled
         }
         @Suppress("LeakingThis")
         add(backedLayer)
@@ -294,6 +338,15 @@ actual open class SkiaLayer internal constructor(
             redrawer?.syncBoundsFromPlatformComponent()
             repaint()
         }
+
+        if (!wasShowing && isShowingNow) {
+            // Becoming visible: software-render a fallback frame into the heavyweight backedLayer until
+            // the GPU surface composites, so the window's first frame shows content instead of the
+            // Canvas's background (see HardwareLayer.paint / paintContentFallback).
+            onGraphicsPainter = OnGraphicsPainter(this)
+            backedLayer.background = Color.RED
+        }
+
     }
 
     private var isShowingCached = false
@@ -380,6 +433,10 @@ actual open class SkiaLayer internal constructor(
     private var pictureRecorder: PictureRecorder? = null
     private val pictureLock = Any()
 
+    // Paints the picture on the layer's Graphics (allocates and holds the resources needed to do so).
+    // Also doubles as the flag indicating whether we need to draw the picture in paint(Graphics).
+    internal var onGraphicsPainter: OnGraphicsPainter? = null
+
     private fun init(recreation: Boolean = false) {
         isDisposed = false
         backedLayer.init()
@@ -413,6 +470,8 @@ actual open class SkiaLayer internal constructor(
             picture = null
             pictureRecorder?.close()
             pictureRecorder = null
+            onGraphicsPainter?.dispose()
+            onGraphicsPainter = null
             backedLayer.dispose()
             peerBufferSizeFixJob?.cancel()
             isDisposed = true
@@ -693,6 +752,8 @@ actual open class SkiaLayer internal constructor(
             with(createDrawScope(forcedSize)) {
                 body()
             }
+            onGraphicsPainter?.dispose()
+            onGraphicsPainter = null
         } catch (_: CancellationException) {
             // ignore
         } catch (e: RenderException) {
@@ -805,5 +866,32 @@ private fun adjustSizeToContentScale(contentScale: Float, value: Int): Int {
         value + 1
     } else {
         value
+    }
+}
+
+
+internal class OnGraphicsPainter(private val layer: SkiaLayer) {
+
+    private var swingPainter: SoftwareSwingPainter? = null
+
+    fun paint(g: Graphics2D, pictureHolder: PictureHolder) {
+        val painter = swingPainter ?: SoftwareSwingPainter(object : SwingLayerProperties {
+            override val width: Int get() = layer.width
+            override val height: Int get() = layer.height
+            override val graphicsConfiguration: GraphicsConfiguration get() = layer.graphicsConfiguration
+            override val adapterPriority: GpuPriority get() = layer.properties.adapterPriority
+            override val gpuResourceCacheLimit: Long get() = layer.properties.gpuResourceCacheLimit
+        }).also { swingPainter = it }
+
+        Surface.makeRaster(
+            ImageInfo.makeS32(pictureHolder.width, pictureHolder.height, ColorAlphaType.PREMUL)
+        ).use { surface ->
+            surface.canvas.drawPicture(pictureHolder.instance)
+            painter.paint(g, surface, texture = 0)
+        }
+    }
+
+    fun dispose() {
+        swingPainter?.dispose()
     }
 }

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt
@@ -5,19 +5,14 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import org.jetbrains.skia.*
+import org.jetbrains.skia.Canvas
 import org.jetbrains.skiko.internal.fastForEach
 import org.jetbrains.skiko.redrawer.Direct3DRedrawer
 import org.jetbrains.skiko.redrawer.Redrawer
 import org.jetbrains.skiko.redrawer.RedrawerManager
-import org.jetbrains.skiko.redrawer.renderTime
-import org.jetbrains.skiko.swing.SoftwareSwingPainter
-import org.jetbrains.skiko.swing.SwingLayerProperties
+import java.awt.*
 import java.awt.Color
-import java.awt.Component
-import java.awt.Dimension
 import java.awt.Graphics
-import java.awt.Graphics2D
-import java.awt.GraphicsConfiguration
 import java.awt.Point
 import java.awt.event.*
 import java.awt.geom.AffineTransform
@@ -33,7 +28,6 @@ import javax.swing.SwingUtilities.isEventDispatchThread
 import javax.swing.event.AncestorEvent
 import javax.swing.event.AncestorListener
 import kotlin.math.floor
-import kotlin.time.measureTime
 
 actual open class SkiaLayer internal constructor(
     accessibleContextProvider: ((Component) -> AccessibleContext)? = null,

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt
@@ -33,6 +33,7 @@ import javax.swing.SwingUtilities.isEventDispatchThread
 import javax.swing.event.AncestorEvent
 import javax.swing.event.AncestorListener
 import kotlin.math.floor
+import kotlin.time.measureTime
 
 actual open class SkiaLayer internal constructor(
     accessibleContextProvider: ((Component) -> AccessibleContext)? = null,
@@ -113,12 +114,6 @@ actual open class SkiaLayer internal constructor(
                 Logger.debug { "Paint called on HardwareLayer $this" }
                 checkContentScale()
 
-                // Draw the picture into the heavyweight Canvas too, because sometimes it's visible for a frame before
-                // the native layer is visible.
-                onGraphicsPainter?.let {
-                    paintContentOnGraphics(g as Graphics2D, it)
-                }
-
                 // 1. JPanel.paint is not always called (in rare cases).
                 //    For example if we call 'jframe.isResizable = false` on Ubuntu
                 //
@@ -127,39 +122,6 @@ actual open class SkiaLayer internal constructor(
                 //
                 // 3. to avoid double paint in one single frame, use needRender instead of renderImmediately
                 redrawer?.needRender(throttledToVsync = false)
-            }
-
-            /**
-             * Software-renders the current content into [g].
-             *
-             * This is needed because the first frame is occasionally visible before the native layer is ready to draw,
-             * and when that happens, what is drawn on the screen is the [HardwareLayer]'s background, causing a visible
-             * flash.
-             */
-            private fun paintContentOnGraphics(g: Graphics2D, onGraphicsPainter: OnGraphicsPainter) {
-                if (!isInited || isDisposed) return
-                try {
-                    // Ensure we have a picture to blit. On the very first paint, before the render loop has
-                    // run (and before the heavyweight child has been laid out, so backedLayer.width may be 0),
-                    // record one at this component's own — reliably valid — size. Otherwise, reuse the picture
-                    // already recorded by the render loop (or by the other layer's paint), so we don't re-run
-                    // the render delegate more than once.
-                    if (picture == null) {
-                        val scale = contentScale
-                        val forcedSize = Dimension(
-                            (width * scale).toInt().coerceAtLeast(0),
-                            (height * scale).toInt().coerceAtLeast(0)
-                        )
-                        update(renderTime(), forcedSize = forcedSize)
-                    }
-                    lockPicture { picture ->
-                        if (picture.width <= 0 || picture.height <= 0) return@lockPicture
-                        onGraphicsPainter.paint(g, picture)
-                    }
-                } catch (e: Exception) {
-                    e.printStackTrace()
-                    Logger.warn(e) { "Failed to software-render fallback frame for $this" }
-                }
             }
 
             @Suppress("OVERRIDE_DEPRECATION")
@@ -338,15 +300,6 @@ actual open class SkiaLayer internal constructor(
             redrawer?.syncBoundsFromPlatformComponent()
             repaint()
         }
-
-        if (!wasShowing && isShowingNow) {
-            // Becoming visible: software-render a fallback frame into the heavyweight backedLayer until
-            // the GPU surface composites, so the window's first frame shows content instead of the
-            // Canvas's background (see HardwareLayer.paint / paintContentFallback).
-            onGraphicsPainter = OnGraphicsPainter(this)
-            backedLayer.background = Color.RED
-        }
-
     }
 
     private var isShowingCached = false
@@ -433,10 +386,6 @@ actual open class SkiaLayer internal constructor(
     private var pictureRecorder: PictureRecorder? = null
     private val pictureLock = Any()
 
-    // Paints the picture on the layer's Graphics (allocates and holds the resources needed to do so).
-    // Also doubles as the flag indicating whether we need to draw the picture in paint(Graphics).
-    internal var onGraphicsPainter: OnGraphicsPainter? = null
-
     private fun init(recreation: Boolean = false) {
         isDisposed = false
         backedLayer.init()
@@ -470,8 +419,6 @@ actual open class SkiaLayer internal constructor(
             picture = null
             pictureRecorder?.close()
             pictureRecorder = null
-            onGraphicsPainter?.dispose()
-            onGraphicsPainter = null
             backedLayer.dispose()
             peerBufferSizeFixJob?.cancel()
             isDisposed = true
@@ -752,8 +699,6 @@ actual open class SkiaLayer internal constructor(
             with(createDrawScope(forcedSize)) {
                 body()
             }
-            onGraphicsPainter?.dispose()
-            onGraphicsPainter = null
         } catch (_: CancellationException) {
             // ignore
         } catch (e: RenderException) {
@@ -866,32 +811,5 @@ private fun adjustSizeToContentScale(contentScale: Float, value: Int): Int {
         value + 1
     } else {
         value
-    }
-}
-
-
-internal class OnGraphicsPainter(private val layer: SkiaLayer) {
-
-    private var swingPainter: SoftwareSwingPainter? = null
-
-    fun paint(g: Graphics2D, pictureHolder: PictureHolder) {
-        val painter = swingPainter ?: SoftwareSwingPainter(object : SwingLayerProperties {
-            override val width: Int get() = layer.width
-            override val height: Int get() = layer.height
-            override val graphicsConfiguration: GraphicsConfiguration get() = layer.graphicsConfiguration
-            override val adapterPriority: GpuPriority get() = layer.properties.adapterPriority
-            override val gpuResourceCacheLimit: Long get() = layer.properties.gpuResourceCacheLimit
-        }).also { swingPainter = it }
-
-        Surface.makeRaster(
-            ImageInfo.makeS32(pictureHolder.width, pictureHolder.height, ColorAlphaType.PREMUL)
-        ).use { surface ->
-            surface.canvas.drawPicture(pictureHolder.instance)
-            painter.paint(g, surface, texture = 0)
-        }
-    }
-
-    fun dispose() {
-        swingPainter?.dispose()
     }
 }

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/context/MetalContextHandler.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/context/MetalContextHandler.kt
@@ -78,9 +78,9 @@ internal class MetalContextHandler(
     fun finishFrameInLiveResize() = finishFrameInLiveResize(device.ptr)
 
     /**
-     * Presents the frame synchronously, so the content is delivered before the window can appear on
-     * screen. Used for a frame rendered while the layer is displayable but not yet showing; see
-     * [org.jetbrains.skiko.redrawer.MetalRedrawer.renderBeforeShown].
+     * Presents the warm-up frame rendered while the layer is displayable but not yet showing, so the
+     * window's first on-screen frame draws content instead of flashing its background.
+     * See [org.jetbrains.skiko.redrawer.MetalRedrawer.renderBeforeShown].
      */
     fun finishFrameBeforeShown() = finishFrameBeforeShown(device.ptr)
 

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/context/MetalContextHandler.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/context/MetalContextHandler.kt
@@ -77,8 +77,16 @@ internal class MetalContextHandler(
      */
     fun finishFrameInLiveResize() = finishFrameInLiveResize(device.ptr)
 
+    /**
+     * Presents the frame synchronously, so the content is delivered before the window can appear on
+     * screen. Used for a frame rendered while the layer is displayable but not yet showing; see
+     * [org.jetbrains.skiko.redrawer.MetalRedrawer.renderBeforeShown].
+     */
+    fun finishFrameBeforeShown() = finishFrameBeforeShown(device.ptr)
+
     private external fun makeMetalContext(device: Long): Long
     private external fun makeMetalRenderTarget(device: Long, width: Int, height: Int): Long
     private external fun finishFrame(device: Long)
     private external fun finishFrameInLiveResize(device: Long)
+    private external fun finishFrameBeforeShown(device: Long)
 }

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/context/MetalContextHandler.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/context/MetalContextHandler.kt
@@ -68,25 +68,23 @@ internal class MetalContextHandler(
         makeMetalContext(device.ptr)
     )
 
-    /** Presents the frame asynchronously (off the main thread). Used for every frame outside a live resize. */
-    fun finishFrame() = finishFrame(device.ptr)
+    /**
+     * Presents the frame asynchronously (off the AppKit main thread).
+     */
+    fun finishFrameAsync() = finishFrameAsync(device.ptr)
 
     /**
-     * Presents the frame synchronously, joining the ambient window-resize transaction.
-     * Must be called on the AppKit main thread during a live resize.
+     * Presents the frame synchronously, in the calling thread.
+     *
+     * Used in two scenarios:
+     * - During live-resize it is called on the AppKit main thread, to join the ambient window-resize transaction.
+     * - Before showing the window, it is called while the layer is already displayable (but not yet showing), so the
+     *   window's first on-screen frame draws content instead of flashing its background.
      */
-    fun finishFrameInLiveResize() = finishFrameInLiveResize(device.ptr)
-
-    /**
-     * Presents the warm-up frame rendered while the layer is displayable but not yet showing, so the
-     * window's first on-screen frame draws content instead of flashing its background.
-     * See [org.jetbrains.skiko.redrawer.MetalRedrawer.renderBeforeShown].
-     */
-    fun finishFrameBeforeShown() = finishFrameBeforeShown(device.ptr)
+    fun finishFrameSync() = finishFrameSync(device.ptr)
 
     private external fun makeMetalContext(device: Long): Long
     private external fun makeMetalRenderTarget(device: Long, width: Int, height: Int): Long
-    private external fun finishFrame(device: Long)
-    private external fun finishFrameInLiveResize(device: Long)
-    private external fun finishFrameBeforeShown(device: Long)
+    private external fun finishFrameAsync(device: Long)
+    private external fun finishFrameSync(device: Long)
 }

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/AWTRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/AWTRedrawer.kt
@@ -110,7 +110,7 @@ internal abstract class AWTRedrawer(
      * land only after the window is already showing, defeating the purpose of the early render).
      */
     protected open fun renderBeforeShown() {
-        renderImmediately()
+        error("renderBeforeShown must be implemented if `supportsRenderingBeforeShown` is `true`")
     }
 
     override fun isTransparentBackgroundSupported() = defaultIsTransparentBackgroundSupported(layer)

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/AWTRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/AWTRedrawer.kt
@@ -83,5 +83,35 @@ internal abstract class AWTRedrawer(
         check(!isDisposed) { "${this.javaClass.simpleName} is disposed" }
     }
 
+    override fun onPlatformComponentResized() {
+        syncBoundsFromPlatformComponent()
+        if (supportsRenderingBeforeShown && !layer.isShowing && layer.isDisplayable && layer.width > 0 && layer.height > 0) {
+            // Render eagerly so the window already has content when it first appears on screen; see
+            // supportsRenderingWhileHidden. A scheduled frame would be skipped (rendering is gated on isShowing).
+            renderBeforeShown()
+        } else {
+            needRender(throttledToVsync = false)
+        }
+    }
+
+    /**
+     * Whether this redrawer can render and present a frame while the layer is displayable but not yet
+     * showing (see [renderBeforeShown]). When `true`, [onPlatformComponentResized] renders eagerly so the
+     * window already has content on its first on-screen frame, avoiding a flash of the window background.
+     */
+    protected open val supportsRenderingBeforeShown: Boolean get() = false
+
+    /**
+     * Renders and presents a frame while the layer is displayable but not showing.
+     *
+     * Only called when [supportsRenderingBeforeShown] is `true`. The default is a plain [renderImmediately];
+     * implementations whose regular present is asynchronous should override this to present synchronously,
+     * guaranteeing the content is delivered before the window can appear on screen (an async present could
+     * land only after the window is already showing, defeating the purpose of the early render).
+     */
+    protected open fun renderBeforeShown() {
+        renderImmediately()
+    }
+
     override fun isTransparentBackgroundSupported() = defaultIsTransparentBackgroundSupported(layer)
 }

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/AWTRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/AWTRedrawer.kt
@@ -104,10 +104,8 @@ internal abstract class AWTRedrawer(
     /**
      * Renders and presents a frame while the layer is displayable but not showing.
      *
-     * Only called when [supportsRenderingBeforeShown] is `true`. The default is a plain [renderImmediately];
-     * implementations whose regular present is asynchronous should override this to present synchronously,
-     * guaranteeing the content is delivered before the window can appear on screen (an async present could
-     * land only after the window is already showing, defeating the purpose of the early render).
+     * Only called when [supportsRenderingBeforeShown] is `true`. Implementations must present the frame in a
+     * way that the window's first on-screen composite reflects it rather than the background.
      */
     protected open fun renderBeforeShown() {
         error("renderBeforeShown must be implemented if `supportsRenderingBeforeShown` is `true`")

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/AWTRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/AWTRedrawer.kt
@@ -86,8 +86,7 @@ internal abstract class AWTRedrawer(
     override fun onPlatformComponentResized() {
         syncBoundsFromPlatformComponent()
         if (supportsRenderingBeforeShown && !layer.isShowing && layer.isDisplayable && layer.width > 0 && layer.height > 0) {
-            // Render eagerly so the window already has content when it first appears on screen; see
-            // supportsRenderingWhileHidden. A scheduled frame would be skipped (rendering is gated on isShowing).
+            // Render eagerly so the window already has content when it first appears on screen
             renderBeforeShown()
         } else {
             needRender(throttledToVsync = false)

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/AWTRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/AWTRedrawer.kt
@@ -83,10 +83,7 @@ internal abstract class AWTRedrawer(
         check(!isDisposed) { "${this.javaClass.simpleName} is disposed" }
     }
 
-    /**
-     * Invoked by [SkiaLayer] when the underlying Swing component is resized.
-     */
-    open fun onLayerComponentResized() {
+    override fun onLayerComponentResized() {
         syncBoundsFromPlatformComponent()
 
         if (!layer.isShowing && layer.isDisplayable && (layer.width > 0) && (layer.height > 0)) {

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/AWTRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/AWTRedrawer.kt
@@ -83,31 +83,28 @@ internal abstract class AWTRedrawer(
         check(!isDisposed) { "${this.javaClass.simpleName} is disposed" }
     }
 
-    override fun onPlatformComponentResized() {
+    /**
+     * Invoked by [SkiaLayer] when the underlying Swing component is resized.
+     */
+    open fun onLayerComponentResized() {
         syncBoundsFromPlatformComponent()
-        if (supportsRenderingBeforeShown && !layer.isShowing && layer.isDisplayable && layer.width > 0 && layer.height > 0) {
-            // Render eagerly so the window already has content when it first appears on screen
+
+        if (!layer.isShowing && layer.isDisplayable && (layer.width > 0) && (layer.height > 0)) {
             renderBeforeShown()
-        } else {
-            needRender(throttledToVsync = false)
+            return
         }
+
+        needRender(throttledToVsync = false)
     }
 
     /**
-     * Whether this redrawer can render and present a frame while the layer is displayable but not yet
-     * showing (see [renderBeforeShown]). When `true`, [onPlatformComponentResized] renders eagerly so the
-     * window already has content on its first on-screen frame, avoiding a flash of the window background.
+     * Renders and presents a frame when the layer is already displayable but not yet showing.
+     * This is needed so we have a frame ready when the window is first shown, to prevent the window background
+     * flashing.
      */
-    protected open val supportsRenderingBeforeShown: Boolean get() = false
-
-    /**
-     * Renders and presents a frame while the layer is displayable but not showing.
-     *
-     * Only called when [supportsRenderingBeforeShown] is `true`. Implementations must present the frame in a
-     * way that the window's first on-screen composite reflects it rather than the background.
-     */
-    protected open fun renderBeforeShown() {
-        error("renderBeforeShown must be implemented if `supportsRenderingBeforeShown` is `true`")
+    protected open fun renderBeforeShown(): Boolean {
+        renderImmediately()
+        return true
     }
 
     override fun isTransparentBackgroundSupported() = defaultIsTransparentBackgroundSupported(layer)

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/Direct3DRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/Direct3DRedrawer.kt
@@ -84,10 +84,10 @@ internal class Direct3DRedrawer(
         super.dispose()
     }
 
-    override fun onPlatformComponentResized() {
+    override fun onLayerComponentResized() {
         // During live resize, the layer tells us its size directly; the AWT size is not in sync
         if (!isHandlingLiveResizeNow) {
-            super.onPlatformComponentResized()
+            super.onLayerComponentResized()
         }
     }
 

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
@@ -146,14 +146,9 @@ internal class MetalRedrawer(
         }
     }
 
-    override val supportsRenderingBeforeShown: Boolean get() = true
+    override val supportsRenderingBeforeShown: Boolean
+        get() = true
 
-    /**
-     * Like [renderImmediately], but presents synchronously: the regular present is asynchronous and
-     * vsync-paced, so a frame rendered just before the window is shown (the warm-up frame) could have its
-     * present land only after the window has already appeared — defeating the purpose of the early render,
-     * with the window still briefly flashing its background color.
-     */
     override fun renderBeforeShown() {
         checkDisposed()
         update()

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
@@ -146,6 +146,29 @@ internal class MetalRedrawer(
         }
     }
 
+    override val supportsRenderingBeforeShown: Boolean get() = true
+
+    /**
+     * Like [renderImmediately], but presents synchronously: the regular present is asynchronous and
+     * vsync-paced, so a frame rendered just before the window is shown (the warm-up frame) could have its
+     * present land only after the window has already appeared — defeating the purpose of the early render,
+     * with the window still briefly flashing its background color.
+     */
+    override fun renderBeforeShown() {
+        checkDisposed()
+        update()
+        inDrawScope {
+            if (!isDisposed) { // Redrawer may be disposed in user code, during `update`
+                performDraw(finishFrame = false)
+            }
+        }
+        synchronized(drawLock) {
+            if (!isDisposed) {
+                contextHandler.finishFrameBeforeShown()
+            }
+        }
+    }
+
     private suspend fun draw() {
         inDrawScope {
             // Move drawing to another thread to free the main thread

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
@@ -157,10 +157,8 @@ internal class MetalRedrawer(
                 performDraw(finishFrame = false)
             }
         }
-        synchronized(drawLock) {
-            if (!isDisposed) {
-                contextHandler.finishFrameBeforeShown()
-            }
+        performNativeDrawAction {
+            contextHandler.finishFrameSync()
         }
     }
 
@@ -193,14 +191,10 @@ internal class MetalRedrawer(
     }
 
     private fun LayerDrawScope.performDraw(finishFrame: Boolean = true) {
-        synchronized(drawLock) {
-            if (!isDisposed) {
-                autoreleasepool {
-                    contextHandler.draw()
-                    if (finishFrame) {
-                        contextHandler.finishFrame()
-                    }
-                }
+        performNativeDrawAction {
+            contextHandler.draw()
+            if (finishFrame) {
+                contextHandler.finishFrameAsync()
             }
         }
     }
@@ -262,7 +256,7 @@ internal class MetalRedrawer(
         // The present must run on the AppKit main thread to join the resize transaction
         synchronized(drawLock) {
             if (!isDisposed) {
-                contextHandler.finishFrameInLiveResize()
+                contextHandler.finishFrameSync()
             }
         }
     }
@@ -296,6 +290,19 @@ internal class MetalRedrawer(
     override fun setVisible(isVisible: Boolean) {
         Logger.debug { "MetalRedrawer#setVisible($isVisible)" }
         setLayerVisible(device.ptr, isVisible)
+    }
+
+    /**
+     * Wraps [block] in the necessary machinery needed to call native, drawing-related, code.
+     */
+    private inline fun performNativeDrawAction(block: () -> Unit) {
+        synchronized(drawLock) {
+            if (!isDisposed) {
+                autoreleasepool {  // This is needed only if the call is not on the AppKit thread
+                    block()
+                }
+            }
+        }
     }
 
     private external fun createMetalDevice(window: Long, transparency: Boolean, frameBuffering: Int, adapter: Long, platformInfo: Long, liveResizeEnabled: Boolean): Long

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.kt
@@ -146,10 +146,7 @@ internal class MetalRedrawer(
         }
     }
 
-    override val supportsRenderingBeforeShown: Boolean
-        get() = true
-
-    override fun renderBeforeShown() {
+    override fun renderBeforeShown(): Boolean {
         checkDisposed()
         update()
         inDrawScope {
@@ -160,6 +157,7 @@ internal class MetalRedrawer(
         performNativeDrawAction {
             contextHandler.finishFrameSync()
         }
+        return true
     }
 
     private suspend fun draw() {
@@ -220,10 +218,10 @@ internal class MetalRedrawer(
         }
     }
 
-    override fun onPlatformComponentResized() {
+    override fun onLayerComponentResized() {
         // During live resize, the layer tells us its size directly; the AWT size is not in sync
         if (!isHandlingLiveResizeNow) {
-            super.onPlatformComponentResized()
+            super.onLayerComponentResized()
         }
     }
 

--- a/skiko/src/awtMain/objectiveC/macos/MetalContextHandler.mm
+++ b/skiko/src/awtMain/objectiveC/macos/MetalContextHandler.mm
@@ -148,5 +148,68 @@ JNIEXPORT void JNICALL Java_org_jetbrains_skiko_context_MetalContextHandler_fini
     });
 }
 
+/// Runs `block` on the AppKit main thread and waits for it to complete (runs it inline when already on
+/// the main thread).
+///
+/// Unlike dispatch_sync(dispatch_get_main_queue(), ...), the block is enqueued directly on the main run
+/// loop with a mode list that includes AWT's special run loop mode, so it is serviced even while the main
+/// thread is spinning inside an AppKit->EDT wait (as can happen around window show). The GCD main queue is
+/// not drained in that special mode, so dispatch_sync could deadlock there; this can't.
+static void performOnMainThreadAndWait(void (^block)(void)) {
+    if (NSThread.isMainThread) {
+        block();
+        return;
+    }
+    dispatch_semaphore_t done = dispatch_semaphore_create(0);
+    // Use string-literal mode names (NSEventTrackingRunLoopMode / NSModalPanelRunLoopMode are AppKit
+    // symbols, not imported here); these match the modes AWT's own performOnMainThread services.
+    NSArray *modes = @[NSDefaultRunLoopMode, @"NSEventTrackingRunLoopMode", @"NSModalPanelRunLoopMode", @"AWTRunLoopMode"];
+    CFRunLoopPerformBlock(CFRunLoopGetMain(), (__bridge CFTypeRef) modes, ^{
+        block();
+        dispatch_semaphore_signal(done);
+    });
+    CFRunLoopWakeUp(CFRunLoopGetMain());
+    dispatch_semaphore_wait(done, DISPATCH_TIME_FOREVER);
+}
+
+/// Presents the current drawable for a frame rendered while the window is not yet showing (the warm-up
+/// frame drawn just before the window is first shown), committing the layer-contents update to the window
+/// server before returning. Otherwise the window's first on-screen frame appears before our content is
+/// committed, briefly flashing the Canvas's background color.
+///
+/// The plain async present ([drawable present] without a transaction) is vsync-paced: it schedules the
+/// contents swap for a later CoreAnimation commit, which can land only after the window is already on
+/// screen. The transactional present (presentsWithTransaction + an explicit committed-and-flushed
+/// CATransaction) makes delivery deterministic — but it must run on the AppKit main thread: committing it
+/// from another thread (the AWT event dispatch thread, where this is called) wedges the layer's present
+/// queue, leaving the window permanently blank.
+///
+/// While the window is hidden there is no other presenter (the frame loop is gated on the layer being
+/// showing, and there is no live resize), so toggling presentsWithTransaction here is safe.
+JNIEXPORT void JNICALL Java_org_jetbrains_skiko_context_MetalContextHandler_finishFrameBeforeShown(
+    JNIEnv *env, jobject contextHandler, jlong devicePtr)
+{
+    finishFrame(devicePtr, ^(MetalDevice *device, id<CAMetalDrawable> currentDrawable, id<MTLCommandBuffer> commandBuffer) {
+        /// commit + waitUntilScheduled guarantees the drawing command buffer (submitted by Skia earlier,
+        /// ahead of this one in the queue) is scheduled first, so the present below can't outrun the
+        /// rendering. Done on the calling thread to keep the main-thread block minimal.
+        [commandBuffer commit];
+        [commandBuffer waitUntilScheduled];
+
+        performOnMainThreadAndWait(^{
+            [CATransaction begin];
+            [CATransaction setValue:(id)kCFBooleanTrue forKey:kCATransactionDisableActions];
+            /// presentsWithTransaction is read at the [present] call, so restoring it right after is safe.
+            device.layer.presentsWithTransaction = YES;
+            [currentDrawable present];
+            device.layer.presentsWithTransaction = NO;
+            [CATransaction commit];
+            /// Push the transaction to the window server now instead of at the end of the current run loop
+            /// cycle — we must return only after the contents swap has been committed.
+            [CATransaction flush];
+        });
+    });
+}
+
 } // extern C
 #endif

--- a/skiko/src/awtMain/objectiveC/macos/MetalContextHandler.mm
+++ b/skiko/src/awtMain/objectiveC/macos/MetalContextHandler.mm
@@ -148,68 +148,26 @@ JNIEXPORT void JNICALL Java_org_jetbrains_skiko_context_MetalContextHandler_fini
     });
 }
 
-/// Runs `block` on the AppKit main thread and waits for it to complete (runs it inline when already on
-/// the main thread).
+/// Presents the current drawable for the warm-up frame rendered just before the window is first shown, so
+/// the window's first on-screen frame draws our content instead of briefly flashing the Canvas's background color.
 ///
-/// Unlike dispatch_sync(dispatch_get_main_queue(), ...), the block is enqueued directly on the main run
-/// loop with a mode list that includes AWT's special run loop mode, so it is serviced even while the main
-/// thread is spinning inside an AppKit->EDT wait (as can happen around window show). The GCD main queue is
-/// not drained in that special mode, so dispatch_sync could deadlock there; this can't.
-static void performOnMainThreadAndWait(void (^block)(void)) {
-    if (NSThread.isMainThread) {
-        block();
-        return;
-    }
-    dispatch_semaphore_t done = dispatch_semaphore_create(0);
-    // Use string-literal mode names (NSEventTrackingRunLoopMode / NSModalPanelRunLoopMode are AppKit
-    // symbols, not imported here); these match the modes AWT's own performOnMainThread services.
-    NSArray *modes = @[NSDefaultRunLoopMode, @"NSEventTrackingRunLoopMode", @"NSModalPanelRunLoopMode", @"AWTRunLoopMode"];
-    CFRunLoopPerformBlock(CFRunLoopGetMain(), (__bridge CFTypeRef) modes, ^{
-        block();
-        dispatch_semaphore_signal(done);
-    });
-    CFRunLoopWakeUp(CFRunLoopGetMain());
-    dispatch_semaphore_wait(done, DISPATCH_TIME_FOREVER);
-}
-
-/// Presents the current drawable for a frame rendered while the window is not yet showing (the warm-up
-/// frame drawn just before the window is first shown), committing the layer-contents update to the window
-/// server before returning. Otherwise the window's first on-screen frame appears before our content is
-/// committed, briefly flashing the Canvas's background color.
-///
-/// The plain async present ([drawable present] without a transaction) is vsync-paced: it schedules the
-/// contents swap for a later CoreAnimation commit, which can land only after the window is already on
-/// screen. The transactional present (presentsWithTransaction + an explicit committed-and-flushed
-/// CATransaction) makes delivery deterministic — but it must run on the AppKit main thread: committing it
-/// from another thread (the AWT event dispatch thread, where this is called) wedges the layer's present
-/// queue, leaving the window permanently blank.
-///
-/// While the window is hidden there is no other presenter (the frame loop is gated on the layer being
-/// showing, and there is no live resize), so toggling presentsWithTransaction here is safe.
+/// A plain asynchronous present is enough: once a warm-up frame has been presented, the window server
+/// composites the window's first on-screen frame only after that drawable's GPU work completes, so the
+/// background is never shown.
 JNIEXPORT void JNICALL Java_org_jetbrains_skiko_context_MetalContextHandler_finishFrameBeforeShown(
     JNIEnv *env, jobject contextHandler, jlong devicePtr)
 {
     finishFrame(devicePtr, ^(MetalDevice *device, id<CAMetalDrawable> currentDrawable, id<MTLCommandBuffer> commandBuffer) {
         /// commit + waitUntilScheduled guarantees the drawing command buffer (submitted by Skia earlier,
         /// ahead of this one in the queue) is scheduled first, so the present below can't outrun the
-        /// rendering. Done on the calling thread to keep the main-thread block minimal.
+        /// rendering.
         [commandBuffer commit];
         [commandBuffer waitUntilScheduled];
-
-        performOnMainThreadAndWait(^{
-            [CATransaction begin];
-            [CATransaction setValue:(id)kCFBooleanTrue forKey:kCATransactionDisableActions];
-            /// presentsWithTransaction is read at the [present] call, so restoring it right after is safe.
-            device.layer.presentsWithTransaction = YES;
-            [currentDrawable present];
-            device.layer.presentsWithTransaction = NO;
-            [CATransaction commit];
-            /// Push the transaction to the window server now instead of at the end of the current run loop
-            /// cycle — we must return only after the contents swap has been committed.
-            [CATransaction flush];
-        });
+        [currentDrawable present];
     });
 }
 
 } // extern C
 #endif
+
+       

--- a/skiko/src/awtMain/objectiveC/macos/MetalContextHandler.mm
+++ b/skiko/src/awtMain/objectiveC/macos/MetalContextHandler.mm
@@ -83,10 +83,10 @@ static void finishFrame(jlong devicePtr, void (^present)(MetalDevice *device, id
     }
 }
 
-/// Presents the current drawable asynchronously — skiko's default, used for every frame outside a live
-/// resize. Called off the AppKit main thread (from the background frame loop) so present work doesn't
+/// Presents the current drawable asynchronously — the default, used under normal circumstances.
+/// Called off the AppKit main thread (from the background frame loop) so present work doesn't
 /// destabilize FPS on the main thread.
-JNIEXPORT void JNICALL Java_org_jetbrains_skiko_context_MetalContextHandler_finishFrame(
+JNIEXPORT void JNICALL Java_org_jetbrains_skiko_context_MetalContextHandler_finishFrameAsync(
     JNIEnv *env, jobject contextHandler, jlong devicePtr)
 {
     finishFrame(devicePtr, ^(MetalDevice *device, id<CAMetalDrawable> currentDrawable, id<MTLCommandBuffer> commandBuffer) {
@@ -120,47 +120,30 @@ JNIEXPORT void JNICALL Java_org_jetbrains_skiko_context_MetalContextHandler_fini
     });
 }
 
-/// Presents the current drawable synchronously, joining the ambient window-resize CATransaction.
-/// Must be called on the AppKit main thread during a live resize (from drawFrameWhileLiveResizing),
-/// where the ambient CATransaction — from AWTMetalLayer.setBounds, committing the window's new size —
-/// flushes the present. This is the sole presenter for the duration of the resize.
-JNIEXPORT void JNICALL Java_org_jetbrains_skiko_context_MetalContextHandler_finishFrameInLiveResize(
+/// Presents the current drawable synchronously
+/// This is used:
+/// - During live-resize, on the AppKit main thread, to join the ambient resize transaction
+/// - When the window is displayable but not yet shown, to make sure the first visible frame already has the content,
+///   avoiding flashing the layer background.
+JNIEXPORT void JNICALL Java_org_jetbrains_skiko_context_MetalContextHandler_finishFrameSync(
     JNIEnv *env, jobject contextHandler, jlong devicePtr)
 {
     finishFrame(devicePtr, ^(MetalDevice *device, id<CAMetalDrawable> currentDrawable, id<MTLCommandBuffer> commandBuffer) {
-        /// presentsWithTransaction is YES for the whole resize session — the live-resize start
-        /// observer (MetalRedrawer.mm) sets it, the end observer clears it. Holding it layer-wide is
-        /// safe because during a resize the main thread is the sole presenter; the only frames that
-        /// could reach the async finishFrame path are stragglers, and they're dropped there rather
-        /// than presenting under YES.
+        /// During live-resize:
+        ///   presentsWithTransaction is YES for the whole resize session — the live-resize start
+        ///   observer (MetalRedrawer.mm) sets it, the end observer clears it. Holding it layer-wide is
+        ///   safe because during a resize the main thread is the sole presenter; the only frames that
+        ///   could reach the async finishFrame path are stragglers, and they're dropped there rather
+        ///   than presenting under YES.
+        ///   Present synchronously so the drawable swap joins the ambient window resize transaction
+        ///   (no nested begin/commit — that would split it back out). commit + waitUntilScheduled
+        ///   guarantees the drawing command buffer (submitted by Skia earlier, ahead of this one in
+        ///   the queue) is scheduled first.
         ///
-        /// Present synchronously so the drawable swap joins the ambient window resize transaction
-        /// (no nested begin/commit — that would split it back out). commit + waitUntilScheduled
-        /// guarantees the drawing command buffer (submitted by Skia earlier, ahead of this one in
-        /// the queue) is scheduled first.
-        ///
-        /// No drawable-vs-layer size guard is needed here (unlike the async finishFrame path): setBounds
-        /// set drawableSize, then we acquired the drawable, rendered, committed and present it all
-        /// synchronously on this thread inside one transaction, so the layer size cannot change underneath.
-        [commandBuffer commit];
-        [commandBuffer waitUntilScheduled];
-        [currentDrawable present];
-    });
-}
-
-/// Presents the current drawable for the warm-up frame rendered just before the window is first shown, so
-/// the window's first on-screen frame draws our content instead of briefly flashing the Canvas's background color.
-///
-/// A plain asynchronous present is enough: once a warm-up frame has been presented, the window server
-/// composites the window's first on-screen frame only after that drawable's GPU work completes, so the
-/// background is never shown.
-JNIEXPORT void JNICALL Java_org_jetbrains_skiko_context_MetalContextHandler_finishFrameBeforeShown(
-    JNIEnv *env, jobject contextHandler, jlong devicePtr)
-{
-    finishFrame(devicePtr, ^(MetalDevice *device, id<CAMetalDrawable> currentDrawable, id<MTLCommandBuffer> commandBuffer) {
-        /// commit + waitUntilScheduled guarantees the drawing command buffer (submitted by Skia earlier,
-        /// ahead of this one in the queue) is scheduled first, so the present below can't outrun the
-        /// rendering.
+        /// In draw-before-visible:
+        ///   commit + waitUntilScheduled guarantees the drawing command buffer (submitted by Skia earlier,
+        ///   ahead of this one in the queue) is scheduled first, so the present below can't outrun the
+        ///   rendering.
         [commandBuffer commit];
         [commandBuffer waitUntilScheduled];
         [currentDrawable present];

--- a/skiko/src/awtMain/objectiveC/macos/MetalContextHandler.mm
+++ b/skiko/src/awtMain/objectiveC/macos/MetalContextHandler.mm
@@ -152,5 +152,3 @@ JNIEXPORT void JNICALL Java_org_jetbrains_skiko_context_MetalContextHandler_fini
 
 } // extern C
 #endif
-
-       

--- a/skiko/src/awtTest/kotlin/org/jetbrains/skiko/FirstWindowShowFlashHelper.kt
+++ b/skiko/src/awtTest/kotlin/org/jetbrains/skiko/FirstWindowShowFlashHelper.kt
@@ -1,0 +1,68 @@
+package org.jetbrains.skiko
+
+import org.jetbrains.skia.Canvas
+import org.jetbrains.skia.FilterTileMode
+import org.jetbrains.skia.ImageFilter
+import org.jetbrains.skia.Paint
+import org.jetbrains.skia.Rect
+import java.awt.BorderLayout
+import java.awt.Color
+import java.awt.Dimension
+import javax.swing.JFrame
+import javax.swing.SwingUtilities
+
+/**
+ * Standalone harness launched in a FRESH JVM by the `no window flash on first show` test.
+ *
+ * The first-show background flash only reproduces on the very first window displayed in a process, so the
+ * test cannot observe it from its own (long-since-warmed-up) JVM. Instead it spawns this harness per run:
+ * a brand-new process whose single window is genuinely its first, using the render API and color passed in
+ * argv (`renderApi rgb`). The window bounds are hard-coded to cover the pixel the parent samples.
+ *
+ * The frame it draws is deliberately made expensive by repeated full-window blur passes, forcing real GPU work
+ * to stress the fix as hard as possible.
+ */
+object FirstWindowShowFlashHelper {
+    // Hard-coded window bounds. The parent (SkiaLayerTest."no window flash on first show") positions its
+    // background window so that the pixel it samples (the background's center) falls within these bounds.
+    private const val X = 400
+    private const val Y = 400
+    private const val WIDTH = 600
+    private const val HEIGHT = 600
+
+    @JvmStatic
+    fun main(args: Array<String>) {
+        val renderApi = GraphicsApi.valueOf(args[0])
+        val color = Color(args[1].toInt())
+
+        SwingUtilities.invokeLater {
+            val layer = SkiaLayer(properties = SkiaLayerProperties(renderApi = renderApi))
+            layer.renderDelegate = object : SkikoRenderDelegate {
+                private val paint = Paint().also { it.color = color.rgb }
+                private val loadFill = Paint().also { it.color = Color.GRAY.rgb }
+
+                override fun onRender(canvas: Canvas, width: Int, height: Int, nanoTime: Long) {
+                    val rect = Rect(0f, 0f, width.toFloat(), height.toFloat())
+                    repeat(1000) {
+                        val layerPaint = Paint().also {
+                            it.imageFilter = ImageFilter.makeBlur(30f, 30f, FilterTileMode.CLAMP)
+                        }
+                        canvas.saveLayer(rect, layerPaint)
+                        canvas.drawRect(rect, loadFill)
+                        canvas.restore()
+                    }
+                    canvas.drawRect(rect, paint)
+                }
+            }
+
+            JFrame().apply {
+                contentPane.add(layer, BorderLayout.CENTER)
+                setLocation(X, Y)
+                size = Dimension(WIDTH, HEIGHT)
+                // Ensure our window lands above the parent's background window at these coordinates.
+                isAlwaysOnTop = true
+                isVisible = true
+            }
+        }
+    }
+}

--- a/skiko/src/awtTest/kotlin/org/jetbrains/skiko/FirstWindowShowFlashHelper.kt
+++ b/skiko/src/awtTest/kotlin/org/jetbrains/skiko/FirstWindowShowFlashHelper.kt
@@ -8,6 +8,7 @@ import org.jetbrains.skia.Rect
 import java.awt.BorderLayout
 import java.awt.Color
 import java.awt.Dimension
+import java.awt.Point
 import javax.swing.JFrame
 import javax.swing.SwingUtilities
 
@@ -25,10 +26,8 @@ import javax.swing.SwingUtilities
 object FirstWindowShowFlashHelper {
     // Hard-coded window bounds. The parent (SkiaLayerTest."no window flash on first show") positions its
     // background window so that the pixel it samples (the background's center) falls within these bounds.
-    private const val X = 400
-    private const val Y = 400
-    private const val WIDTH = 600
-    private const val HEIGHT = 600
+    private val WINDOW_LOCATION = Point(400, 400)
+    private val WINDOW_SIZE = Dimension(600, 600)
 
     @JvmStatic
     fun main(args: Array<String>) {
@@ -57,8 +56,8 @@ object FirstWindowShowFlashHelper {
 
             JFrame().apply {
                 contentPane.add(layer, BorderLayout.CENTER)
-                setLocation(X, Y)
-                size = Dimension(WIDTH, HEIGHT)
+                location = WINDOW_LOCATION
+                size = WINDOW_SIZE
                 // Ensure our window lands above the parent's background window at these coordinates.
                 isAlwaysOnTop = true
                 isVisible = true

--- a/skiko/src/awtTest/kotlin/org/jetbrains/skiko/FirstWindowShowFlashHelper.kt
+++ b/skiko/src/awtTest/kotlin/org/jetbrains/skiko/FirstWindowShowFlashHelper.kt
@@ -9,7 +9,7 @@ import java.awt.BorderLayout
 import java.awt.Color
 import java.awt.Dimension
 import java.awt.Point
-import javax.swing.JFrame
+import javax.swing.JWindow
 import javax.swing.SwingUtilities
 
 /**
@@ -54,11 +54,13 @@ object FirstWindowShowFlashHelper {
                 }
             }
 
-            JFrame().apply {
+            // Use JWindow, not JFrame because the latter is shown with a fade-in animation on Windows,
+            // which breaks the color comparison in the test
+            JWindow().apply {
                 contentPane.add(layer, BorderLayout.CENTER)
                 location = WINDOW_LOCATION
                 size = WINDOW_SIZE
-                // Ensure our window lands above the parent's background window at these coordinates.
+                // Ensure our window is above the parent's background window
                 isAlwaysOnTop = true
                 isVisible = true
             }

--- a/skiko/src/awtTest/kotlin/org/jetbrains/skiko/FirstWindowShowFlashHelper.kt
+++ b/skiko/src/awtTest/kotlin/org/jetbrains/skiko/FirstWindowShowFlashHelper.kt
@@ -39,13 +39,13 @@ object FirstWindowShowFlashHelper {
             layer.renderDelegate = object : SkikoRenderDelegate {
                 private val paint = Paint().also { it.color = color.rgb }
                 private val loadFill = Paint().also { it.color = Color.GRAY.rgb }
+                private val layerPaint = Paint().also {
+                    it.imageFilter = ImageFilter.makeBlur(30f, 30f, FilterTileMode.CLAMP)
+                }
 
                 override fun onRender(canvas: Canvas, width: Int, height: Int, nanoTime: Long) {
                     val rect = Rect(0f, 0f, width.toFloat(), height.toFloat())
                     repeat(1000) {
-                        val layerPaint = Paint().also {
-                            it.imageFilter = ImageFilter.makeBlur(30f, 30f, FilterTileMode.CLAMP)
-                        }
                         canvas.saveLayer(rect, layerPaint)
                         canvas.drawRect(rect, loadFill)
                         canvas.restore()

--- a/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
+++ b/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
@@ -1280,7 +1280,7 @@ class SkiaLayerTest {
         }
 
         try {
-            repeat(10) { testRun ->
+            repeat(8) { testRun ->
                 // Wait until the sampled pixel shows the (green) background before launching the child.
                 waitForSampledPixelCloseTo(bgColor)
 

--- a/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
+++ b/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
@@ -1202,13 +1202,13 @@ class SkiaLayerTest {
     }
 
     @OptIn(ExperimentalAtomicApi::class)
-    @Test(timeout = 120000)
+    @Test(timeout = 240000)
     fun `no window flash on first show`() = uiTest {
-        // Until the issue is fixed in other redrawers
+        // Exclude known-bad pairs of OSes and graphics APIs.
         // Don't use assumeTrue, as uiTest iterates over multiple renderers,
         // and if one of them is skipped, the whole test is skipped
-        val fixedRenderApis = setOf(GraphicsApi.METAL/*, GraphicsApi.DIRECT3D*/)
-        if (renderApi !in fixedRenderApis) return@uiTest
+        val badRenderApis = setOf<Pair<OS, GraphicsApi>>()
+        if (Pair(hostOs, renderApi) in badRenderApis) return@uiTest
 
         val bgColor = Color.GREEN
         val fgColor = Color.BLACK
@@ -1220,7 +1220,7 @@ class SkiaLayerTest {
         // then screenshot the center pixel while the child shows, making sure it is always either black (the
         // child's content) or green (this background) - never a flash of some other color.
 
-        val backgroundWindow = JFrame().also {
+        val backgroundWindow = JFrame(renderApi.name).also {
             it.location = Point(200, 200)
             it.size = Dimension(1000, 1000)
             it.contentPane.background = bgColor
@@ -1228,6 +1228,7 @@ class SkiaLayerTest {
         backgroundWindow.isVisible = true
         backgroundWindow.waitUntilOpened()
         delay(200)
+        backgroundWindow.toFront()
 
         val pixelLocation = backgroundWindow.bounds.let {
             Point(it.x + it.width / 2, it.y + it.height / 2)

--- a/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
+++ b/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
@@ -1257,7 +1257,6 @@ class SkiaLayerTest {
         }
 
         suspend fun waitForSampledPixelCloseTo(targetColor: Color) {
-            println("Waiting for $targetColor")
             do {
                 delay(200)
             } while (!lastPixelColorDetected.load().let { it != null && it.closeTo(targetColor) })
@@ -1282,13 +1281,10 @@ class SkiaLayerTest {
         }
 
         try {
-            repeat(20) { testRun ->
-                println("[${renderTime().nanoseconds.inWholeSeconds}] Test run $testRun")
-
+            repeat(10) { testRun ->
                 // Wait until the sampled pixel shows the (green) background before launching the child.
                 waitForSampledPixelCloseTo(bgColor)
 
-                println("Launching child process")
                 val child = ProcessBuilder(childCommand)
                     .redirectErrorStream(true)
                     .redirectOutput(ProcessBuilder.Redirect.INHERIT)
@@ -1305,13 +1301,11 @@ class SkiaLayerTest {
                     )
                     assertTrue(contentShown, "Child window content never appeared in run ${testRun + 1}.")
                 } finally {
-                    println("Waiting for child process to stop")
                     child.destroy()
                     if (!child.waitFor(5, TimeUnit.SECONDS)) child.destroyForcibly()
                 }
             }
         } finally {
-            println("Waiting for sampling thread to stop")
             stopThread.getAndSet(true)
             t.join()
             backgroundWindow.dispose()

--- a/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
+++ b/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
@@ -32,7 +32,9 @@ import java.awt.Color
 import java.awt.Graphics
 import java.awt.Point
 import java.awt.event.*
+import java.io.File
 import java.util.concurrent.Semaphore
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.swing.Box
 import javax.swing.JComponent
@@ -51,6 +53,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 @Suppress("SameParameterValue")
 class SkiaLayerTest {
@@ -1209,9 +1212,12 @@ class SkiaLayerTest {
         val bgColor = Color.GREEN
         val fgColor = Color.BLACK
 
-        // Put up a large green window, and then repeatedly show a smaller black window on top of it while
-        // screenshotting the pixel at the center, making sure that pixel is always either black (the
-        // window's content) or green (the background window) - never a flash of some other color.
+        // The first-show flash only reproduces on the very FIRST window displayed in a process. This test's
+        // own JVM warmed that up long ago (earlier tests showed windows), so instead each run spawns a
+        // fresh JVM (FirstShowFlashHarness) whose single black Metal window is genuinely its first. We keep a
+        // large green background window here to provide a known reference color behind the child's window,
+        // then screenshot the center pixel while the child shows, making sure it is always either black (the
+        // child's content) or green (this background) - never a flash of some other color.
 
         val backgroundWindow = JFrame().also {
             it.size = Dimension(1000, 1000)
@@ -1225,52 +1231,81 @@ class SkiaLayerTest {
         val pixelLocation = backgroundWindow.bounds.let {
             Point(it.x + it.width / 2, it.y + it.height / 2)
         }
-        val nonBlackPixelDetected = AtomicReference<Color?>(null)
-        val stopThread = AtomicBoolean(false)
-        val semaphore = Semaphore(0, true)
+        // The child harness hard-codes its window bounds to cover this pixel (the background window's center).
 
+        val flashPixelDetected = AtomicReference<Color?>(null)
+        val lastPixelColorDetected = AtomicReference<Color?>(null)
+        val stopThread = AtomicBoolean(false)
+
+        // Sample continuously (never stops on detection, so every run is still checked) and latch the first
+        // pixel that is neither the background nor the content color.
         val t = thread {
             val robot = Robot()
-            while (!stopThread.get()) {
-                val pixel = robot.getPixelColor(pixelLocation.x, pixelLocation.y)
-                if (!pixel.closeTo(fgColor) && !pixel.closeTo(bgColor)) {
-                    nonBlackPixelDetected.store(pixel)
-                    return@thread
+            try {
+                while (!stopThread.get()) {
+                    val pixel = robot.getPixelColor(pixelLocation.x, pixelLocation.y)
+                    lastPixelColorDetected.store(pixel)
+                    if (!pixel.closeTo(fgColor) && !pixel.closeTo(bgColor)) {
+                        flashPixelDetected.compareAndSet(null, pixel)
+                    }
                 }
-                semaphore.release()
+            } catch (e: Exception) {
+                e.printStackTrace()
             }
         }
-        // Wait for the thread to start reading pixels
-        semaphore.acquire()
+
+        suspend fun waitForSampledPixelCloseTo(targetColor: Color) {
+            do {
+                delay(200)
+            } while (!lastPixelColorDetected.load().let { it != null && it.closeTo(targetColor) })
+        }
+
+        // Build the command that launches a child JVM running FirstShowFlashHarness, forwarding this JVM's
+        // classpath, every skiko.* system property (notably skiko.library.path, which is how the native
+        // library is located), and the same --add-opens the test task uses.
+        val javaExe = File(System.getProperty("java.home"), "bin${File.separator}java").absolutePath
+        val childCommand = buildList {
+            add(javaExe)
+            add("-cp")
+            add(System.getProperty("java.class.path"))
+            System.getProperties().stringPropertyNames()
+                .filter { it.startsWith("skiko.") }
+                .forEach { add("-D$it=${System.getProperty(it)}") }
+            add("--add-opens")
+            add("java.desktop/sun.font=ALL-UNNAMED")
+            add(FirstWindowShowFlashHelper::class.java.name)
+            add(renderApi.name)
+            add(fgColor.rgb.toString())
+        }
 
         try {
-            repeat(50) { testRun ->
-                delay(50)
-                lateinit var renderDelegate: SolidColorRenderer
-                val window = UiTestWindow {
-                    size = Dimension(600, 600)
-                    location = Point(400, 400)
-                    background = Color.WHITE
-                    renderDelegate = SolidColorRenderer(
-                        layer = layer,
-                        color = fgColor,
-                    )
-                    layer.renderDelegate = renderDelegate
-                    contentPane.add(layer, BorderLayout.CENTER)
-                }
+            repeat(20) { testRun ->
+                // Wait until the sampled pixel shows the (green) background before launching the child.
+                waitForSampledPixelCloseTo(bgColor)
 
+                val child = ProcessBuilder(childCommand)
+                    .redirectErrorStream(true)
+                    .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+                    .start()
                 try {
-                    window.isVisible = true
-                    window.waitUntilOpened()
-                    delay(100)
-                    assertNull(nonBlackPixelDetected.load(), "Detected a non-black pixel on window show in run ${testRun + 1}.")
+                    // Wait for the child's black content to reach the screen
+                    val contentShown = withTimeoutOrNull(30.seconds) {
+                        waitForSampledPixelCloseTo(fgColor)
+                        true
+                    } ?: false
+                    assertNull(
+                        flashPixelDetected.load(),
+                        "Detected a flash (neither background nor content color) on first show in run ${testRun + 1}."
+                    )
+                    assertTrue(contentShown, "Child window content never appeared in run ${testRun + 1}.")
                 } finally {
-                    stopThread.getAndSet(true)
-                    t.join()
-                    window.dispose()
+                    child.destroy()
+                    if (!child.waitFor(5, TimeUnit.SECONDS)) child.destroyForcibly()
                 }
             }
         } finally {
+            stopThread.getAndSet(true)
+            t.join()
             backgroundWindow.dispose()
         }
     }

--- a/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
+++ b/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
@@ -16,6 +16,7 @@ import org.jetbrains.skiko.redrawer.MetalRedrawer
 import org.jetbrains.skiko.redrawer.MetalVSyncer
 import org.jetbrains.skiko.redrawer.Redrawer
 import org.jetbrains.skiko.redrawer.defaultIsTransparentBackgroundSupported
+import org.jetbrains.skiko.redrawer.renderTime
 import org.jetbrains.skiko.swing.SkiaSwingLayer
 import org.jetbrains.skiko.util.ScreenshotTestRule
 import org.jetbrains.skiko.util.UiTestScope
@@ -53,6 +54,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.Duration.Companion.seconds
 
 @Suppress("SameParameterValue")
@@ -1255,6 +1257,7 @@ class SkiaLayerTest {
         }
 
         suspend fun waitForSampledPixelCloseTo(targetColor: Color) {
+            println("Waiting for $targetColor")
             do {
                 delay(200)
             } while (!lastPixelColorDetected.load().let { it != null && it.closeTo(targetColor) })
@@ -1280,9 +1283,12 @@ class SkiaLayerTest {
 
         try {
             repeat(20) { testRun ->
+                println("[${renderTime().nanoseconds.inWholeSeconds}] Test run $testRun")
+
                 // Wait until the sampled pixel shows the (green) background before launching the child.
                 waitForSampledPixelCloseTo(bgColor)
 
+                println("Launching child process")
                 val child = ProcessBuilder(childCommand)
                     .redirectErrorStream(true)
                     .redirectOutput(ProcessBuilder.Redirect.INHERIT)
@@ -1299,11 +1305,13 @@ class SkiaLayerTest {
                     )
                     assertTrue(contentShown, "Child window content never appeared in run ${testRun + 1}.")
                 } finally {
+                    println("Waiting for child process to stop")
                     child.destroy()
                     if (!child.waitFor(5, TimeUnit.SECONDS)) child.destroyForcibly()
                 }
             }
         } finally {
+            println("Waiting for sampling thread to stop")
             stopThread.getAndSet(true)
             t.join()
             backgroundWindow.dispose()

--- a/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
+++ b/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
@@ -41,13 +41,17 @@ import javax.swing.JLayeredPane
 import javax.swing.JPanel
 import javax.swing.SwingUtilities
 import javax.swing.WindowConstants
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.concurrent.thread
+import kotlin.coroutines.resume
 import kotlin.math.absoluteValue
 import kotlin.random.Random
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.nanoseconds
 
 @Suppress("SameParameterValue")
 class SkiaLayerTest {
@@ -1195,6 +1199,84 @@ class SkiaLayerTest {
         }
     }
 
+    @OptIn(ExperimentalAtomicApi::class)
+    @Test
+    fun `no window flash on first show`() = uiTest {
+        // Until the issue is fixed in other redrawers
+        // Don't use assumeTrue, as uiTest iterates over multiple renderers,
+        // and if one of them is skipped, the whole test is skipped
+        if ((renderApi != GraphicsApi.METAL) && (renderApi != GraphicsApi.DIRECT3D)) return@uiTest
+
+        val bgColor = Color.GREEN
+        val fgColor = Color.BLACK
+
+        // Put up a large green window, and then repeatedly show a smaller black window on top of it while
+        // screenshotting the pixel at the center, making sure that pixel is always either black (the
+        // window's content) or green (the background window) - never a flash of some other color.
+
+        val backgroundWindow = JFrame().also {
+            it.size = Dimension(1000, 1000)
+            it.location = Point(200, 200)
+            it.contentPane.background = bgColor
+        }
+        backgroundWindow.isVisible = true
+        backgroundWindow.waitUntilOpened()
+        delay(200)
+
+        val pixelLocation = backgroundWindow.bounds.let {
+            Point(it.x + it.width / 2, it.y + it.height / 2)
+        }
+        val nonBlackPixelDetected = AtomicReference<Color?>(null)
+        val stopThread = AtomicBoolean(false)
+        val semaphore = Semaphore(0, true)
+
+        val t = thread {
+            val robot = Robot()
+            while (!stopThread.get()) {
+                val pixel = robot.getPixelColor(pixelLocation.x, pixelLocation.y)
+                if (!pixel.closeTo(fgColor) && !pixel.closeTo(bgColor)) {
+                    nonBlackPixelDetected.store(pixel)
+                    return@thread
+                }
+                semaphore.release()
+            }
+        }
+        // Wait for the thread to start reading pixels
+        semaphore.acquire()
+
+        try {
+            repeat(20) { testRun ->
+                delay(250)
+                lateinit var renderDelegate: SolidColorRenderer
+                val window = UiTestWindow {
+                    size = Dimension(600, 600)
+                    location = Point(400, 400)
+                    background = bgColor
+                    renderDelegate = SolidColorRenderer(
+                        layer = layer,
+                        color = fgColor,
+                    )
+                    layer.renderDelegate = renderDelegate
+                    contentPane.add(layer, BorderLayout.CENTER)
+                }
+
+                try {
+                    // Wait for the thread to start reading pixels
+                    window.isVisible = true
+                    window.waitUntilOpened()
+                    delay(250)
+                    assertNull(nonBlackPixelDetected.load(), "Detected a non-black pixel on window show in run ${testRun + 1}.")
+                } finally {
+                    stopThread.getAndSet(true)
+                    t.join()
+                    window.dispose()
+                }
+            }
+        } finally {
+            backgroundWindow.dispose()
+        }
+    }
+
     @Test
     fun `temporary change is not visible with needRender(throttledToVsync = false)`() = uiTest {
         assumeTrue(hostOs.isMacOS)
@@ -1637,3 +1719,12 @@ class SkiaLayerTest {
 }
 
 internal fun JFrame.close() = dispatchEvent(WindowEvent(this, WindowEvent.WINDOW_CLOSING))
+
+private suspend fun Window.waitUntilOpened() = suspendCancellableCoroutine { continuation ->
+    addWindowListener(object : WindowAdapter() {
+        override fun windowOpened(e: WindowEvent?) {
+            removeWindowListener(this)
+            continuation.resume(Unit)
+        }
+    })
+}

--- a/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
+++ b/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
@@ -1245,13 +1245,13 @@ class SkiaLayerTest {
         semaphore.acquire()
 
         try {
-            repeat(20) { testRun ->
-                delay(250)
+            repeat(50) { testRun ->
+                delay(50)
                 lateinit var renderDelegate: SolidColorRenderer
                 val window = UiTestWindow {
                     size = Dimension(600, 600)
                     location = Point(400, 400)
-                    background = bgColor
+                    background = Color.WHITE
                     renderDelegate = SolidColorRenderer(
                         layer = layer,
                         color = fgColor,
@@ -1261,10 +1261,9 @@ class SkiaLayerTest {
                 }
 
                 try {
-                    // Wait for the thread to start reading pixels
                     window.isVisible = true
                     window.waitUntilOpened()
-                    delay(250)
+                    delay(100)
                     assertNull(nonBlackPixelDetected.load(), "Detected a non-black pixel on window show in run ${testRun + 1}.")
                 } finally {
                     stopThread.getAndSet(true)

--- a/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
+++ b/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
@@ -51,7 +51,6 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.nanoseconds
 
 @Suppress("SameParameterValue")
 class SkiaLayerTest {

--- a/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
+++ b/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
@@ -16,7 +16,6 @@ import org.jetbrains.skiko.redrawer.MetalRedrawer
 import org.jetbrains.skiko.redrawer.MetalVSyncer
 import org.jetbrains.skiko.redrawer.Redrawer
 import org.jetbrains.skiko.redrawer.defaultIsTransparentBackgroundSupported
-import org.jetbrains.skiko.redrawer.renderTime
 import org.jetbrains.skiko.swing.SkiaSwingLayer
 import org.jetbrains.skiko.util.ScreenshotTestRule
 import org.jetbrains.skiko.util.UiTestScope
@@ -54,7 +53,6 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.Duration.Companion.seconds
 
 @Suppress("SameParameterValue")
@@ -1756,11 +1754,19 @@ class SkiaLayerTest {
 
 internal fun JFrame.close() = dispatchEvent(WindowEvent(this, WindowEvent.WINDOW_CLOSING))
 
-private suspend fun Window.waitUntilOpened() = suspendCancellableCoroutine { continuation ->
-    addWindowListener(object : WindowAdapter() {
-        override fun windowOpened(e: WindowEvent?) {
-            removeWindowListener(this)
-            continuation.resume(Unit)
+private suspend fun Window.waitUntilOpened() {
+    if (isShowing) return
+    lateinit var listener: WindowListener
+    try {
+        suspendCancellableCoroutine { continuation ->
+            listener = object : WindowAdapter() {
+                override fun windowOpened(e: WindowEvent?) {
+                    continuation.resume(Unit)
+                }
+            }
+            addWindowListener(listener)
         }
-    })
+    } finally {
+        removeWindowListener(listener)
+    }
 }

--- a/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
+++ b/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
@@ -1202,7 +1202,7 @@ class SkiaLayerTest {
     }
 
     @OptIn(ExperimentalAtomicApi::class)
-    @Test
+    @Test(timeout = 120000)
     fun `no window flash on first show`() = uiTest {
         // Until the issue is fixed in other redrawers
         // Don't use assumeTrue, as uiTest iterates over multiple renderers,

--- a/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
+++ b/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
@@ -1209,7 +1209,8 @@ class SkiaLayerTest {
         // Until the issue is fixed in other redrawers
         // Don't use assumeTrue, as uiTest iterates over multiple renderers,
         // and if one of them is skipped, the whole test is skipped
-        if (renderApi != GraphicsApi.METAL) return@uiTest
+        val fixedRenderApis = setOf(GraphicsApi.METAL/*, GraphicsApi.DIRECT3D*/)
+        if (renderApi !in fixedRenderApis) return@uiTest
 
         val bgColor = Color.GREEN
         val fgColor = Color.BLACK
@@ -1222,8 +1223,8 @@ class SkiaLayerTest {
         // child's content) or green (this background) - never a flash of some other color.
 
         val backgroundWindow = JFrame().also {
-            it.size = Dimension(1000, 1000)
             it.location = Point(200, 200)
+            it.size = Dimension(1000, 1000)
             it.contentPane.background = bgColor
         }
         backgroundWindow.isVisible = true
@@ -1271,7 +1272,7 @@ class SkiaLayerTest {
             add("-cp")
             add(System.getProperty("java.class.path"))
             System.getProperties().stringPropertyNames()
-                .filter { it.startsWith("skiko.") }
+                .filter { it.startsWith("skiko.") || it.startsWith("sun.") }
                 .forEach { add("-D$it=${System.getProperty(it)}") }
             add("--add-opens")
             add("java.desktop/sun.font=ALL-UNNAMED")

--- a/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
+++ b/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
@@ -1205,7 +1205,7 @@ class SkiaLayerTest {
         // Until the issue is fixed in other redrawers
         // Don't use assumeTrue, as uiTest iterates over multiple renderers,
         // and if one of them is skipped, the whole test is skipped
-        if ((renderApi != GraphicsApi.METAL) && (renderApi != GraphicsApi.DIRECT3D)) return@uiTest
+        if (renderApi != GraphicsApi.METAL) return@uiTest
 
         val bgColor = Color.GREEN
         val fgColor = Color.BLACK

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skiko/redrawer/Redrawer.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skiko/redrawer/Redrawer.kt
@@ -17,6 +17,10 @@ internal interface Redrawer {
     fun setVisible(isVisible: Boolean) = Unit
     val renderInfo: String
     fun isTransparentBackgroundSupported(): Boolean
+    /**
+     * Invoked by AWT [SkiaLayer] when the underlying Swing component is resized. Unused in other source-sets.
+     */
+    fun onLayerComponentResized() = Unit
 }
 
 internal fun defaultIsTransparentBackgroundSupported(layer: SkiaLayer): Boolean {

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skiko/redrawer/Redrawer.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skiko/redrawer/Redrawer.kt
@@ -17,14 +17,6 @@ internal interface Redrawer {
     fun setVisible(isVisible: Boolean) = Unit
     val renderInfo: String
     fun isTransparentBackgroundSupported(): Boolean
-
-    /**
-     * Invoked by [SkiaLayer] when the underlying platform component is resized.
-     */
-    fun onPlatformComponentResized() {
-        syncBoundsFromPlatformComponent()
-        needRender(throttledToVsync = false)
-    }
 }
 
 internal fun defaultIsTransparentBackgroundSupported(layer: SkiaLayer): Boolean {


### PR DESCRIPTION
Fix by presenting the first frame when the window is displayable but not yet visible.

Fixes https://youtrack.jetbrains.com/issue/CMP-10484/Metal-Eliminate-window-background-flash-on-first-show
Fixes https://youtrack.jetbrains.com/issue/CMP-10485/Direct3D-Eliminate-window-background-flash-on-first-show