### PR TITLE
Update emscripten docker ubuntu version

### DIFF
--- a/skiko/docker/linux-emscripten-amd64/Dockerfile
+++ b/skiko/docker/linux-emscripten-amd64/Dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt update -y && \
     apt install binutils build-essential software-properties-common -y && \
-    apt install zip unzip git python curl wget -y && \
+    apt install zip unzip git python3 curl wget -y && \
     apt install fontconfig libfontconfig1-dev libglu1-mesa-dev libxrandr-dev libdbus-1-dev -y && \
     apt install openjdk-21-jdk -y && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This PR fixes the following error which has started occurring more frequently:
```
stderr: error: emsdk requires Python 3.10 or later (/usr/bin/python3 3.8.10 (default, Mar 18 2025, 20:04:55))
```