### PR TITLE
Fix graphite publishing

### DIFF
--- a/skiko/gradle.properties
+++ b/skiko/gradle.properties
@@ -4,9 +4,6 @@ kotlin.code.style=official
 kotlin.mpp.applyDefaultHierarchyTemplate=false
 kotlin.mpp.enableCInteropCommonization=true
 kotlin.js.yarn.lock.file=false
-# skiko-graphite is included on Linux so CI can publish its common KMP module metadata.
-# With the default properties below, Graphite has no enabled targets on Linux because its JVM target is macOS-only.
-kotlin.internal.suppressGradlePluginErrors=NoKotlinTargetsDeclared
 skiko.kotlin.language.version=2.2
 skiko.kotlin.api.version=2.2
 

--- a/skiko/gradle.properties
+++ b/skiko/gradle.properties
@@ -4,6 +4,9 @@ kotlin.code.style=official
 kotlin.mpp.applyDefaultHierarchyTemplate=false
 kotlin.mpp.enableCInteropCommonization=true
 kotlin.js.yarn.lock.file=false
+# skiko-graphite is included on Linux so CI can publish its common KMP module metadata.
+# With the default properties below, Graphite has no enabled targets on Linux because its JVM target is macOS-only.
+kotlin.internal.suppressGradlePluginErrors=NoKotlinTargetsDeclared
 skiko.kotlin.language.version=2.2
 skiko.kotlin.api.version=2.2
 

--- a/skiko/settings.gradle.kts
+++ b/skiko/settings.gradle.kts
@@ -21,6 +21,4 @@ include("docs")
 include("import-generator")
 include("test-utils")
 include("skiko-skottie")
-if (System.getProperty("os.name") == "Mac OS X") {
-    include("skiko-graphite")
-}
+include("skiko-graphite")

--- a/skiko/skiko-graphite/build.gradle.kts
+++ b/skiko/skiko-graphite/build.gradle.kts
@@ -3,18 +3,25 @@
 import org.jetbrains.compose.internal.publishing.MavenCentralProperties
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile
 import tasks.configuration.*
 import dsl.SkikoDependencyScope
 
 plugins {
-    kotlin("multiplatform")
+    kotlin("multiplatform") apply false
     org.jetbrains.dokka
     `maven-publish`
     signing
     org.gradle.crypto.checksum
 }
+
+// skiko-graphite is included on Linux so CI can publish its common KMP module metadata.
+// With the default properties below, Graphite has no enabled targets on Linux because its JVM target is macOS-only.
+extra["kotlin.internal.suppressGradlePluginErrors"] = "NoKotlinTargetsDeclared"
+apply(plugin = "org.jetbrains.kotlin.multiplatform")
+val kotlin = extensions.getByType<KotlinMultiplatformExtension>()
 
 val skiko = SkikoProperties(rootProject)
 val targetOs = hostOs
@@ -72,7 +79,7 @@ repositories {
     google()
 }
 
-kotlin {
+kotlin.run {
     compilerOptions {
         languageVersion.set(skikoKotlinLanguageVersion)
         apiVersion.set(skikoKotlinApiVersion)


### PR DESCRIPTION
Previously, Graphite’s iOS and tvOS target artifacts could be published, but its root `skiko-graphite` module was missing. This prevented normal KMP dependency resolution through:                                                  
```
implementation("org.jetbrains.skiko:skiko-graphite:<version>")                                                                                                                                                           
```                                                                                                                                                                                                                                     
The common publication task (in TeamCity) ran only on Linux CI, while `skiko-graphite` was included only on macOS. Exposing the project on Linux closes that CI coverage gap without publishing a JVM variant. 