### PR TITLE
Add graphite module

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,7 @@ jobs:
         run: |
           ./gradlew -p skiko --no-daemon --stacktrace \
             -Pskiko.native.enabled=true \
+            -Pskiko.graphite.jvm.enabled=true \
             -Dskiko.test.onci=true \
             -Dskiko.test.performance.enabled=false \
             awtTest

--- a/skiko/build.gradle.kts
+++ b/skiko/build.gradle.kts
@@ -443,11 +443,12 @@ fun configureSymbolsFor(os: OS, arch: Arch) {
     val skiaBindingsDir = skikoProjectContext.registerOrGetSkiaDirProvider(os, arch)
     val coreCompile = tasks.named<CompileSkikoCppTask>("compileJvmBindings$suffix")
     val coreObjcCompile = if (os.isMacOs) tasks.named<CompileSkikoObjCTask>("objcCompile$suffix") else null
-    val requiredSymbolFiles = files(
-        skikoProjectContext.jvmRequiredSymbolsFor(os, arch).also {
-            dependencies.add(it.name, project(":skiko-skottie"))
-        }
-    )
+    val requiredSymbols = skikoProjectContext.jvmRequiredSymbolsFor(os, arch)
+    dependencies.add(requiredSymbols.name, project(":skiko-skottie"))
+    if (os != OS.Android && supportGraphiteJvm) {
+        dependencies.add(requiredSymbols.name, project(":skiko-graphite"))
+    }
+    val requiredSymbolFiles = files(requiredSymbols)
 
     skikoProjectContext.configureGenerateSymbolsList(
         os, arch, skiaBindingsDir, coreCompile, coreObjcCompile, requiredSymbolFiles

--- a/skiko/buildSrc/src/main/kotlin/SkikoProjectContext.kt
+++ b/skiko/buildSrc/src/main/kotlin/SkikoProjectContext.kt
@@ -184,6 +184,9 @@ val Project.supportAndroid: Boolean
 val Project.supportAwt: Boolean
     get() = findProperty(SkikoGradleProperties.AWT_ENABLED) == "true" || isInIdea
 
+val Project.supportGraphiteJvm: Boolean
+    get() = hostOs == OS.MacOS && findProperty(SkikoGradleProperties.GRAPHITE_JVM_ENABLED) == "true"
+
 val Project.supportAllNative: Boolean
     get() = findProperty(SkikoGradleProperties.NATIVE_ENABLED) == "true" || isInIdea
 

--- a/skiko/buildSrc/src/main/kotlin/properties.kt
+++ b/skiko/buildSrc/src/main/kotlin/properties.kt
@@ -270,6 +270,7 @@ object SkikoGradleProperties {
     const val KOTLIN_LANGUAGE_VERSION = "skiko.kotlin.language.version"
     const val KOTLIN_API_VERSION = "skiko.kotlin.api.version"
     const val AWT_ENABLED = "skiko.awt.enabled"
+    const val GRAPHITE_JVM_ENABLED = "skiko.graphite.jvm.enabled"
     const val WASM_ENABLED = "skiko.wasm.enabled"
     const val ANDROID_ENABLED = "skiko.android.enabled"
     const val NATIVE_ENABLED = "skiko.native.enabled"

--- a/skiko/buildSrc/src/main/kotlin/publishing.kt
+++ b/skiko/buildSrc/src/main/kotlin/publishing.kt
@@ -89,10 +89,12 @@ fun SkikoProjectContext.declarePublications() {
     val ctx = SkikoPublishingContext(this)
     ctx.configurePublishingRepositories()
     ctx.configurePublicationDefaults()
-    ctx.configureAllJvmRuntimeJarPublications()
-    ctx.configureAwtRuntimeAllJarPublication()
-    ctx.configureAwtRuntimeJarPublication()
-    ctx.configureAwtPublicationConstraints()
+    if (kotlin.targets.findByName("awt") != null) {
+        ctx.configureAllJvmRuntimeJarPublications()
+        ctx.configureAwtRuntimeAllJarPublication()
+        ctx.configureAwtRuntimeJarPublication()
+        ctx.configureAwtPublicationConstraints()
+    }
     ctx.configureAdditionalRuntimeLibrariesPublication()
     ctx.configureWebPublication()
     ctx.configureAndroidPublication()

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/CommonTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/CommonTasksConfiguration.kt
@@ -6,12 +6,13 @@ import SkiaBuildType
 import SkikoProperties
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.getByType
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompileTool
 import registerSkikoTask
 import skiaVersion
 import supportAndroid
-import supportAwt
 import supportNativeIosArm64
 import supportNativeIosSimulatorArm64
 import supportNativeIosX64
@@ -133,6 +134,8 @@ fun skiaPreprocessorFlags(os: OS, buildType: SkiaBuildType): Array<String> {
 }
 
 fun Project.configureSignAndPublishDependencies() {
+    val hasAwtTarget = extensions.getByType<KotlinMultiplatformExtension>().targets.findByName("awt") != null
+
     if (supportWeb) {
         tasks.configureEach {
             val publishJs = "publishJsPublicationTo"
@@ -275,7 +278,7 @@ fun Project.configureSignAndPublishDependencies() {
         }
     }
 
-    if (supportAwt) {
+    if (hasAwtTarget) {
         val publishJvmRuntimeAngleX64 = "publishSkikoJvmRuntimeAngleWindowsX64PublicationToComposeRepoRepository"
         val publishJvmRuntimeAngleArm64 = "publishSkikoJvmRuntimeAngleWindowsArm64PublicationToComposeRepoRepository"
         val signJvmRuntimeX64 = "signSkikoJvmRuntimeWindowsX64Publication"
@@ -304,7 +307,7 @@ fun Project.configureSignAndPublishDependencies() {
 
         when {
             name.startsWith(publishKmp) -> {
-                if (supportAwt) {
+                if (hasAwtTarget) {
                     dependsOn(signAwt)
                     dependsOn(signAwtRuntimeElements)
                 }

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/JvmTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/JvmTasksConfiguration.kt
@@ -389,7 +389,11 @@ fun SkikoProjectContext.createObjcCompileTask(
 
     val srcDirs = projectDirs(
         "src/awtMain/objectiveC/${os.id}"
-    )
+    ) + if (skiko.includeTestHelpers) {
+        projectDirs("src/jvmTest/objectiveC")
+    } else {
+        emptyList()
+    }
     sourceRoots.set(srcDirs)
     val jdkHome = File(System.getProperty("java.home") ?: error("'java.home' is null"))
 

--- a/skiko/ci/build.gradle.kts
+++ b/skiko/ci/build.gradle.kts
@@ -10,6 +10,11 @@ val skikoSkottieArtifacts = SkikoArtifacts(
     displayName = "Skiko Skottie",
     pomDescription = "Kotlin Skia Skottie bindings",
 )
+val skikoGraphiteArtifacts = SkikoArtifacts(
+    artifactIdPrefix = "skiko-graphite",
+    displayName = "Skiko Graphite",
+    pomDescription = "Kotlin Skia Graphite bindings",
+)
 
 val skikoArtifactIds: List<String> =
     listOf(
@@ -58,6 +63,16 @@ val skikoArtifactIds: List<String> =
         skikoSkottieArtifacts.nativeArtifactIdFor(OS.TVOS, Arch.Arm64),
         skikoSkottieArtifacts.nativeArtifactIdFor(OS.TVOS, Arch.Arm64, isUikitSim = true),
         "${skikoSkottieArtifacts.jvmRuntimeArtifactId}-all",
+
+        skikoGraphiteArtifacts.commonArtifactId,
+        skikoGraphiteArtifacts.nativeArtifactIdFor(OS.MacOS, Arch.Arm64),
+        skikoGraphiteArtifacts.nativeArtifactIdFor(OS.MacOS, Arch.X64),
+        skikoGraphiteArtifacts.nativeArtifactIdFor(OS.IOS, Arch.X64),
+        skikoGraphiteArtifacts.nativeArtifactIdFor(OS.IOS, Arch.Arm64),
+        skikoGraphiteArtifacts.nativeArtifactIdFor(OS.IOS, Arch.Arm64, isUikitSim = true),
+        skikoGraphiteArtifacts.nativeArtifactIdFor(OS.TVOS, Arch.X64),
+        skikoGraphiteArtifacts.nativeArtifactIdFor(OS.TVOS, Arch.Arm64),
+        skikoGraphiteArtifacts.nativeArtifactIdFor(OS.TVOS, Arch.Arm64, isUikitSim = true),
 )
 
 val downloadSkikoArtifactsFromComposeDev by tasks.registering(DownloadFromSpaceMavenRepoTask::class) {

--- a/skiko/docs/build.gradle.kts
+++ b/skiko/docs/build.gradle.kts
@@ -16,5 +16,8 @@ dokka {
 
 dependencies {
     dokka(project(":"))
+    rootProject.findProject(":skiko-graphite")?.let {
+        dokka(it)
+    }
     dokka(project(":skiko-skottie"))
 }

--- a/skiko/gradle.properties
+++ b/skiko/gradle.properties
@@ -44,3 +44,6 @@ skiko.native.ios.enabled=false
 skiko.native.ios.arm64.enabled=false
 skiko.native.ios.simulatorArm64.enabled=false
 skiko.native.ios.x64.enabled=false
+
+skiko.graphite.jvm.enabled=false
+

--- a/skiko/settings.gradle.kts
+++ b/skiko/settings.gradle.kts
@@ -21,3 +21,6 @@ include("docs")
 include("import-generator")
 include("test-utils")
 include("skiko-skottie")
+if (System.getProperty("os.name") == "Mac OS X") {
+    include("skiko-graphite")
+}

--- a/skiko/skiko-graphite/build.gradle.kts
+++ b/skiko/skiko-graphite/build.gradle.kts
@@ -61,9 +61,6 @@ val graphiteProjectContext = SkikoProjectContext(
     windowsSdkPathProvider = {
         findWindowsSdkPaths(gradle, targetArch)
     },
-    createChecksumsTask = { os: OS, arch: Arch, fileToChecksum: Provider<File> ->
-        createChecksumsTask(os, arch, fileToChecksum)
-    },
     additionalRuntimeLibraries = emptyList(),
     configureDependencies = graphiteDependencies,
 )
@@ -167,18 +164,6 @@ kotlin {
 }
 
 
-// TODO now it can be moved, move it if you change this
-// Can't be moved to buildSrc because of Checksum dependency
-fun createChecksumsTask(
-    targetOs: OS,
-    targetArch: Arch,
-    fileToChecksum: Provider<File>,
-) = project.registerSkikoTask<org.gradle.crypto.checksum.Checksum>("createChecksums", targetOs, targetArch) {
-    inputFiles = project.files(fileToChecksum)
-    checksumAlgorithm = org.gradle.crypto.checksum.Checksum.Algorithm.SHA256
-    outputDirectory = layout.buildDirectory.dir("checksums-${targetId(targetOs, targetArch)}")
-}
-
 if (supportAwt && supportGraphiteJvm) {
     val graphiteAwtJarForTests by project.tasks.registering(Jar::class) {
         archiveBaseName.set("skiko-graphite-awt-test")
@@ -209,22 +194,6 @@ if (supportAwt && supportGraphiteJvm) {
     graphiteProjectContext.provideJvmRequiredSymbols(targetOs, targetArch)
     if (targetOs == OS.MacOS && targetArch == Arch.Arm64) {
         graphiteProjectContext.provideJvmRequiredSymbols(OS.MacOS, Arch.X64)
-    }
-}
-
-afterEvaluate {
-    tasks.configureEach {
-        if (group == "publishing") {
-            // There are many intermediate tasks in 'publishing' group.
-            // There are a lot of them and they have verbose names.
-            // To decrease noise in './gradlew tasks' output and Intellij Gradle tool window,
-            // group verbose tasks in a separate group 'other publishing'.
-            val allRepositories = publishing.repositories.map { it.name } + "MavenLocal"
-            val publishToTasks = allRepositories.map { "publishTo$it" }
-            if (name != "publish" && name !in publishToTasks) {
-                group = "other publishing"
-            }
-        }
     }
 }
 

--- a/skiko/skiko-graphite/build.gradle.kts
+++ b/skiko/skiko-graphite/build.gradle.kts
@@ -1,0 +1,248 @@
+@file:OptIn(ExperimentalKotlinGradlePluginApi::class)
+
+import org.jetbrains.compose.internal.publishing.MavenCentralProperties
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+import org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile
+import tasks.configuration.*
+import dsl.SkikoDependencyScope
+
+plugins {
+    kotlin("multiplatform")
+    org.jetbrains.dokka
+    `maven-publish`
+    signing
+    org.gradle.crypto.checksum
+}
+
+val skiko = SkikoProperties(rootProject)
+val targetOs = hostOs
+val targetArch = skiko.targetArch
+val coreProject = project(":")
+val graphiteArtifacts = SkikoArtifacts(
+    artifactIdPrefix = "skiko-graphite",
+    displayName = "Skiko Graphite",
+    pomDescription = "Kotlin Skia Graphite bindings",
+)
+
+val graphiteDependencies: SkikoDependencyScope.() -> Unit = {
+    dependsOnCore()
+    targets {
+        jvm {
+            macos {
+                staticSkiaLibs("skia_graphite_ext")
+                linkFlags("-lobjc")
+                frameworks("CoreFoundation", "Foundation", "Metal")
+            }
+            linux {
+                staticSkiaLibs("skia_graphite_ext")
+            }
+            windows {
+                staticSkiaLibs("skia_graphite_dawn_ext", "dawn_combined")
+                dynamicSystemLibs("onecore_apiset", "dxguid")
+            }
+        }
+        native {
+            staticSkiaLibs("skia_graphite_ext")
+            macos { frameworks("CoreFoundation", "Foundation", "Metal") }
+            ios { frameworks("CoreFoundation", "Foundation", "Metal") }
+            tvos { frameworks("CoreFoundation", "Foundation", "Metal") }
+        }
+    }
+}
+
+val graphiteProjectContext = SkikoProjectContext(
+    project = project,
+    skiko = skiko,
+    kotlin = kotlin,
+    kind = SkikoModuleKind.EXTENSION,
+    artifacts = graphiteArtifacts,
+    windowsSdkPathProvider = {
+        findWindowsSdkPaths(gradle, targetArch)
+    },
+    createChecksumsTask = { os: OS, arch: Arch, fileToChecksum: Provider<File> ->
+        createChecksumsTask(os, arch, fileToChecksum)
+    },
+    additionalRuntimeLibraries = emptyList(),
+    configureDependencies = graphiteDependencies,
+)
+
+repositories {
+    mavenCentral {
+        url = uri("https://cache-redirector.jetbrains.com/maven-central")
+    }
+    google()
+}
+
+kotlin {
+    compilerOptions {
+        languageVersion.set(skikoKotlinLanguageVersion)
+        apiVersion.set(skikoKotlinApiVersion)
+        freeCompilerArgs.add("-opt-in=org.jetbrains.skiko.InternalSkikoApi")
+    }
+
+    applyHierarchyTemplate(skikoSourceSetHierarchyTemplate)
+
+    if (supportAwt && supportGraphiteJvm) {
+        jvm("awt") {
+            compilations.all {
+                compileTaskProvider.configure {
+                    compilerOptions.jvmTarget.set(JvmTarget.JVM_11)
+                }
+            }
+        }
+    }
+
+
+    fun coreNativeSymbolSources(os: OS, arch: Arch, isUikitSim: Boolean) =
+        graphiteProjectContext.nativeSymbolSourcesFor(os, arch, isUikitSim).also {
+            dependencies.add(it.name, coreProject)
+        }
+
+    if (supportNativeMac) {
+        graphiteProjectContext.configureNativeTarget(OS.MacOS, Arch.X64, macosX64(), ::coreNativeSymbolSources)
+        graphiteProjectContext.configureNativeTarget(OS.MacOS, Arch.Arm64, macosArm64(), ::coreNativeSymbolSources)
+    }
+    if (supportNativeIosArm64) {
+        graphiteProjectContext.configureNativeTarget(OS.IOS, Arch.Arm64, iosArm64(), ::coreNativeSymbolSources)
+    }
+    if (supportNativeIosSimulatorArm64) {
+        graphiteProjectContext.configureNativeTarget(OS.IOS, Arch.Arm64, iosSimulatorArm64(), ::coreNativeSymbolSources)
+    }
+    if (supportNativeIosX64) {
+        graphiteProjectContext.configureNativeTarget(OS.IOS, Arch.X64, iosX64(), ::coreNativeSymbolSources)
+    }
+    if (supportNativeTvosArm64) {
+        graphiteProjectContext.configureNativeTarget(OS.TVOS, Arch.Arm64, tvosArm64(), ::coreNativeSymbolSources)
+    }
+    if (supportNativeTvosSimulatorArm64) {
+        graphiteProjectContext.configureNativeTarget(OS.TVOS, Arch.Arm64, tvosSimulatorArm64(), ::coreNativeSymbolSources)
+    }
+    if (supportNativeTvosX64) {
+        graphiteProjectContext.configureNativeTarget(OS.TVOS, Arch.X64, tvosX64(), ::coreNativeSymbolSources)
+    }
+
+    sourceSets.commonMain.dependencies {
+        implementation(kotlin("stdlib"))
+        /*
+        We use compileOnly here because the root project publishes multiple artifacts
+        which makes api/implementation(project(":")) fail during publishing.
+        This avoids Gradle's multi-publication ambiguity but skiko core is NOT added
+        as a transitive dependency of skiko-graphite, and it will NOT appear in the published POM
+        consumers MUST explicitly depend on both:
+            - implementation("org.jetbrains.skiko:skiko-x")
+            - implementation("org.jetbrains.skiko:skiko-graphite-x")
+         */
+        compileOnly(coreProject)
+    }
+
+    sourceSets.commonTest.dependencies {
+        implementation(kotlin("test"))
+        implementation(coreProject)
+    }
+
+    if (supportAwt && supportGraphiteJvm) {
+        graphiteProjectContext.jvmMainSourceSet?.dependencies {
+            implementation(kotlin("stdlib"))
+        }
+        graphiteProjectContext.jvmTestSourceSet?.dependencies {
+            implementation(kotlin("test-junit"))
+            implementation(kotlin("test"))
+        }
+        graphiteProjectContext.awtMainSourceSet?.dependencies {
+            implementation(libs.jetbrainsRuntime.api)
+        }
+    }
+
+
+    if (supportAnyNative) {
+        sourceSets.all {
+            // Really ugly, see https://youtrack.jetbrains.com/issue/KT-46649 why it is required,
+            // note that setting it per source set still keeps it unset in commonized source sets.
+            languageSettings.optIn("kotlin.native.SymbolNameIsInternal")
+        }
+        configureIOSTestsWithMetal(project)
+    }
+}
+
+
+// TODO now it can be moved, move it if you change this
+// Can't be moved to buildSrc because of Checksum dependency
+fun createChecksumsTask(
+    targetOs: OS,
+    targetArch: Arch,
+    fileToChecksum: Provider<File>,
+) = project.registerSkikoTask<org.gradle.crypto.checksum.Checksum>("createChecksums", targetOs, targetArch) {
+    inputFiles = project.files(fileToChecksum)
+    checksumAlgorithm = org.gradle.crypto.checksum.Checksum.Algorithm.SHA256
+    outputDirectory = layout.buildDirectory.dir("checksums-${targetId(targetOs, targetArch)}")
+}
+
+if (supportAwt && supportGraphiteJvm) {
+    val graphiteAwtJarForTests by project.tasks.registering(Jar::class) {
+        archiveBaseName.set("skiko-graphite-awt-test")
+        from(kotlin.jvm("awt").compilations["main"].output.allOutputs)
+    }
+    val coreJvmLinkedLibrary = graphiteProjectContext.jvmLinkedLibraryFor(targetOs, targetArch).also {
+        dependencies.add(it.name, coreProject)
+    }
+    val macosX64CoreLinkedLibrary = if (targetOs == OS.MacOS && targetArch == Arch.Arm64) {
+        graphiteProjectContext.jvmLinkedLibraryFor(OS.MacOS, Arch.X64).also {
+            dependencies.add(it.name, coreProject)
+        }
+    } else {
+        null
+    }
+    val coreJvmRuntimeJar = graphiteProjectContext.jvmRuntimeJarFor(targetOs, targetArch).also {
+        dependencies.add(it.name, coreProject)
+    }
+
+    graphiteProjectContext.setupJvmTestTask(
+        graphiteAwtJarForTests,
+        targetOs,
+        targetArch,
+        files(coreJvmLinkedLibrary),
+        macosX64CoreLinkedLibrary?.let { files(it) },
+        coreJvmRuntimeJar,
+    )
+    graphiteProjectContext.provideJvmRequiredSymbols(targetOs, targetArch)
+    if (targetOs == OS.MacOS && targetArch == Arch.Arm64) {
+        graphiteProjectContext.provideJvmRequiredSymbols(OS.MacOS, Arch.X64)
+    }
+}
+
+afterEvaluate {
+    tasks.configureEach {
+        if (group == "publishing") {
+            // There are many intermediate tasks in 'publishing' group.
+            // There are a lot of them and they have verbose names.
+            // To decrease noise in './gradlew tasks' output and Intellij Gradle tool window,
+            // group verbose tasks in a separate group 'other publishing'.
+            val allRepositories = publishing.repositories.map { it.name } + "MavenLocal"
+            val publishToTasks = allRepositories.map { "publishTo$it" }
+            if (name != "publish" && name !in publishToTasks) {
+                group = "other publishing"
+            }
+        }
+    }
+}
+
+graphiteProjectContext.declarePublications()
+
+val mavenCentral = MavenCentralProperties(project)
+if (skiko.isTeamcityCIBuild || mavenCentral.signArtifacts) {
+    signing {
+        sign(publishing.publications)
+        useInMemoryPgpKeys(mavenCentral.signArtifactsKey.get(), mavenCentral.signArtifactsPassword.get())
+    }
+    configureSignAndPublishDependencies()
+}
+
+tasks.withType<KotlinNativeCompile>().configureEach {
+    compilerOptions.freeCompilerArgs.add("-opt-in=kotlinx.cinterop.ExperimentalForeignApi")
+}
+
+tasks.withType<KotlinCompilationTask<*>>().configureEach {
+    compilerOptions.freeCompilerArgs.add("-Xexpect-actual-classes")
+}

--- a/skiko/skiko-graphite/src/commonMain/cpp/common/GraphiteImageProvider.cc
+++ b/skiko/skiko-graphite/src/commonMain/cpp/common/GraphiteImageProvider.cc
@@ -1,0 +1,66 @@
+#include "GraphiteImageProvider.hh"
+
+#include "include/core/SkTiledImageUtils.h"
+#include "include/gpu/graphite/Image.h"
+#include "src/core/SkChecksum.h"
+#include "src/core/SkLRUCache.h"
+
+namespace {
+constexpr int kDefaultNumCachedImages = 256;
+
+class ImageKey {
+public:
+    ImageKey(const SkImage* image, bool mipmapped) {
+        fValues[0] = 0;
+        SkTiledImageUtils::GetImageKeyValues(image, &fValues[1]);
+        fValues[kNumValues - 1] = mipmapped ? 1 : 0;
+        fValues[0] = SkChecksum::Hash32(&fValues[1], (kNumValues - 1) * sizeof(uint32_t));
+    }
+
+    uint32_t hash() const { return fValues[0]; }
+
+    bool operator==(const ImageKey& other) const {
+        for (int i = 0; i < kNumValues; ++i) {
+            if (fValues[i] != other.fValues[i]) return false;
+        }
+        return true;
+    }
+
+private:
+    static constexpr int kNumValues = SkTiledImageUtils::kNumImageKeyValues + 2;
+    uint32_t fValues[kNumValues];
+};
+
+struct ImageHash {
+    size_t operator()(const ImageKey& key) const { return key.hash(); }
+};
+}  // namespace
+
+struct SkikoGraphiteImageProvider::Impl {
+    SkLRUCache<ImageKey, sk_sp<SkImage>, ImageHash> cache{kDefaultNumCachedImages};
+};
+
+SkikoGraphiteImageProvider::SkikoGraphiteImageProvider() : fImpl(std::make_unique<Impl>()) {}
+
+SkikoGraphiteImageProvider::~SkikoGraphiteImageProvider() = default;
+
+sk_sp<SkikoGraphiteImageProvider> SkikoGraphiteImageProvider::Make() {
+    return sk_sp<SkikoGraphiteImageProvider>(new SkikoGraphiteImageProvider());
+}
+
+sk_sp<SkImage> SkikoGraphiteImageProvider::findOrCreate(
+        skgpu::graphite::Recorder* recorder,
+        const SkImage* image,
+        SkImage::RequiredProperties requiredProperties) {
+    if (!requiredProperties.fMipmapped) {
+        if (auto cached = fImpl->cache.find(ImageKey(image, true))) return *cached;
+    }
+
+    ImageKey key(image, requiredProperties.fMipmapped);
+    if (auto cached = fImpl->cache.find(key)) return *cached;
+
+    sk_sp<SkImage> textureImage = SkImages::TextureFromImage(recorder, image, requiredProperties);
+    if (!textureImage) return nullptr;
+
+    return *fImpl->cache.insert(key, std::move(textureImage));
+}

--- a/skiko/skiko-graphite/src/commonMain/cpp/common/include/GraphiteImageProvider.hh
+++ b/skiko/skiko-graphite/src/commonMain/cpp/common/include/GraphiteImageProvider.hh
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "include/core/SkImage.h"
+#include "include/gpu/graphite/ImageProvider.h"
+
+#include <memory>
+
+// Adapted from Skia's GraphiteToolUtils.cpp:
+// https://github.com/google/skia/blob/c16d0e9f30b1a1613401c0db3c93a3c2aa37c8ba/tools/graphite/GraphiteToolUtils.cpp#L26
+class SkikoGraphiteImageProvider final : public skgpu::graphite::ImageProvider {
+public:
+    static sk_sp<SkikoGraphiteImageProvider> Make();
+
+    ~SkikoGraphiteImageProvider() override;
+
+    sk_sp<SkImage> findOrCreate(
+            skgpu::graphite::Recorder* recorder,
+            const SkImage* image,
+            SkImage::RequiredProperties requiredProperties) override;
+
+private:
+    SkikoGraphiteImageProvider();
+
+    struct Impl;
+    std::unique_ptr<Impl> fImpl;
+};

--- a/skiko/skiko-graphite/src/commonMain/kotlin/org/jetbrains/skia/gpu/graphite/BackendTexture.kt
+++ b/skiko/skiko-graphite/src/commonMain/kotlin/org/jetbrains/skia/gpu/graphite/BackendTexture.kt
@@ -1,0 +1,33 @@
+package org.jetbrains.skia.gpu.graphite
+
+import org.jetbrains.skia.ExternalSymbolName
+import org.jetbrains.skia.impl.Managed
+import org.jetbrains.skia.impl.Native.Companion.NullPointer
+import org.jetbrains.skia.impl.NativePointer
+import org.jetbrains.skiko.ExperimentalSkikoApi
+
+@ExperimentalSkikoApi
+class BackendTexture internal constructor(ptr: NativePointer) : Managed(ptr, _FinalizerHolder.PTR) {
+    companion object {
+        init {
+            GraphiteLibrary.load()
+        }
+
+        fun wrapMetalTexture(texturePtr: NativePointer, width: Int, height: Int): BackendTexture {
+            requireMetalSupport()
+            require(texturePtr != NullPointer) { "Metal texture pointer is null" }
+            require(width > 0 && height > 0) { "Texture dimensions must be positive" }
+            return BackendTexture(_nWrapMetalTexture(texturePtr, width, height))
+        }
+    }
+
+    private object _FinalizerHolder {
+        val PTR = _nGetBackendTextureFinalizer()
+    }
+}
+
+@ExternalSymbolName("org_jetbrains_skia_gpu_graphite_BackendTexture__1nGetFinalizer")
+private external fun _nGetBackendTextureFinalizer(): NativePointer
+
+@ExternalSymbolName("org_jetbrains_skia_gpu_graphite_BackendTexture__1nWrapMetalTexture")
+private external fun _nWrapMetalTexture(texturePtr: NativePointer, width: Int, height: Int): NativePointer

--- a/skiko/skiko-graphite/src/commonMain/kotlin/org/jetbrains/skia/gpu/graphite/BackendTexture.kt
+++ b/skiko/skiko-graphite/src/commonMain/kotlin/org/jetbrains/skia/gpu/graphite/BackendTexture.kt
@@ -4,6 +4,7 @@ import org.jetbrains.skia.ExternalSymbolName
 import org.jetbrains.skia.impl.Managed
 import org.jetbrains.skia.impl.Native.Companion.NullPointer
 import org.jetbrains.skia.impl.NativePointer
+import org.jetbrains.skia.impl.Stats
 import org.jetbrains.skiko.ExperimentalSkikoApi
 
 @ExperimentalSkikoApi
@@ -17,6 +18,7 @@ class BackendTexture internal constructor(ptr: NativePointer) : Managed(ptr, _Fi
             requireMetalSupport()
             require(texturePtr != NullPointer) { "Metal texture pointer is null" }
             require(width > 0 && height > 0) { "Texture dimensions must be positive" }
+            Stats.onNativeCall()
             return BackendTexture(_nMakeMetal(width, height, texturePtr))
         }
     }

--- a/skiko/skiko-graphite/src/commonMain/kotlin/org/jetbrains/skia/gpu/graphite/BackendTexture.kt
+++ b/skiko/skiko-graphite/src/commonMain/kotlin/org/jetbrains/skia/gpu/graphite/BackendTexture.kt
@@ -7,6 +7,9 @@ import org.jetbrains.skia.impl.NativePointer
 import org.jetbrains.skia.impl.Stats
 import org.jetbrains.skiko.ExperimentalSkikoApi
 
+/**
+ * Represents a backend-specific texture that can be used by Graphite.
+ */
 @ExperimentalSkikoApi
 class BackendTexture internal constructor(ptr: NativePointer) : Managed(ptr, _FinalizerHolder.PTR) {
     companion object {
@@ -14,6 +17,14 @@ class BackendTexture internal constructor(ptr: NativePointer) : Managed(ptr, _Fi
             GraphiteLibrary.load()
         }
 
+        /**
+         * Creates a Graphite backend texture that wraps a Metal texture.
+         *
+         * @param width width of the texture in pixels.
+         * @param height height of the texture in pixels.
+         * @param texturePtr native pointer to the Metal texture to wrap.
+         * @return a backend texture wrapping the supplied Metal texture.
+         */
         fun makeMetal(width: Int, height: Int, texturePtr: NativePointer): BackendTexture {
             requireMetalSupport()
             require(texturePtr != NullPointer) { "Metal texture pointer is null" }

--- a/skiko/skiko-graphite/src/commonMain/kotlin/org/jetbrains/skia/gpu/graphite/BackendTexture.kt
+++ b/skiko/skiko-graphite/src/commonMain/kotlin/org/jetbrains/skia/gpu/graphite/BackendTexture.kt
@@ -30,7 +30,9 @@ class BackendTexture internal constructor(ptr: NativePointer) : Managed(ptr, _Fi
             require(texturePtr != NullPointer) { "Metal texture pointer is null" }
             require(width > 0 && height > 0) { "Texture dimensions must be positive" }
             Stats.onNativeCall()
-            return BackendTexture(_nMakeMetal(width, height, texturePtr))
+            val ptr = _nMakeMetal(width, height, texturePtr)
+            check(ptr != NullPointer) { "Failed to create a Graphite Metal backend texture" }
+            return BackendTexture(ptr)
         }
     }
 

--- a/skiko/skiko-graphite/src/commonMain/kotlin/org/jetbrains/skia/gpu/graphite/BackendTexture.kt
+++ b/skiko/skiko-graphite/src/commonMain/kotlin/org/jetbrains/skia/gpu/graphite/BackendTexture.kt
@@ -13,11 +13,11 @@ class BackendTexture internal constructor(ptr: NativePointer) : Managed(ptr, _Fi
             GraphiteLibrary.load()
         }
 
-        fun wrapMetalTexture(texturePtr: NativePointer, width: Int, height: Int): BackendTexture {
+        fun makeMetal(width: Int, height: Int, texturePtr: NativePointer): BackendTexture {
             requireMetalSupport()
             require(texturePtr != NullPointer) { "Metal texture pointer is null" }
             require(width > 0 && height > 0) { "Texture dimensions must be positive" }
-            return BackendTexture(_nWrapMetalTexture(texturePtr, width, height))
+            return BackendTexture(_nMakeMetal(width, height, texturePtr))
         }
     }
 
@@ -29,5 +29,5 @@ class BackendTexture internal constructor(ptr: NativePointer) : Managed(ptr, _Fi
 @ExternalSymbolName("org_jetbrains_skia_gpu_graphite_BackendTexture__1nGetFinalizer")
 private external fun _nGetBackendTextureFinalizer(): NativePointer
 
-@ExternalSymbolName("org_jetbrains_skia_gpu_graphite_BackendTexture__1nWrapMetalTexture")
-private external fun _nWrapMetalTexture(texturePtr: NativePointer, width: Int, height: Int): NativePointer
+@ExternalSymbolName("org_jetbrains_skia_gpu_graphite_BackendTexture__1nMakeMetal")
+private external fun _nMakeMetal(width: Int, height: Int, texturePtr: NativePointer): NativePointer

--- a/skiko/skiko-graphite/src/commonMain/kotlin/org/jetbrains/skia/gpu/graphite/GraphiteContext.kt
+++ b/skiko/skiko-graphite/src/commonMain/kotlin/org/jetbrains/skia/gpu/graphite/GraphiteContext.kt
@@ -1,0 +1,72 @@
+package org.jetbrains.skia.gpu.graphite
+
+import org.jetbrains.skia.ExternalSymbolName
+import org.jetbrains.skia.impl.Managed
+import org.jetbrains.skia.impl.NativePointer
+import org.jetbrains.skia.impl.Stats
+import org.jetbrains.skia.impl.reachabilityBarrier
+import org.jetbrains.skiko.ExperimentalSkikoApi
+
+@ExperimentalSkikoApi
+class GraphiteContext internal constructor(ptr: NativePointer) : Managed(ptr, _FinalizerHolder.PTR) {
+    companion object {
+        init {
+            GraphiteLibrary.load()
+        }
+
+        fun makeMetal(devicePtr: NativePointer, queuePtr: NativePointer): GraphiteContext {
+            requireMetalSupport()
+            require(devicePtr != NullPointer) { "Metal device pointer is null" }
+            require(queuePtr != NullPointer) { "Metal queue pointer is null" }
+            Stats.onNativeCall()
+            val ptr = _nMakeMetal(devicePtr, queuePtr)
+            check(ptr != NullPointer) { "Failed to create a Graphite Metal context" }
+            return GraphiteContext(ptr)
+        }
+    }
+
+    fun makeRecorder(): Recorder {
+        Stats.onNativeCall()
+        val ptr = _nMakeRecorder(nativePtr)
+        check(ptr != NullPointer) { "Failed to create a Graphite recorder" }
+        return Recorder(ptr)
+    }
+
+    fun insertRecording(recording: Recording) {
+        try {
+            Stats.onNativeCall()
+            _nInsertRecording(nativePtr, recording.nativePtr)
+        } finally {
+            reachabilityBarrier(this)
+            reachabilityBarrier(recording)
+        }
+    }
+
+    fun submit(syncCpu: Boolean = false) {
+        try {
+            Stats.onNativeCall()
+            _nSubmit(nativePtr, syncCpu)
+        } finally {
+            reachabilityBarrier(this)
+        }
+    }
+
+    private object _FinalizerHolder {
+        val PTR = _nGetGraphiteContextFinalizer()
+    }
+}
+
+@ExternalSymbolName("org_jetbrains_skia_gpu_graphite_GraphiteContext__1nGetFinalizer")
+private external fun _nGetGraphiteContextFinalizer(): NativePointer
+
+@ExternalSymbolName("org_jetbrains_skia_gpu_graphite_GraphiteContext__1nMakeMetal")
+private external fun _nMakeMetal(devicePtr: NativePointer, queuePtr: NativePointer): NativePointer
+
+@ExternalSymbolName("org_jetbrains_skia_gpu_graphite_GraphiteContext__1nMakeRecorder")
+private external fun _nMakeRecorder(contextPtr: NativePointer): NativePointer
+
+@ExternalSymbolName("org_jetbrains_skia_gpu_graphite_GraphiteContext__1nInsertRecording")
+private external fun _nInsertRecording(contextPtr: NativePointer, recordingPtr: NativePointer)
+
+@ExternalSymbolName("org_jetbrains_skia_gpu_graphite_GraphiteContext__1nSubmit")
+private external fun _nSubmit(contextPtr: NativePointer, syncCpu: Boolean)

--- a/skiko/skiko-graphite/src/commonMain/kotlin/org/jetbrains/skia/gpu/graphite/GraphiteContext.kt
+++ b/skiko/skiko-graphite/src/commonMain/kotlin/org/jetbrains/skia/gpu/graphite/GraphiteContext.kt
@@ -41,10 +41,14 @@ class GraphiteContext internal constructor(ptr: NativePointer) : Managed(ptr, _F
      * @return a new recorder.
      */
     fun makeRecorder(): Recorder {
-        Stats.onNativeCall()
-        val ptr = _nMakeRecorder(nativePtr)
-        check(ptr != NullPointer) { "Failed to create a Graphite recorder" }
-        return Recorder(ptr)
+        return try {
+            Stats.onNativeCall()
+            val ptr = _nMakeRecorder(nativePtr)
+            check(ptr != NullPointer) { "Failed to create a Graphite recorder" }
+            Recorder(ptr)
+        } finally {
+            reachabilityBarrier(this)
+        }
     }
 
     /**

--- a/skiko/skiko-graphite/src/commonMain/kotlin/org/jetbrains/skia/gpu/graphite/GraphiteContext.kt
+++ b/skiko/skiko-graphite/src/commonMain/kotlin/org/jetbrains/skia/gpu/graphite/GraphiteContext.kt
@@ -7,6 +7,9 @@ import org.jetbrains.skia.impl.Stats
 import org.jetbrains.skia.impl.reachabilityBarrier
 import org.jetbrains.skiko.ExperimentalSkikoApi
 
+/**
+ * The main entry point for Graphite, responsible for managing and coordinating GPU resources.
+ */
 @ExperimentalSkikoApi
 class GraphiteContext internal constructor(ptr: NativePointer) : Managed(ptr, _FinalizerHolder.PTR) {
     companion object {
@@ -14,6 +17,13 @@ class GraphiteContext internal constructor(ptr: NativePointer) : Managed(ptr, _F
             GraphiteLibrary.load()
         }
 
+        /**
+         * Creates a Graphite context that submits work to a Metal command queue.
+         *
+         * @param devicePtr native pointer to the Metal device.
+         * @param queuePtr native pointer to the Metal command queue.
+         * @return a Graphite context backed by Metal.
+         */
         fun makeMetal(devicePtr: NativePointer, queuePtr: NativePointer): GraphiteContext {
             requireMetalSupport()
             require(devicePtr != NullPointer) { "Metal device pointer is null" }
@@ -25,6 +35,11 @@ class GraphiteContext internal constructor(ptr: NativePointer) : Managed(ptr, _F
         }
     }
 
+    /**
+     * Creates a [Recorder] that records drawing commands for this context.
+     *
+     * @return a new recorder.
+     */
     fun makeRecorder(): Recorder {
         Stats.onNativeCall()
         val ptr = _nMakeRecorder(nativePtr)
@@ -32,6 +47,13 @@ class GraphiteContext internal constructor(ptr: NativePointer) : Managed(ptr, _F
         return Recorder(ptr)
     }
 
+    /**
+     * Adds a [recording] to this context's pending GPU work.
+     *
+     * The work is sent to the GPU by a subsequent call to [submit].
+     *
+     * @param recording recording to insert.
+     */
     fun insertRecording(recording: Recording) {
         try {
             Stats.onNativeCall()
@@ -42,6 +64,11 @@ class GraphiteContext internal constructor(ptr: NativePointer) : Managed(ptr, _F
         }
     }
 
+    /**
+     * Submits pending work to the GPU.
+     *
+     * @param syncCpu if `true`, waits for the submitted GPU work to finish before returning.
+     */
     fun submit(syncCpu: Boolean = false) {
         try {
             Stats.onNativeCall()

--- a/skiko/skiko-graphite/src/commonMain/kotlin/org/jetbrains/skia/gpu/graphite/GraphiteLibrary.kt
+++ b/skiko/skiko-graphite/src/commonMain/kotlin/org/jetbrains/skia/gpu/graphite/GraphiteLibrary.kt
@@ -1,0 +1,15 @@
+package org.jetbrains.skia.gpu.graphite
+
+import org.jetbrains.skiko.OS
+import org.jetbrains.skiko.hostOs
+
+internal expect object GraphiteLibrary {
+    fun load()
+}
+
+internal fun requireMetalSupport() {
+    when (hostOs) {
+        OS.MacOS, OS.Ios, OS.Tvos -> Unit
+        else -> throw UnsupportedOperationException("Graphite Metal is not supported on ${hostOs.id}")
+    }
+}

--- a/skiko/skiko-graphite/src/commonMain/kotlin/org/jetbrains/skia/gpu/graphite/Recorder.kt
+++ b/skiko/skiko-graphite/src/commonMain/kotlin/org/jetbrains/skia/gpu/graphite/Recorder.kt
@@ -1,0 +1,32 @@
+package org.jetbrains.skia.gpu.graphite
+
+import org.jetbrains.skia.ExternalSymbolName
+import org.jetbrains.skia.impl.Managed
+import org.jetbrains.skia.impl.NativePointer
+import org.jetbrains.skia.impl.Stats
+import org.jetbrains.skia.impl.reachabilityBarrier
+import org.jetbrains.skiko.ExperimentalSkikoApi
+
+@ExperimentalSkikoApi
+class Recorder internal constructor(ptr: NativePointer) : Managed(ptr, _FinalizerHolder.PTR) {
+    fun snap(): Recording {
+        try {
+            Stats.onNativeCall()
+            val ptr = _nSnap(nativePtr)
+            check(ptr != NullPointer) { "Failed to create a Graphite recording" }
+            return Recording(ptr)
+        } finally {
+            reachabilityBarrier(this)
+        }
+    }
+
+    private object _FinalizerHolder {
+        val PTR = _nGetRecorderFinalizer()
+    }
+}
+
+@ExternalSymbolName("org_jetbrains_skia_gpu_graphite_Recorder__1nGetFinalizer")
+private external fun _nGetRecorderFinalizer(): NativePointer
+
+@ExternalSymbolName("org_jetbrains_skia_gpu_graphite_Recorder__1nSnap")
+private external fun _nSnap(recorderPtr: NativePointer): NativePointer

--- a/skiko/skiko-graphite/src/commonMain/kotlin/org/jetbrains/skia/gpu/graphite/Recorder.kt
+++ b/skiko/skiko-graphite/src/commonMain/kotlin/org/jetbrains/skia/gpu/graphite/Recorder.kt
@@ -7,8 +7,21 @@ import org.jetbrains.skia.impl.Stats
 import org.jetbrains.skia.impl.reachabilityBarrier
 import org.jetbrains.skiko.ExperimentalSkikoApi
 
+/**
+ * Provides the interface for recording drawing commands and snapping them into a [Recording].
+ *
+ * A recorder is intended to be used from one thread and is not thread-safe. Different recorders
+ * can be used on different threads.
+ */
 @ExperimentalSkikoApi
 class Recorder internal constructor(ptr: NativePointer) : Managed(ptr, _FinalizerHolder.PTR) {
+    /**
+     * Captures the drawing commands accumulated since the previous call to `snap`.
+     *
+     * The recorder is reset and ready to record new commands after this call.
+     *
+     * @return a recording containing the captured commands.
+     */
     fun snap(): Recording {
         try {
             Stats.onNativeCall()

--- a/skiko/skiko-graphite/src/commonMain/kotlin/org/jetbrains/skia/gpu/graphite/Recording.kt
+++ b/skiko/skiko-graphite/src/commonMain/kotlin/org/jetbrains/skia/gpu/graphite/Recording.kt
@@ -1,0 +1,16 @@
+package org.jetbrains.skia.gpu.graphite
+
+import org.jetbrains.skia.ExternalSymbolName
+import org.jetbrains.skia.impl.Managed
+import org.jetbrains.skia.impl.NativePointer
+import org.jetbrains.skiko.ExperimentalSkikoApi
+
+@ExperimentalSkikoApi
+class Recording internal constructor(ptr: NativePointer) : Managed(ptr, _FinalizerHolder.PTR) {
+    private object _FinalizerHolder {
+        val PTR = _nGetRecordingFinalizer()
+    }
+}
+
+@ExternalSymbolName("org_jetbrains_skia_gpu_graphite_Recording__1nGetFinalizer")
+private external fun _nGetRecordingFinalizer(): NativePointer

--- a/skiko/skiko-graphite/src/commonMain/kotlin/org/jetbrains/skia/gpu/graphite/Recording.kt
+++ b/skiko/skiko-graphite/src/commonMain/kotlin/org/jetbrains/skia/gpu/graphite/Recording.kt
@@ -5,6 +5,9 @@ import org.jetbrains.skia.impl.Managed
 import org.jetbrains.skia.impl.NativePointer
 import org.jetbrains.skiko.ExperimentalSkikoApi
 
+/**
+ * An immutable collection of drawing commands snapped from a [Recorder] for GPU submission.
+ */
 @ExperimentalSkikoApi
 class Recording internal constructor(ptr: NativePointer) : Managed(ptr, _FinalizerHolder.PTR) {
     private object _FinalizerHolder {

--- a/skiko/skiko-graphite/src/commonMain/kotlin/org/jetbrains/skia/gpu/graphite/SurfaceFactory.kt
+++ b/skiko/skiko-graphite/src/commonMain/kotlin/org/jetbrains/skia/gpu/graphite/SurfaceFactory.kt
@@ -1,0 +1,51 @@
+package org.jetbrains.skia.gpu.graphite
+
+import org.jetbrains.skia.ColorSpace
+import org.jetbrains.skia.ExternalSymbolName
+import org.jetbrains.skia.Surface
+import org.jetbrains.skia.SurfaceColorFormat
+import org.jetbrains.skia.SurfaceProps
+import org.jetbrains.skia.impl.InteropPointer
+import org.jetbrains.skia.impl.Native.Companion.NullPointer
+import org.jetbrains.skia.impl.NativePointer
+import org.jetbrains.skia.impl.Stats
+import org.jetbrains.skia.impl.getPtr
+import org.jetbrains.skia.impl.interopScope
+import org.jetbrains.skia.impl.reachabilityBarrier
+import org.jetbrains.skiko.ExperimentalSkikoApi
+
+@ExperimentalSkikoApi
+fun Surface.Companion.makeFromBackendTexture(
+    recorder: Recorder,
+    backendTexture: BackendTexture,
+    colorFormat: SurfaceColorFormat,
+    colorSpace: ColorSpace?,
+    surfaceProps: SurfaceProps? = null,
+): Surface? {
+    return try {
+        Stats.onNativeCall()
+        val ptr = interopScope {
+            _nMakeFromBackendTexture(
+                recorder.nativePtr,
+                backendTexture.nativePtr,
+                colorFormat.ordinal,
+                getPtr(colorSpace),
+                toInterop(surfaceProps?.packToIntArray()),
+            )
+        }
+        if (ptr == NullPointer) null else Surface(ptr)
+    } finally {
+        reachabilityBarrier(recorder)
+        reachabilityBarrier(backendTexture)
+        reachabilityBarrier(colorSpace)
+    }
+}
+
+@ExternalSymbolName("org_jetbrains_skia_gpu_graphite_SurfaceFactory__1nMakeFromBackendTexture")
+private external fun _nMakeFromBackendTexture(
+    recorderPtr: NativePointer,
+    backendTexturePtr: NativePointer,
+    colorType: Int,
+    colorSpacePtr: NativePointer,
+    surfaceProps: InteropPointer,
+): NativePointer

--- a/skiko/skiko-graphite/src/commonMain/kotlin/org/jetbrains/skia/gpu/graphite/SurfaceFactory.kt
+++ b/skiko/skiko-graphite/src/commonMain/kotlin/org/jetbrains/skia/gpu/graphite/SurfaceFactory.kt
@@ -13,6 +13,15 @@ import org.jetbrains.skia.impl.interopScope
 import org.jetbrains.skia.impl.reachabilityBarrier
 import org.jetbrains.skiko.ExperimentalSkikoApi
 
+/**
+ * Creates a Graphite surface that renders into a [backendTexture] using [recorder].
+ *
+ * @param recorder recorder used by the surface to record drawing commands.
+ * @param backendTexture backend texture that receives the rendered content.
+ * @param colorSpace color space describing how colors are interpreted, or `null` for no color space.
+ * @param surfaceProps optional surface properties controlling pixel geometry and rendering behavior.
+ * @return a surface wrapping the backend texture, or `null` if the surface could not be created.
+ */
 @ExperimentalSkikoApi
 fun Surface.Companion.wrapBackendTexture(
     recorder: Recorder,

--- a/skiko/skiko-graphite/src/commonMain/kotlin/org/jetbrains/skia/gpu/graphite/SurfaceFactory.kt
+++ b/skiko/skiko-graphite/src/commonMain/kotlin/org/jetbrains/skia/gpu/graphite/SurfaceFactory.kt
@@ -3,7 +3,6 @@ package org.jetbrains.skia.gpu.graphite
 import org.jetbrains.skia.ColorSpace
 import org.jetbrains.skia.ExternalSymbolName
 import org.jetbrains.skia.Surface
-import org.jetbrains.skia.SurfaceColorFormat
 import org.jetbrains.skia.SurfaceProps
 import org.jetbrains.skia.impl.InteropPointer
 import org.jetbrains.skia.impl.Native.Companion.NullPointer
@@ -15,20 +14,18 @@ import org.jetbrains.skia.impl.reachabilityBarrier
 import org.jetbrains.skiko.ExperimentalSkikoApi
 
 @ExperimentalSkikoApi
-fun Surface.Companion.makeFromBackendTexture(
+fun Surface.Companion.wrapBackendTexture(
     recorder: Recorder,
     backendTexture: BackendTexture,
-    colorFormat: SurfaceColorFormat,
     colorSpace: ColorSpace?,
     surfaceProps: SurfaceProps? = null,
 ): Surface? {
     return try {
         Stats.onNativeCall()
         val ptr = interopScope {
-            _nMakeFromBackendTexture(
+            _nWrapBackendTexture(
                 recorder.nativePtr,
                 backendTexture.nativePtr,
-                colorFormat.ordinal,
                 getPtr(colorSpace),
                 toInterop(surfaceProps?.packToIntArray()),
             )
@@ -41,11 +38,10 @@ fun Surface.Companion.makeFromBackendTexture(
     }
 }
 
-@ExternalSymbolName("org_jetbrains_skia_gpu_graphite_SurfaceFactory__1nMakeFromBackendTexture")
-private external fun _nMakeFromBackendTexture(
+@ExternalSymbolName("org_jetbrains_skia_gpu_graphite_SurfaceFactory__1nWrapBackendTexture")
+private external fun _nWrapBackendTexture(
     recorderPtr: NativePointer,
     backendTexturePtr: NativePointer,
-    colorType: Int,
     colorSpacePtr: NativePointer,
     surfaceProps: InteropPointer,
 ): NativePointer

--- a/skiko/skiko-graphite/src/commonTest/kotlin/org/jetbrains/skia/gpu/graphite/GraphiteTest.kt
+++ b/skiko/skiko-graphite/src/commonTest/kotlin/org/jetbrains/skia/gpu/graphite/GraphiteTest.kt
@@ -20,5 +20,5 @@ class GraphiteTest {
     }
 }
 
-@ExperimentalSkikoApi
+@OptIn(ExperimentalSkikoApi::class)
 internal expect fun makeTestGraphiteContext(): GraphiteContext?

--- a/skiko/skiko-graphite/src/commonTest/kotlin/org/jetbrains/skia/gpu/graphite/GraphiteTest.kt
+++ b/skiko/skiko-graphite/src/commonTest/kotlin/org/jetbrains/skia/gpu/graphite/GraphiteTest.kt
@@ -1,0 +1,24 @@
+package org.jetbrains.skia.gpu.graphite
+
+import org.jetbrains.skia.impl.use
+import org.jetbrains.skiko.ExperimentalSkikoApi
+import kotlin.test.Test
+
+@OptIn(ExperimentalSkikoApi::class)
+class GraphiteTest {
+    @Test
+    fun contextCanRecordAndSubmit() {
+        val context = makeTestGraphiteContext() ?: return
+        context.use { context ->
+            context.makeRecorder().use { recorder ->
+                recorder.snap().use { recording ->
+                    context.insertRecording(recording)
+                    context.submit(syncCpu = true)
+                }
+            }
+        }
+    }
+}
+
+@ExperimentalSkikoApi
+internal expect fun makeTestGraphiteContext(): GraphiteContext?

--- a/skiko/skiko-graphite/src/darwinTest/kotlin/org/jetbrains/skia/gpu/graphite/GraphiteTestHelpers.kt
+++ b/skiko/skiko-graphite/src/darwinTest/kotlin/org/jetbrains/skia/gpu/graphite/GraphiteTestHelpers.kt
@@ -3,10 +3,14 @@ package org.jetbrains.skia.gpu.graphite
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.objcPtr
 import org.jetbrains.skiko.ExperimentalSkikoApi
+import org.jetbrains.skiko.OS
+import org.jetbrains.skiko.hostOs
 import platform.Metal.MTLCreateSystemDefaultDevice
 
 @OptIn(ExperimentalForeignApi::class, ExperimentalSkikoApi::class)
 internal actual fun makeTestGraphiteContext(): GraphiteContext? {
+    if (hostOs == OS.Tvos) return null
+
     val device = checkNotNull(MTLCreateSystemDefaultDevice()) {
         "Metal is not supported on this system"
     }

--- a/skiko/skiko-graphite/src/darwinTest/kotlin/org/jetbrains/skia/gpu/graphite/GraphiteTestHelpers.kt
+++ b/skiko/skiko-graphite/src/darwinTest/kotlin/org/jetbrains/skia/gpu/graphite/GraphiteTestHelpers.kt
@@ -1,0 +1,17 @@
+package org.jetbrains.skia.gpu.graphite
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.objcPtr
+import org.jetbrains.skiko.ExperimentalSkikoApi
+import platform.Metal.MTLCreateSystemDefaultDevice
+
+@OptIn(ExperimentalForeignApi::class, ExperimentalSkikoApi::class)
+internal actual fun makeTestGraphiteContext(): GraphiteContext? {
+    val device = checkNotNull(MTLCreateSystemDefaultDevice()) {
+        "Metal is not supported on this system"
+    }
+    val queue = checkNotNull(device.newCommandQueue()) {
+        "Failed to create a Metal command queue"
+    }
+    return GraphiteContext.makeMetal(device.objcPtr(), queue.objcPtr())
+}

--- a/skiko/skiko-graphite/src/jvmMain/cpp/common/BackendTexture.cc
+++ b/skiko/skiko-graphite/src/jvmMain/cpp/common/BackendTexture.cc
@@ -1,0 +1,28 @@
+#include <jni.h>
+
+#include "include/gpu/graphite/BackendTexture.h"
+#if defined(SK_METAL)
+#include "include/gpu/graphite/mtl/MtlGraphiteTypes_cpp.h"
+#endif
+
+static void deleteBackendTexture(skgpu::graphite::BackendTexture* texture) {
+    delete texture;
+}
+
+extern "C" JNIEXPORT jlong JNICALL
+Java_org_jetbrains_skia_gpu_graphite_BackendTextureKt__1nGetBackendTextureFinalizer(JNIEnv*, jclass) {
+    return static_cast<jlong>(reinterpret_cast<uintptr_t>(&deleteBackendTexture));
+}
+
+extern "C" JNIEXPORT jlong JNICALL
+Java_org_jetbrains_skia_gpu_graphite_BackendTextureKt__1nWrapMetalTexture(
+        JNIEnv*, jclass, jlong texturePtr, jint width, jint height) {
+#if defined(SK_METAL)
+    auto texture = skgpu::graphite::BackendTextures::MakeMetal(
+            SkISize::Make(width, height),
+            reinterpret_cast<CFTypeRef>(static_cast<uintptr_t>(texturePtr)));
+    return reinterpret_cast<jlong>(new skgpu::graphite::BackendTexture(texture));
+#else
+    return 0;
+#endif
+}

--- a/skiko/skiko-graphite/src/jvmMain/cpp/common/BackendTexture.cc
+++ b/skiko/skiko-graphite/src/jvmMain/cpp/common/BackendTexture.cc
@@ -15,8 +15,8 @@ Java_org_jetbrains_skia_gpu_graphite_BackendTextureKt__1nGetBackendTextureFinali
 }
 
 extern "C" JNIEXPORT jlong JNICALL
-Java_org_jetbrains_skia_gpu_graphite_BackendTextureKt__1nWrapMetalTexture(
-        JNIEnv*, jclass, jlong texturePtr, jint width, jint height) {
+Java_org_jetbrains_skia_gpu_graphite_BackendTextureKt__1nMakeMetal(
+        JNIEnv*, jclass, jint width, jint height, jlong texturePtr) {
 #if defined(SK_METAL)
     auto texture = skgpu::graphite::BackendTextures::MakeMetal(
             SkISize::Make(width, height),

--- a/skiko/skiko-graphite/src/jvmMain/cpp/common/GraphiteContext.cc
+++ b/skiko/skiko-graphite/src/jvmMain/cpp/common/GraphiteContext.cc
@@ -1,0 +1,68 @@
+#include <jni.h>
+
+#include "GraphiteImageProvider.hh"
+#include "include/gpu/graphite/Context.h"
+#include "include/gpu/graphite/ContextOptions.h"
+#include "include/gpu/graphite/GraphiteTypes.h"
+#include "include/gpu/graphite/Recorder.h"
+#if defined(SK_METAL)
+#include "include/gpu/graphite/mtl/MtlBackendContext.h"
+#endif
+
+static void deleteGraphiteContext(skgpu::graphite::Context* context) {
+    delete context;
+}
+
+extern "C" JNIEXPORT jlong JNICALL
+Java_org_jetbrains_skia_gpu_graphite_GraphiteContextKt__1nGetGraphiteContextFinalizer(JNIEnv*, jclass) {
+    return static_cast<jlong>(reinterpret_cast<uintptr_t>(&deleteGraphiteContext));
+}
+
+extern "C" JNIEXPORT jlong JNICALL
+Java_org_jetbrains_skia_gpu_graphite_GraphiteContextKt__1nMakeMetal(
+        JNIEnv*, jclass, jlong devicePtr, jlong queuePtr) {
+#if defined(SK_METAL)
+    skgpu::graphite::MtlBackendContext backendContext{};
+    backendContext.fDevice.retain(
+            reinterpret_cast<CFTypeRef>(static_cast<uintptr_t>(devicePtr)));
+    backendContext.fQueue.retain(
+            reinterpret_cast<CFTypeRef>(static_cast<uintptr_t>(queuePtr)));
+
+    skgpu::graphite::ContextOptions options{};
+    options.fRequireOrderedRecordings = true;
+    return reinterpret_cast<jlong>(
+            skgpu::graphite::ContextFactory::MakeMetal(backendContext, options).release());
+#else
+    return 0;
+#endif
+}
+
+extern "C" JNIEXPORT jlong JNICALL
+Java_org_jetbrains_skia_gpu_graphite_GraphiteContextKt__1nMakeRecorder(
+        JNIEnv*, jclass, jlong contextPtr) {
+    auto context = reinterpret_cast<skgpu::graphite::Context*>(
+            static_cast<uintptr_t>(contextPtr));
+    skgpu::graphite::RecorderOptions options{};
+    options.fImageProvider = SkikoGraphiteImageProvider::Make();
+    return reinterpret_cast<jlong>(context->makeRecorder(options).release());
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_org_jetbrains_skia_gpu_graphite_GraphiteContextKt__1nInsertRecording(
+        JNIEnv*, jclass, jlong contextPtr, jlong recordingPtr) {
+    auto context = reinterpret_cast<skgpu::graphite::Context*>(
+            static_cast<uintptr_t>(contextPtr));
+    skgpu::graphite::InsertRecordingInfo info{};
+    info.fRecording = reinterpret_cast<skgpu::graphite::Recording*>(
+            static_cast<uintptr_t>(recordingPtr));
+    context->insertRecording(info);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_org_jetbrains_skia_gpu_graphite_GraphiteContextKt__1nSubmit(
+        JNIEnv*, jclass, jlong contextPtr, jboolean syncCpu) {
+    auto context = reinterpret_cast<skgpu::graphite::Context*>(
+            static_cast<uintptr_t>(contextPtr));
+    context->submit(skgpu::graphite::SubmitInfo(
+            syncCpu ? skgpu::graphite::SyncToCpu::kYes : skgpu::graphite::SyncToCpu::kNo));
+}

--- a/skiko/skiko-graphite/src/jvmMain/cpp/common/Recorder.cc
+++ b/skiko/skiko-graphite/src/jvmMain/cpp/common/Recorder.cc
@@ -1,0 +1,20 @@
+#include <jni.h>
+
+#include "include/gpu/graphite/Recorder.h"
+
+static void deleteRecorder(skgpu::graphite::Recorder* recorder) {
+    delete recorder;
+}
+
+extern "C" JNIEXPORT jlong JNICALL
+Java_org_jetbrains_skia_gpu_graphite_RecorderKt__1nGetRecorderFinalizer(JNIEnv*, jclass) {
+    return static_cast<jlong>(reinterpret_cast<uintptr_t>(&deleteRecorder));
+}
+
+extern "C" JNIEXPORT jlong JNICALL
+Java_org_jetbrains_skia_gpu_graphite_RecorderKt__1nSnap(
+        JNIEnv*, jclass, jlong recorderPtr) {
+    auto recorder = reinterpret_cast<skgpu::graphite::Recorder*>(
+            static_cast<uintptr_t>(recorderPtr));
+    return reinterpret_cast<jlong>(recorder->snap().release());
+}

--- a/skiko/skiko-graphite/src/jvmMain/cpp/common/Recording.cc
+++ b/skiko/skiko-graphite/src/jvmMain/cpp/common/Recording.cc
@@ -1,0 +1,12 @@
+#include <jni.h>
+
+#include "include/gpu/graphite/Recording.h"
+
+static void deleteRecording(skgpu::graphite::Recording* recording) {
+    delete recording;
+}
+
+extern "C" JNIEXPORT jlong JNICALL
+Java_org_jetbrains_skia_gpu_graphite_RecordingKt__1nGetRecordingFinalizer(JNIEnv*, jclass) {
+    return static_cast<jlong>(reinterpret_cast<uintptr_t>(&deleteRecording));
+}

--- a/skiko/skiko-graphite/src/jvmMain/cpp/common/SurfaceFactory.cc
+++ b/skiko/skiko-graphite/src/jvmMain/cpp/common/SurfaceFactory.cc
@@ -1,0 +1,31 @@
+#include <jni.h>
+
+#include "interop.hh"
+#include "include/core/SkColorSpace.h"
+#include "include/gpu/graphite/BackendTexture.h"
+#include "include/gpu/graphite/Recorder.h"
+#include "include/gpu/graphite/Surface.h"
+
+extern "C" JNIEXPORT jlong JNICALL
+Java_org_jetbrains_skia_gpu_graphite_SurfaceFactoryKt__1nMakeFromBackendTexture(
+        JNIEnv* env,
+        jclass,
+        jlong recorderPtr,
+        jlong backendTexturePtr,
+        jint colorType,
+        jlong colorSpacePtr,
+        jintArray surfacePropsValues) {
+    auto recorder = reinterpret_cast<skgpu::graphite::Recorder*>(
+            static_cast<uintptr_t>(recorderPtr));
+    auto backendTexture = reinterpret_cast<skgpu::graphite::BackendTexture*>(
+            static_cast<uintptr_t>(backendTexturePtr));
+    auto colorSpace = sk_ref_sp(reinterpret_cast<SkColorSpace*>(
+            static_cast<uintptr_t>(colorSpacePtr)));
+    auto surfaceProps = skija::SurfaceProps::toSkSurfaceProps(env, surfacePropsValues);
+    return reinterpret_cast<jlong>(SkSurfaces::WrapBackendTexture(
+            recorder,
+            *backendTexture,
+            static_cast<SkColorType>(colorType),
+            std::move(colorSpace),
+            surfaceProps.get()).release());
+}

--- a/skiko/skiko-graphite/src/jvmMain/cpp/common/SurfaceFactory.cc
+++ b/skiko/skiko-graphite/src/jvmMain/cpp/common/SurfaceFactory.cc
@@ -7,12 +7,11 @@
 #include "include/gpu/graphite/Surface.h"
 
 extern "C" JNIEXPORT jlong JNICALL
-Java_org_jetbrains_skia_gpu_graphite_SurfaceFactoryKt__1nMakeFromBackendTexture(
+Java_org_jetbrains_skia_gpu_graphite_SurfaceFactoryKt__1nWrapBackendTexture(
         JNIEnv* env,
         jclass,
         jlong recorderPtr,
         jlong backendTexturePtr,
-        jint colorType,
         jlong colorSpacePtr,
         jintArray surfacePropsValues) {
     auto recorder = reinterpret_cast<skgpu::graphite::Recorder*>(
@@ -25,7 +24,6 @@ Java_org_jetbrains_skia_gpu_graphite_SurfaceFactoryKt__1nMakeFromBackendTexture(
     return reinterpret_cast<jlong>(SkSurfaces::WrapBackendTexture(
             recorder,
             *backendTexture,
-            static_cast<SkColorType>(colorType),
             std::move(colorSpace),
             surfaceProps.get()).release());
 }

--- a/skiko/skiko-graphite/src/jvmMain/kotlin/org/jetbrains/skia/gpu/graphite/GraphiteLibrary.jvm.kt
+++ b/skiko/skiko-graphite/src/jvmMain/kotlin/org/jetbrains/skia/gpu/graphite/GraphiteLibrary.jvm.kt
@@ -1,0 +1,14 @@
+package org.jetbrains.skia.gpu.graphite
+
+import org.jetbrains.skiko.Library
+import org.jetbrains.skiko.LibraryLoader
+import org.jetbrains.skiko.hostId
+
+private val graphiteLoader = LibraryLoader("skiko-graphite-$hostId")
+
+internal actual object GraphiteLibrary {
+    actual fun load() {
+        Library.load()
+        graphiteLoader.loadOnce()
+    }
+}

--- a/skiko/skiko-graphite/src/jvmTest/kotlin/org/jetbrains/skia/gpu/graphite/GraphiteTestHelpers.kt
+++ b/skiko/skiko-graphite/src/jvmTest/kotlin/org/jetbrains/skia/gpu/graphite/GraphiteTestHelpers.kt
@@ -1,0 +1,31 @@
+package org.jetbrains.skia.gpu.graphite
+
+import org.jetbrains.skia.ExternalSymbolName
+import org.jetbrains.skia.impl.NativePointer
+import org.jetbrains.skiko.ExperimentalSkikoApi
+import org.jetbrains.skiko.OS
+import org.jetbrains.skiko.hostOs
+
+@OptIn(ExperimentalSkikoApi::class)
+internal actual fun makeTestGraphiteContext(): GraphiteContext? = when (hostOs) {
+    OS.MacOS -> makeTestMetalContext()
+    else -> null
+}
+
+@OptIn(ExperimentalSkikoApi::class)
+private fun makeTestMetalContext(): GraphiteContext {
+    GraphiteLibrary.load()
+    val metalObjects = _nCreateMetalObjects()
+    check(metalObjects.size == 2) { "Failed to create test Metal objects" }
+    return try {
+        GraphiteContext.makeMetal(metalObjects[0], metalObjects[1])
+    } finally {
+        _nReleaseMetalObjects(metalObjects[0], metalObjects[1])
+    }
+}
+
+@ExternalSymbolName("org_jetbrains_skia_gpu_graphite_GraphiteTestHelpers__1nCreateMetalObjects")
+private external fun _nCreateMetalObjects(): LongArray
+
+@ExternalSymbolName("org_jetbrains_skia_gpu_graphite_GraphiteTestHelpers__1nReleaseMetalObjects")
+private external fun _nReleaseMetalObjects(devicePtr: NativePointer, queuePtr: NativePointer)

--- a/skiko/skiko-graphite/src/jvmTest/objectiveC/GraphiteTestHelpers.mm
+++ b/skiko/skiko-graphite/src/jvmTest/objectiveC/GraphiteTestHelpers.mm
@@ -1,0 +1,30 @@
+#import <Metal/Metal.h>
+
+#include <jni.h>
+
+extern "C" JNIEXPORT jlongArray JNICALL
+Java_org_jetbrains_skia_gpu_graphite_GraphiteTestHelpersKt__1nCreateMetalObjects(
+        JNIEnv* env, jclass) {
+    @autoreleasepool {
+        id<MTLDevice> device = MTLCreateSystemDefaultDevice();
+        id<MTLCommandQueue> queue = [device newCommandQueue];
+        if (device == nil || queue == nil) {
+            return env->NewLongArray(0);
+        }
+
+        jlong pointers[] = {
+            reinterpret_cast<jlong>((__bridge_retained void*)device),
+            reinterpret_cast<jlong>((__bridge_retained void*)queue),
+        };
+        jlongArray result = env->NewLongArray(2);
+        env->SetLongArrayRegion(result, 0, 2, pointers);
+        return result;
+    }
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_org_jetbrains_skia_gpu_graphite_GraphiteTestHelpersKt__1nReleaseMetalObjects(
+        JNIEnv*, jclass, jlong devicePtr, jlong queuePtr) {
+    CFRelease(reinterpret_cast<CFTypeRef>(devicePtr));
+    CFRelease(reinterpret_cast<CFTypeRef>(queuePtr));
+}

--- a/skiko/skiko-graphite/src/nativeJsMain/cpp/BackendTexture.cc
+++ b/skiko/skiko-graphite/src/nativeJsMain/cpp/BackendTexture.cc
@@ -1,0 +1,20 @@
+#include "common.h"
+
+#include "include/gpu/graphite/BackendTexture.h"
+#include "include/gpu/graphite/mtl/MtlGraphiteTypes_cpp.h"
+
+static void deleteBackendTexture(skgpu::graphite::BackendTexture* texture) {
+    delete texture;
+}
+
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_gpu_graphite_BackendTexture__1nGetFinalizer() {
+    return reinterpret_cast<KNativePointer>(&deleteBackendTexture);
+}
+
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_gpu_graphite_BackendTexture__1nWrapMetalTexture(
+        KNativePointer texturePtr, KInt width, KInt height) {
+    auto texture = skgpu::graphite::BackendTextures::MakeMetal(
+            SkISize::Make(width, height),
+            reinterpret_cast<CFTypeRef>(texturePtr));
+    return reinterpret_cast<KNativePointer>(new skgpu::graphite::BackendTexture(texture));
+}

--- a/skiko/skiko-graphite/src/nativeJsMain/cpp/BackendTexture.cc
+++ b/skiko/skiko-graphite/src/nativeJsMain/cpp/BackendTexture.cc
@@ -11,8 +11,8 @@ SKIKO_EXPORT KNativePointer org_jetbrains_skia_gpu_graphite_BackendTexture__1nGe
     return reinterpret_cast<KNativePointer>(&deleteBackendTexture);
 }
 
-SKIKO_EXPORT KNativePointer org_jetbrains_skia_gpu_graphite_BackendTexture__1nWrapMetalTexture(
-        KNativePointer texturePtr, KInt width, KInt height) {
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_gpu_graphite_BackendTexture__1nMakeMetal(
+        KInt width, KInt height, KNativePointer texturePtr) {
     auto texture = skgpu::graphite::BackendTextures::MakeMetal(
             SkISize::Make(width, height),
             reinterpret_cast<CFTypeRef>(texturePtr));

--- a/skiko/skiko-graphite/src/nativeJsMain/cpp/GraphiteContext.cc
+++ b/skiko/skiko-graphite/src/nativeJsMain/cpp/GraphiteContext.cc
@@ -1,0 +1,51 @@
+#include "common.h"
+#include "GraphiteImageProvider.hh"
+
+#include "include/gpu/graphite/Context.h"
+#include "include/gpu/graphite/ContextOptions.h"
+#include "include/gpu/graphite/GraphiteTypes.h"
+#include "include/gpu/graphite/Recorder.h"
+#include "include/gpu/graphite/mtl/MtlBackendContext.h"
+
+static void deleteGraphiteContext(skgpu::graphite::Context* context) {
+    delete context;
+}
+
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_gpu_graphite_GraphiteContext__1nGetFinalizer() {
+    return reinterpret_cast<KNativePointer>(&deleteGraphiteContext);
+}
+
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_gpu_graphite_GraphiteContext__1nMakeMetal(
+        KNativePointer devicePtr, KNativePointer queuePtr) {
+    skgpu::graphite::MtlBackendContext backendContext{};
+    backendContext.fDevice.retain(reinterpret_cast<CFTypeRef>(devicePtr));
+    backendContext.fQueue.retain(reinterpret_cast<CFTypeRef>(queuePtr));
+
+    skgpu::graphite::ContextOptions options{};
+    options.fRequireOrderedRecordings = true;
+    return reinterpret_cast<KNativePointer>(
+            skgpu::graphite::ContextFactory::MakeMetal(backendContext, options).release());
+}
+
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_gpu_graphite_GraphiteContext__1nMakeRecorder(
+        KNativePointer contextPtr) {
+    auto context = reinterpret_cast<skgpu::graphite::Context*>(contextPtr);
+    skgpu::graphite::RecorderOptions options{};
+    options.fImageProvider = SkikoGraphiteImageProvider::Make();
+    return reinterpret_cast<KNativePointer>(context->makeRecorder(options).release());
+}
+
+SKIKO_EXPORT void org_jetbrains_skia_gpu_graphite_GraphiteContext__1nInsertRecording(
+        KNativePointer contextPtr, KNativePointer recordingPtr) {
+    auto context = reinterpret_cast<skgpu::graphite::Context*>(contextPtr);
+    skgpu::graphite::InsertRecordingInfo info{};
+    info.fRecording = reinterpret_cast<skgpu::graphite::Recording*>(recordingPtr);
+    context->insertRecording(info);
+}
+
+SKIKO_EXPORT void org_jetbrains_skia_gpu_graphite_GraphiteContext__1nSubmit(
+        KNativePointer contextPtr, KBoolean syncCpu) {
+    auto context = reinterpret_cast<skgpu::graphite::Context*>(contextPtr);
+    context->submit(skgpu::graphite::SubmitInfo(
+            syncCpu ? skgpu::graphite::SyncToCpu::kYes : skgpu::graphite::SyncToCpu::kNo));
+}

--- a/skiko/skiko-graphite/src/nativeJsMain/cpp/Recorder.cc
+++ b/skiko/skiko-graphite/src/nativeJsMain/cpp/Recorder.cc
@@ -1,0 +1,17 @@
+#include "common.h"
+
+#include "include/gpu/graphite/Recorder.h"
+
+static void deleteRecorder(skgpu::graphite::Recorder* recorder) {
+    delete recorder;
+}
+
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_gpu_graphite_Recorder__1nGetFinalizer() {
+    return reinterpret_cast<KNativePointer>(&deleteRecorder);
+}
+
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_gpu_graphite_Recorder__1nSnap(
+        KNativePointer recorderPtr) {
+    auto recorder = reinterpret_cast<skgpu::graphite::Recorder*>(recorderPtr);
+    return reinterpret_cast<KNativePointer>(recorder->snap().release());
+}

--- a/skiko/skiko-graphite/src/nativeJsMain/cpp/Recording.cc
+++ b/skiko/skiko-graphite/src/nativeJsMain/cpp/Recording.cc
@@ -1,0 +1,11 @@
+#include "common.h"
+
+#include "include/gpu/graphite/Recording.h"
+
+static void deleteRecording(skgpu::graphite::Recording* recording) {
+    delete recording;
+}
+
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_gpu_graphite_Recording__1nGetFinalizer() {
+    return reinterpret_cast<KNativePointer>(&deleteRecording);
+}

--- a/skiko/skiko-graphite/src/nativeJsMain/cpp/SurfaceFactory.cc
+++ b/skiko/skiko-graphite/src/nativeJsMain/cpp/SurfaceFactory.cc
@@ -1,0 +1,24 @@
+#include "common.h"
+
+#include "include/core/SkColorSpace.h"
+#include "include/gpu/graphite/BackendTexture.h"
+#include "include/gpu/graphite/Recorder.h"
+#include "include/gpu/graphite/Surface.h"
+
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_gpu_graphite_SurfaceFactory__1nMakeFromBackendTexture(
+        KNativePointer recorderPtr,
+        KNativePointer backendTexturePtr,
+        KInt colorType,
+        KNativePointer colorSpacePtr,
+        KInteropPointer surfacePropsValues) {
+    auto recorder = reinterpret_cast<skgpu::graphite::Recorder*>(recorderPtr);
+    auto backendTexture = reinterpret_cast<skgpu::graphite::BackendTexture*>(backendTexturePtr);
+    auto colorSpace = sk_ref_sp(reinterpret_cast<SkColorSpace*>(colorSpacePtr));
+    auto surfaceProps = skija::SurfaceProps::toSkSurfaceProps(surfacePropsValues);
+    return reinterpret_cast<KNativePointer>(SkSurfaces::WrapBackendTexture(
+            recorder,
+            *backendTexture,
+            static_cast<SkColorType>(colorType),
+            std::move(colorSpace),
+            surfaceProps.get()).release());
+}

--- a/skiko/skiko-graphite/src/nativeJsMain/cpp/SurfaceFactory.cc
+++ b/skiko/skiko-graphite/src/nativeJsMain/cpp/SurfaceFactory.cc
@@ -5,10 +5,9 @@
 #include "include/gpu/graphite/Recorder.h"
 #include "include/gpu/graphite/Surface.h"
 
-SKIKO_EXPORT KNativePointer org_jetbrains_skia_gpu_graphite_SurfaceFactory__1nMakeFromBackendTexture(
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_gpu_graphite_SurfaceFactory__1nWrapBackendTexture(
         KNativePointer recorderPtr,
         KNativePointer backendTexturePtr,
-        KInt colorType,
         KNativePointer colorSpacePtr,
         KInteropPointer surfacePropsValues) {
     auto recorder = reinterpret_cast<skgpu::graphite::Recorder*>(recorderPtr);
@@ -18,7 +17,6 @@ SKIKO_EXPORT KNativePointer org_jetbrains_skia_gpu_graphite_SurfaceFactory__1nMa
     return reinterpret_cast<KNativePointer>(SkSurfaces::WrapBackendTexture(
             recorder,
             *backendTexture,
-            static_cast<SkColorType>(colorType),
             std::move(colorSpace),
             surfaceProps.get()).release());
 }

--- a/skiko/skiko-graphite/src/nativeMain/kotlin/org/jetbrains/skia/gpu/graphite/GraphiteLibrary.native.kt
+++ b/skiko/skiko-graphite/src/nativeMain/kotlin/org/jetbrains/skia/gpu/graphite/GraphiteLibrary.native.kt
@@ -1,0 +1,5 @@
+package org.jetbrains.skia.gpu.graphite
+
+internal actual object GraphiteLibrary {
+    actual fun load() = Unit
+}

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Surface.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Surface.kt
@@ -2,6 +2,7 @@ package org.jetbrains.skia
 
 import org.jetbrains.skia.impl.*
 import org.jetbrains.skia.impl.Library.Companion.staticLoad
+import org.jetbrains.skiko.InternalSkikoApi
 
 class Surface : RefCnt {
     companion object {
@@ -1008,7 +1009,8 @@ class Surface : RefCnt {
             reachabilityBarrier(this)
         }
 
-    internal constructor(ptr: NativePointer) : super(ptr) {
+    @InternalSkikoApi
+    constructor(ptr: NativePointer) : super(ptr) {
         _context = null
         _renderTarget = null
     }

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/SurfaceProps.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/SurfaceProps.kt
@@ -1,5 +1,7 @@
 package org.jetbrains.skia
 
+import org.jetbrains.skiko.InternalSkikoApi
+
 class SurfaceProps constructor(
     internal val isDeviceIndependentFonts: Boolean = false,
     internal val pixelGeometry: PixelGeometry = PixelGeometry.UNKNOWN
@@ -44,7 +46,8 @@ class SurfaceProps constructor(
         return if (pixelGeometry == _pixelGeometry) this else SurfaceProps(isDeviceIndependentFonts, _pixelGeometry)
     }
 
-    internal fun packToIntArray(): IntArray {
+    @InternalSkikoApi
+    fun packToIntArray(): IntArray {
         return intArrayOf(_getFlags(), _getPixelGeometryOrdinal())
     }
 }

--- a/skiko/src/jvmMain/cpp/common/interop.hh
+++ b/skiko/src/jvmMain/cpp/common/interop.hh
@@ -314,7 +314,9 @@ namespace skija {
     }
 
     namespace SurfaceProps {
-        std::unique_ptr<SkSurfaceProps> toSkSurfaceProps(JNIEnv* env, jintArray surfacePropsInts);
+        SKIKO_JVM_EXPORT std::unique_ptr<SkSurfaceProps> toSkSurfaceProps(
+                JNIEnv* env,
+                jintArray surfacePropsInts);
     }
 
     namespace SamplingMode {


### PR DESCRIPTION
This PR adds a separate Graphite module. The currently supported targets are iOS, tvOS, native macOS, and JVM macOS.

Since only macOS is currently supported for the JVM target, its hidden under  `skiko.graphite.jvm.enabled` defaulting to false. We won't publish the JVM target until all JVM targets are supported.

Fixes [SKIKO-1128](https://youtrack.jetbrains.com/issue/SKIKO-1128)