### PR TITLE
Update Skia to m152

### DIFF
--- a/skiko/gradle.properties
+++ b/skiko/gradle.properties
@@ -10,7 +10,7 @@ skiko.kotlin.api.version=2.2
 deploy.version=0.0.0
 
 # a tag from https://github.com/JetBrains/skia/releases
-dependencies.skia=m151-ab72428249
+dependencies.skia=m152-7bb45c7c26
 
 # a tag from https://github.com/JetBrains/angle-pack
 dependencies.angle=ec4d8f8e4d

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Path.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Path.kt
@@ -20,8 +20,6 @@ import kotlin.math.min
  * outside the geometry. Path also describes the winding rule used to fill
  * overlapping contours.
  *
- * Internally, Path lazily computes metrics likes bounds and convexity. Call
- * [updateBoundsCache] to make Path thread safe.
  */
 class Path internal constructor(ptr: NativePointer) : Managed(ptr, _FinalizerHolder.PTR), Iterable<PathSegment?> {
     companion object {
@@ -936,23 +934,6 @@ class Path internal constructor(ptr: NativePointer) : Managed(ptr, _FinalizerHol
         }
 
     /**
-     * Updates internal bounds so that subsequent calls to [bounds] are instantaneous.
-     * Unaltered copies of Path may also access cached bounds through [bounds].
-     *
-     * For now, identical to calling [bounds] and ignoring the returned value.
-     *
-     * Call to prepare Path subsequently drawn from multiple threads,
-     * to avoid a race condition where each draw separately computes the bounds.
-     *
-     * @return  this
-     */
-    fun updateBoundsCache(): Path {
-        Stats.onNativeCall()
-        _nUpdateBoundsCache(_ptr)
-        return this
-    }
-
-    /**
      * Returns minimum and maximum axes values of the lines and curves in Path.
      * Returns (0, 0, 0, 0) if Path contains no points.
      * Returned bounds width and height may be larger or smaller than area affected
@@ -1334,9 +1315,6 @@ private external fun _nApproximateBytesUsed(ptr: NativePointer): Int
 
 @ExternalSymbolName("org_jetbrains_skia_Path__1nGetBounds")
 private external fun _nGetBounds(ptr: NativePointer, rect: InteropPointer)
-
-@ExternalSymbolName("org_jetbrains_skia_Path__1nUpdateBoundsCache")
-private external fun _nUpdateBoundsCache(ptr: NativePointer)
 
 @ExternalSymbolName("org_jetbrains_skia_Path__1nComputeTightBounds")
 private external fun _nComputeTightBounds(ptr: NativePointer, rect: InteropPointer)

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Path.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Path.kt
@@ -19,7 +19,6 @@ import kotlin.math.min
  * When used to draw a filled area, Path describes whether the fill is inside or
  * outside the geometry. Path also describes the winding rule used to fill
  * overlapping contours.
- *
  */
 class Path internal constructor(ptr: NativePointer) : Managed(ptr, _FinalizerHolder.PTR), Iterable<PathSegment?> {
     companion object {
@@ -909,6 +908,15 @@ class Path internal constructor(ptr: NativePointer) : Managed(ptr, _FinalizerHol
             reachabilityBarrier(this)
             reachabilityBarrier(other)
         }
+    }
+
+    // TODO: Remove in CMP 1.14.
+    @Deprecated(
+        message = "updateBoundsCache() is obsolete and is now a no-op stub.",
+        level = DeprecationLevel.HIDDEN,
+    )
+    fun updateBoundsCache(): Path {
+        return this
     }
 
     /**

--- a/skiko/src/commonTest/kotlin/org/jetbrains/skia/PathTest.kt
+++ b/skiko/src/commonTest/kotlin/org/jetbrains/skia/PathTest.kt
@@ -112,14 +112,6 @@ class PathTest {
     }
 
     @Test
-    fun updateBoundsCacheTest() {
-        val path = PathBuilder().lineTo(40f, 40f).lineTo(40f, 0f).lineTo(0f, 40f).lineTo(0f, 0f).closePath().detach()
-        val bounds = Rect(0.0f, 0.0f, 40.0f, 40.0f)
-        assertTrue(path.updateBoundsCache() === path)
-        assertCloseEnough(bounds, path.bounds)
-    }
-
-    @Test
     fun rawTest() {
         val pts = arrayOf(Point(0f, 0f), Point(10f, 10f), Point(20f, 0f))
         val verbs = arrayOf(PathVerb.MOVE, PathVerb.LINE, PathVerb.LINE)

--- a/skiko/src/jvmMain/cpp/common/Path.cc
+++ b/skiko/src/jvmMain/cpp/common/Path.cc
@@ -195,11 +195,6 @@ extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_PathKt__1nGetBounds(JN
     skija::Rect::copyToInterop(env, instance->getBounds(), resultArray);
 }
 
-extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_PathKt__1nUpdateBoundsCache(JNIEnv* env, jclass jclass, jlong ptr) {
-    SkPath* instance = reinterpret_cast<SkPath*>(static_cast<uintptr_t>(ptr));
-    instance->updateBoundsCache();
-}
-
 extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_PathKt__1nComputeTightBounds(JNIEnv* env, jclass jclass, jlong ptr, jfloatArray resultArray) {
     SkPath* instance = reinterpret_cast<SkPath*>(static_cast<uintptr_t>(ptr));
     skija::Rect::copyToInterop(env, instance->computeTightBounds(), resultArray);

--- a/skiko/src/nativeJsMain/cpp/Path.cc
+++ b/skiko/src/nativeJsMain/cpp/Path.cc
@@ -187,11 +187,6 @@ SKIKO_EXPORT void org_jetbrains_skia_Path__1nGetBounds(KNativePointer ptr, KInte
     skija::Rect::copyToInterop(bounds, resultArray);
 }
 
-SKIKO_EXPORT void org_jetbrains_skia_Path__1nUpdateBoundsCache(KNativePointer ptr) {
-    SkPath* instance = reinterpret_cast<SkPath*>((ptr));
-    instance->updateBoundsCache();
-}
-
 SKIKO_EXPORT void org_jetbrains_skia_Path__1nComputeTightBounds(KNativePointer ptr, KInteropPointer resultArray) {
     SkPath* instance = reinterpret_cast<SkPath*>((ptr));
     SkRect bounds = instance->computeTightBounds();


### PR DESCRIPTION
This PR removes the `updateBoundsCache` from the `Path` following the Skia m152 release notes
> Since SkPath data is now immutable and we always compute the bounds upfront, SkPath::updateBoundsCache() no longer serves any purpose and has been removed.

Fixes - [SKIKO-1152](https://youtrack.jetbrains.com/issue/SKIKO-1152)