### PR TITLE
* [proof of concept] support for RoboVM/JVM on iOS(arm64) platform that enables Compose there 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Supported platforms:
    * Kotlin/JS + WebAssembly in browsers
    * Kotlin/Native on iOS(arm64 and x64)
    * Kotlin/Native on macOS (arm64 and x64)
+   * Kotlin/RoboVM/JVM on iOS(arm64)
 
 ## API documentation
 

--- a/skiko/build.gradle.kts
+++ b/skiko/build.gradle.kts
@@ -56,6 +56,8 @@ allprojects {
 repositories {
     mavenCentral()
     google()
+    // for RoboVM snapshots
+    maven("https://central.sonatype.com/repository/maven-snapshots")
 }
 
 kotlin {
@@ -174,6 +176,21 @@ kotlin {
         skikoProjectContext.configureNativeTarget(OS.TVOS, Arch.X64, tvosX64())
     }
 
+    if (supportAnyRoboVMIos) {
+        skikoProjectContext.configureRoboVmTarget(
+            OS.IOS, target = jvm(ROBOVM_IOS_TARGET_NAME)
+        )
+    }
+    if (supportAnyRoboVMIos) {
+        // RoboVM reuses the AWT-free JVM (JNI) implementation of the Skia API, like the
+        // Android target does, but stays outside of the "jvm" source set group.
+        val jvmMainSourceSet = sourceSets.findByName("jvmMain")
+            ?: sourceSets.create("jvmMain").apply { dependsOn(sourceSets.getByName("commonMain")) }
+        sourceSets.named("robovmMain") {
+            dependsOn(jvmMainSourceSet)
+        }
+    }
+
     sourceSets.commonMain.dependencies {
         implementation(kotlin("stdlib"))
         implementation(libs.coroutines.core)
@@ -203,6 +220,11 @@ kotlin {
 
     skikoProjectContext.androidMainSourceSet?.dependencies {
         implementation(libs.coroutines.android)
+    }
+
+    skikoProjectContext.robovmMainSourceSet?.dependencies {
+        compileOnly(project.robovmDependency("robovm-rt"))
+        compileOnly(project.robovmDependency("robovm-cocoatouch"))
     }
 
     skikoProjectContext.jvmTestSourceSet?.dependencies {

--- a/skiko/buildSrc/settings.gradle.kts
+++ b/skiko/buildSrc/settings.gradle.kts
@@ -30,6 +30,8 @@ dependencyResolutionManagement {
         }
 
         mavenCentral()
+        // for RoboVM snapshot builds
+        maven("https://central.sonatype.com/repository/maven-snapshots")
     }
 
     versionCatalogs {

--- a/skiko/buildSrc/src/main/kotlin/SkiaTarget.kt
+++ b/skiko/buildSrc/src/main/kotlin/SkiaTarget.kt
@@ -4,6 +4,8 @@ enum class SkiaTarget(
 ) {
     IOS("ios", listOf("-P${SkikoGradleProperties.AWT_ENABLED}=false")),
     IOS_SIM("iosSim", listOf("-P${SkikoGradleProperties.AWT_ENABLED}=false")),
+    // using same id=ios for RoboVM, as id is used only for prepareLocalSkiaBuild (but we are not interested in it)
+    IOS_ROBOVM("ios", listOf("-P${SkikoGradleProperties.AWT_ENABLED}=false")),
     MACOS("macos", listOf("-P${SkikoGradleProperties.AWT_ENABLED}=true")),
     WINDOWS("windows", listOf("-P${SkikoGradleProperties.AWT_ENABLED}=true")),
     LINUX("linux", listOf("-P${SkikoGradleProperties.AWT_ENABLED}=true")),
@@ -24,7 +26,7 @@ enum class SkiaTarget(
         }
 
     fun machines(hostArch: Arch): List<Arch> = when (this) {
-        IOS -> listOf(if (hostArch == Arch.Arm64) Arch.Arm64 else Arch.X64)
+        IOS, IOS_ROBOVM -> listOf(if (hostArch == Arch.Arm64) Arch.Arm64 else Arch.X64)
         IOS_SIM -> listOf(if (hostArch == Arch.Arm64) Arch.Arm64 else Arch.X64)
         MACOS -> if (hostArch == Arch.Arm64) listOf(Arch.Arm64, Arch.X64) else listOf(Arch.X64)
         WINDOWS -> listOf(hostArch)
@@ -36,6 +38,7 @@ enum class SkiaTarget(
         val archProperties = when (this) {
             IOS -> listOf("-P${SkikoGradleProperties.NATIVE_IOS}.${hostArch.gradleProperty}.enabled=true")
             IOS_SIM -> listOf("-P${SkikoGradleProperties.NATIVE_IOS}.simulator${hostArch.titleCase}.enabled=true")
+            IOS_ROBOVM -> listOf("-P${SkikoGradleProperties.ROBOVM_IOS}.${hostArch.gradleProperty}.enabled=true")
             else -> emptyList()
         }
         return gradleProperties + archProperties
@@ -45,12 +48,13 @@ enum class SkiaTarget(
         fun fromString(target: String): SkiaTarget = when (target) {
             "ios" -> IOS
             "iosSim" -> IOS_SIM
+            "iosRobovm" -> IOS_ROBOVM
             "macos" -> MACOS
             "windows" -> WINDOWS
             "linux" -> LINUX
             "wasm" -> WASM
             else -> throw IllegalArgumentException(
-                "Unknown SKIA_TARGET: $target. Valid targets: ios, iosSim, macos, windows, linux, wasm"
+                "Unknown SKIA_TARGET: $target. Valid targets: ios, iosSim, iosRobovm, macos, windows, linux, wasm"
             )
         }
     }

--- a/skiko/buildSrc/src/main/kotlin/SkikoProjectContext.kt
+++ b/skiko/buildSrc/src/main/kotlin/SkikoProjectContext.kt
@@ -29,6 +29,7 @@ class SkikoProjectContext(
 }
 
 fun SkikoProjectContext.declareSkiaTasks() {
+    // Note: the RoboVM target reuse the "ios"/"iosSim" Skia binaries
     mapOf(
         "android" to listOf("arm64", "x64"),
         "ios" to listOf("arm64", "x64"),
@@ -156,6 +157,24 @@ val Project.supportNativeLinux: Boolean
 
 val Project.supportAnyNative: Boolean
     get() = supportAllNative || supportAnyNativeIos || supportNativeMac || supportNativeLinux
+
+val Project.supportAllRoboVM: Boolean
+    get() = findProperty(SkikoGradleProperties.ROBOVM_ENABLED) == "true" || isInIdea
+
+val Project.supportAllRoboVMIos: Boolean
+    get() = supportAllRoboVM || findProperty("${SkikoGradleProperties.ROBOVM_IOS}.enabled") == "true" || isInIdea
+
+val Project.supportRoboVMIosArm64: Boolean
+    get() = supportAllRoboVMIos || findProperty(SkikoGradleProperties.ROBOVM_IOS_ARM64) == "true" || isInIdea
+
+val Project.supportRoboVMIosSimulatorArm64: Boolean
+    get() = supportAllRoboVMIos || findProperty(SkikoGradleProperties.ROBOVM_IOS_SIMULATOR_ARM64) == "true" || isInIdea
+
+val Project.supportAnyRoboVMIos: Boolean
+    get() = supportAllRoboVMIos || supportRoboVMIosArm64 || supportRoboVMIosSimulatorArm64
+
+val Project.supportAnyRoboVM: Boolean
+    get() = supportAllRoboVM || supportAnyRoboVMIos
 
 val Project.supportWeb: Boolean
     get() = findProperty(SkikoGradleProperties.WASM_ENABLED) == "true" || isInIdea

--- a/skiko/buildSrc/src/main/kotlin/properties.kt
+++ b/skiko/buildSrc/src/main/kotlin/properties.kt
@@ -268,6 +268,10 @@ object SkikoGradleProperties {
     const val NATIVE_TVOS_X64 = "skiko.native.tvos.x64.enabled"
     const val NATIVE_MAC = "skiko.native.mac.enabled"
     const val NATIVE_LINUX = "skiko.native.linux.enabled"
+    const val ROBOVM_ENABLED = "skiko.robovm.enabled"
+    const val ROBOVM_IOS = "skiko.robovm.ios"
+    const val ROBOVM_IOS_ARM64 = "skiko.robovm.ios.arm64.enabled"
+    const val ROBOVM_IOS_SIMULATOR_ARM64 = "skiko.robovm.ios.simulatorArm64.enabled"
 }
 
 object SkikoArtifacts {

--- a/skiko/buildSrc/src/main/kotlin/sourceHierarchy.kt
+++ b/skiko/buildSrc/src/main/kotlin/sourceHierarchy.kt
@@ -2,8 +2,12 @@
 
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.plugin.KotlinHierarchyTemplate
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
+import tasks.configuration.robovmIosTargetNames
 
-val SkikoProjectContext.jvmMainSourceSet get() = if (project.supportAwt) kotlin.sourceSets.getByName("jvmMain") else null
+// jvmMain (the AWT-free JNI implementation of the Skia API) is also consumed by the
+// RoboVM targets, so it exists even when the AWT flavor is disabled.
+val SkikoProjectContext.jvmMainSourceSet get() = if (project.supportAwt || project.supportAnyRoboVMIos) kotlin.sourceSets.getByName("jvmMain") else null
 
 val SkikoProjectContext.jvmTestSourceSet get() = if (project.supportAwt) kotlin.sourceSets.getByName("jvmTest") else null
 
@@ -19,11 +23,26 @@ val SkikoProjectContext.webTestSourceSet get() = if (project.supportWeb) kotlin.
 
 val SkikoProjectContext.wasmJsTest get() = if (project.supportWeb) kotlin.sourceSets.getByName("wasmJsTest") else null
 
+val SkikoProjectContext.robovmMainSourceSet get() = if (project.supportAnyRoboVMIos) kotlin.sourceSets.getByName("robovmMain") else null
+
+val SkikoProjectContext.robovmTestSourceSet get() = if (project.supportAnyRoboVMIos) kotlin.sourceSets.getByName("robovmTest") else null
+
 val skikoSourceSetHierarchyTemplate = KotlinHierarchyTemplate {
     common {
         group("jvm") {
             withAndroidTarget()
-            withJvm()
+            // All Kotlin/JVM targets except the RoboVM as it has has no AWT/JAWT/Canvas, so it must not see the shared jvm sources.
+            withCompilations { compilation ->
+                compilation.target.platformType == KotlinPlatformType.jvm &&
+                        compilation.target.name !in robovmIosTargetNames
+            }
+        }
+
+        // RoboVM (JVM on iOS): deliberately outside both the "jvm" group (no AWT)
+        // and the "native" group (no Kotlin/Native runtime). Rendering follows the
+        // native iOS approach (Metal) via RoboVM CocoaTouch classes.
+        group("robovm") {
+            withCompilations { it.target.name in robovmIosTargetNames }
         }
 
         group("web") {

--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/RoboVmTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/RoboVmTasksConfiguration.kt
@@ -1,0 +1,374 @@
+package tasks.configuration
+
+import Arch
+import CompileSkikoCppTask
+import LinkSkikoTask
+import OS
+import SkikoProjectContext
+import compilerForTarget
+import isCompatibleWithHost
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.api.attributes.Attribute
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.TaskProvider
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
+import projectDirs
+import registerOrGetSkiaDirProvider
+import registerSkikoTask
+import supportRoboVMIosArm64
+import supportRoboVMIosSimulatorArm64
+import java.io.File
+
+/**
+ * RoboVM targets build infrastructure.
+ *
+ * The Skia binaries are shared with the Kotlin/Native iOS targets
+ * (see [SkikoProjectContext.declareSkiaTasks]: "ios"/"iosSim" configs).
+ */
+
+/** Name of the Kotlin/JVM target running via RoboVM on iOS devices and simulators. */
+const val ROBOVM_IOS_TARGET_NAME = "iosRobovm"
+
+/** All RoboVM Kotlin target names; used to carve them out of the "jvm" source set group. */
+val robovmIosTargetNames = setOf(ROBOVM_IOS_TARGET_NAME)
+
+const val ROBOVM_MAVEN_GROUP = "com.robovmx"
+const val ROBOVM_DEFAULT_VERSION = "10.2.2.5-SNAPSHOT"
+
+/** RoboVM version, overridable with the `dependencies.robovm` gradle property. */
+val Project.robovmVersion: String
+    get() = findProperty("dependencies.robovm")?.toString() ?: ROBOVM_DEFAULT_VERSION
+
+fun Project.robovmDependency(artifactId: String): String = "$ROBOVM_MAVEN_GROUP:$artifactId:$robovmVersion"
+
+/**
+ * Build directory layout for the RoboVM artifacts of a single (arch, device/simulator) pair,
+ * e.g. `build/robovm/iosSim-arm64`. Consumed by the bridge compile/link tasks (next phase).
+ */
+class RoboVmTargetDirs(
+    project: Project,
+    os: OS,
+    arch: Arch,
+    isSimulator: Boolean,
+) {
+    val targetString: String = "${os.idWithSuffix(isUikitSim = isSimulator)}-${arch.id}"
+
+    /** Root for all RoboVM build artifacts of this target. */
+    val rootDir: Provider<Directory> = project.layout.buildDirectory.dir("robovm/$targetString")
+
+    /** Object files of the compiled JNI bridges. */
+    val bridgesObjDir: Provider<Directory> = rootDir.map { it.dir("bridges/obj") }
+
+    /** Static library with the skiko JNI bridges, linked into the app binary by RoboVM. */
+    val bridgesStaticDir: Provider<Directory> = rootDir.map { it.dir("bridges/static") }
+
+    /** Native libraries (Skia + bridges) packaged for RoboVM consumers. */
+    val nativeLibsDir: Provider<Directory> = rootDir.map { it.dir("libs") }
+}
+
+fun SkikoProjectContext.robovmDirsFor(os: OS, arch: Arch, isSimulator: Boolean): RoboVmTargetDirs =
+    RoboVmTargetDirs(project, os, arch, isSimulator)
+
+/**
+ * C++ source roots that are compiled into the RoboVM JNI bridges (next phase).
+ * Reuses the common and JVM (JNI) bindings, but not the AWT-specific ones.
+ * RoboVM-specific bridge sources live in `src/robovmMain/cpp`.
+ */
+fun robovmBridgesSourceRoots(): List<String> = listOf(
+    "src/commonMain/cpp/common",
+    "src/jvmMain/cpp/common",
+    "src/robovmMain/cpp",
+)
+
+/**
+ * Configures a RoboVM Kotlin/JVM target: bytecode level, version generation,
+ * RoboVM dependencies and the Skia binaries providers shared with the native iOS targets.
+ */
+fun SkikoProjectContext.configureRoboVmTarget(
+    os: OS,
+    target: KotlinJvmTarget,
+): Unit = with(this.project) {
+    if (!os.isCompatibleWithHost) return
+    if (os != OS.IOS) throw GradleException("RoboVM is only supported for iOS, got: $os")
+
+    // RoboVM sticks to Java 8 bytecode
+    target.compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_1_8)
+    }
+    
+    target.attributes {
+        attribute(Attribute.of("skiko.robovmVariant", String::class.java), "ios")
+    }
+
+    target.generateVersion(os, Arch.Arm64, skiko)
+
+    // RoboVM runtime and CocoaTouch bindings are provided by the RoboVM toolchain
+    // of the consuming app, so they must not leak into the published dependencies.
+    target.compilations.getByName("main").defaultSourceSet.dependencies {
+        compileOnly(robovmDependency("robovm-rt"))
+        compileOnly(robovmDependency("robovm-cocoatouch"))
+    }
+    target.compilations.getByName("test").defaultSourceSet.dependencies {
+        compileOnly(robovmDependency("robovm-rt"))
+        compileOnly(robovmDependency("robovm-cocoatouch"))
+    }
+
+    val linkTasks = mutableListOf<TaskProvider<LinkSkikoTask>>()
+    if (project.supportRoboVMIosArm64) {
+        linkTasks += registerRoboVmBridgesTasks(os, Arch.Arm64, isSimulator = false)
+    }
+    if (project.supportRoboVMIosSimulatorArm64) {
+        linkTasks += registerRoboVmBridgesTasks(os, Arch.Arm64, isSimulator = true)
+    }
+    
+    val libsTask = registerRoboVmLibsTask(linkTasks)
+    
+    val createRoboVmXmlTask = project.tasks.register("createRoboVmXml") {
+        val xmlFile = project.layout.buildDirectory.file("robovm/robovm.xml")
+        outputs.file(xmlFile)
+        
+        doLast {
+            xmlFile.get().asFile.apply {
+                parentFile.mkdirs()
+                writeText("""
+                    <config>
+                        <libs>
+                            <lib variant="simulator" force="true">libs_sim/libskiko.a</lib>
+                            <lib variant="device" force="true">libs_iphone/libskiko.a</lib>
+                            <lib variant="simulator" force="false">libs_sim/libskresources.a</lib>
+                            <lib variant="device" force="false">libs_iphone/libskresources.a</lib>
+                            <lib variant="simulator" force="false">libs_sim/libskparagraph.a</lib>
+                            <lib variant="device" force="false">libs_iphone/libskparagraph.a</lib>
+                            <lib variant="simulator" force="false">libs_sim/libskia.a</lib>
+                            <lib variant="device" force="false">libs_iphone/libskia.a</lib>
+                            <lib variant="simulator" force="false">libs_sim/libicu.a</lib>
+                            <lib variant="device" force="false">libs_iphone/libicu.a</lib>
+                            <lib variant="simulator" force="false">libs_sim/libjsonreader.a</lib>
+                            <lib variant="device" force="false">libs_iphone/libjsonreader.a</lib>
+                            <lib variant="simulator" force="false">libs_sim/libskottie.a</lib>
+                            <lib variant="device" force="false">libs_iphone/libskottie.a</lib>
+                            <lib variant="simulator" force="false">libs_sim/libsvg.a</lib>
+                            <lib variant="device" force="false">libs_iphone/libsvg.a</lib>
+                            <lib variant="simulator" force="false">libs_sim/libpng.a</lib>
+                            <lib variant="device" force="false">libs_iphone/libpng.a</lib>
+                            <lib variant="simulator" force="false">libs_sim/libwebp_sse41.a</lib>
+                            <lib variant="device" force="false">libs_iphone/libwebp_sse41.a</lib>
+                            <lib variant="simulator" force="false">libs_sim/libsksg.a</lib>
+                            <lib variant="device" force="false">libs_iphone/libsksg.a</lib>
+                            <lib variant="simulator" force="false">libs_sim/libskunicode_core.a</lib>
+                            <lib variant="device" force="false">libs_iphone/libskunicode_core.a</lib>
+                            <lib variant="simulator" force="false">libs_sim/libskunicode_icu.a</lib>
+                            <lib variant="device" force="false">libs_iphone/libskunicode_icu.a</lib>
+                            <lib variant="simulator" force="false">libs_sim/libwebp.a</lib>
+                            <lib variant="device" force="false">libs_iphone/libwebp.a</lib>
+                            <lib variant="simulator" force="false">libs_sim/libdng_sdk.a</lib>
+                            <lib variant="device" force="false">libs_iphone/libdng_sdk.a</lib>
+                            <lib variant="simulator" force="false">libs_sim/libpiex.a</lib>
+                            <lib variant="device" force="false">libs_iphone/libpiex.a</lib>
+                            <lib variant="simulator" force="false">libs_sim/libharfbuzz.a</lib>
+                            <lib variant="device" force="false">libs_iphone/libharfbuzz.a</lib>
+                            <lib variant="simulator" force="false">libs_sim/libexpat.a</lib>
+                            <lib variant="device" force="false">libs_iphone/libexpat.a</lib>
+                            <lib variant="simulator" force="false">libs_sim/libzlib.a</lib>
+                            <lib variant="device" force="false">libs_iphone/libzlib.a</lib>
+                            <lib variant="simulator" force="false">libs_sim/libjpeg.a</lib>
+                            <lib variant="device" force="false">libs_iphone/libjpeg.a</lib>
+                            <lib variant="simulator" force="false">libs_sim/libskshaper.a</lib>
+                            <lib variant="device" force="false">libs_iphone/libskshaper.a</lib>
+                        </libs>
+                        <forceLinkClasses>
+                            <pattern>org.jetbrains.skia.AnimationFrameInfo</pattern>
+                            <pattern>org.jetbrains.skia.Color4f</pattern>
+                            <pattern>org.jetbrains.skia.Drawable</pattern>
+                            <pattern>org.jetbrains.skia.FontFamilyName</pattern>
+                            <pattern>org.jetbrains.skia.FontFeature</pattern>
+                            <pattern>org.jetbrains.skia.FontMgr</pattern>
+                            <pattern>org.jetbrains.skia.FontVariation</pattern>
+                            <pattern>org.jetbrains.skia.FontVariationAxis</pattern>
+                            <pattern>org.jetbrains.skia.IPoint</pattern>
+                            <pattern>org.jetbrains.skia.IRect</pattern>
+                            <pattern>org.jetbrains.skia.ImageInfo</pattern>
+                            <pattern>org.jetbrains.skia.PaintFilterCanvas</pattern>
+                            <pattern>org.jetbrains.skia.Path</pattern>
+                            <pattern>org.jetbrains.skia.PathSegment</pattern>
+                            <pattern>org.jetbrains.skia.Point</pattern>
+                            <pattern>org.jetbrains.skia.RRect</pattern>
+                            <pattern>org.jetbrains.skia.RSXform</pattern>
+                            <pattern>org.jetbrains.skia.Rect</pattern>
+                            <pattern>org.jetbrains.skia.impl.Native</pattern>
+                            <pattern>org.jetbrains.skia.paragraph.DecorationStyle</pattern>
+                            <pattern>org.jetbrains.skia.paragraph.LineMetrics</pattern>
+                            <pattern>org.jetbrains.skia.paragraph.Shadow</pattern>
+                            <pattern>org.jetbrains.skia.paragraph.TextBox</pattern>
+                            <pattern>org.jetbrains.skia.shaper.BidiRun</pattern>
+                            <pattern>org.jetbrains.skia.shaper.FontMgrRunIterator</pattern>
+                            <pattern>org.jetbrains.skia.shaper.FontRun</pattern>
+                            <pattern>org.jetbrains.skia.shaper.HbIcuScriptRunIterator</pattern>
+                            <pattern>org.jetbrains.skia.shaper.IcuBidiRunIterator</pattern>
+                            <pattern>org.jetbrains.skia.shaper.LanguageRun</pattern>
+                            <pattern>org.jetbrains.skia.shaper.RunHandler</pattern>
+                            <pattern>org.jetbrains.skia.shaper.RunInfo</pattern>
+                            <pattern>org.jetbrains.skia.shaper.ScriptRun</pattern>
+                            <pattern>org.jetbrains.skia.shaper.ShapingOptions</pattern>
+                            <pattern>org.jetbrains.skia.shaper.TextBlobBuilderRunHandler</pattern>
+                            <pattern>org.jetbrains.skia.svg.SVGLength</pattern>
+                            <pattern>org.jetbrains.skia.svg.SVGPreserveAspectRatio</pattern>
+                            <pattern>org.jetbrains.skia.skottie.Logger</pattern>
+                        </forceLinkClasses>
+                        <frameworks>
+                            <framework>Metal</framework>"
+                            <framework>CoreGraphics</framework>"
+                            <framework>CoreText</framework>"
+                        </frameworks>
+                    </config>
+                """.trimIndent())
+            }
+        }
+    }
+    
+    // Package the libs into the JAR
+    val jarTaskName = target.artifactsTaskName
+    project.tasks.named(jarTaskName, org.gradle.api.tasks.bundling.Jar::class.java) {
+        dependsOn(libsTask, createRoboVmXmlTask)
+        from(libsTask.map { it.outputs.files }) {
+            into("META-INF/robovm/ios/")
+        }
+        from(createRoboVmXmlTask.map { it.outputs.files }) {
+            into("META-INF/robovm/ios/")
+        }
+    }
+}
+
+fun SkikoProjectContext.registerRoboVmBridgesTasks(
+    os: OS, arch: Arch, isSimulator: Boolean
+): TaskProvider<LinkSkikoTask> {
+    val skiaDirProvider = registerOrGetSkiaDirProvider(os, arch, isUikitSim = isSimulator)
+    val targetDirs = robovmDirsFor(os, arch, isSimulator)
+    
+    return with(project) {
+        val suffix = arch.id.capitalize() + if (isSimulator) "Sim" else ""
+        val compileName = "compileRoboVmBridges$suffix"
+        val linkName = "linkRoboVmBridges$suffix"
+        
+        val compileTask = registerSkikoTask<CompileSkikoCppTask>(compileName, os, arch) {
+            dependsOn(skiaDirProvider)
+            val unpackedSkia = skiaDirProvider.get()
+            
+            compiler.set(compilerForTarget(os, arch))
+            buildTargetOS.set(os)
+            if (isSimulator) buildSuffix.set("sim")
+            buildTargetArch.set(arch)
+            buildVariant.set(buildType)
+            
+            sourceRoots.set(projectDirs(*robovmBridgesSourceRoots().toTypedArray()))
+            
+            val jdkHome = File(System.getProperty("java.home") ?: error("'java.home' is null"))
+            includeHeadersNonRecursive(jdkHome.resolve("include"))
+            includeHeadersNonRecursive(jdkHome.resolve("include/darwin"))
+            
+            skiaHeadersDirs(unpackedSkia).forEach {
+                includeHeadersNonRecursive(it)
+            }
+            
+            val projectDir = project.projectDir
+            includeHeadersNonRecursive(projectDir.resolve("src/awtMain/cpp/include"))
+            includeHeadersNonRecursive(projectDir.resolve("src/jvmMain/cpp/common"))
+            includeHeadersNonRecursive(projectDir.resolve("src/jvmMain/cpp/include"))
+            includeHeadersNonRecursive(projectDir.resolve("src/commonMain/cpp/common/include"))
+            
+            val sdkRoot = findXcodeSdkRoot()
+            val iphoneOsSdk = "$sdkRoot/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk"
+            val iphoneSimSdk = "$sdkRoot/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk"
+            val iosArchFlags = when (arch) {
+                Arch.Arm64 -> arrayOf(
+                    "-target", if (isSimulator) "arm64-apple-ios-simulator" else "arm64-apple-ios",
+                    "-isysroot", if (isSimulator) iphoneSimSdk else iphoneOsSdk,
+                    if (isSimulator) "-mios-simulator-version-min=12.0" else "-mios-version-min=12.0"
+                )
+                else -> throw GradleException("Unsupported arch: $arch")
+            }
+            
+            flags.set(listOf(
+                *iosArchFlags,
+                *buildType.clangFlags,
+                "-stdlib=libc++",
+                *skiaPreprocessorFlags(OS.IOS, buildType),
+            ))
+            
+            outDir.set(targetDirs.bridgesObjDir)
+        }
+        
+        registerSkikoTask<LinkSkikoTask>(linkName, os, arch) {
+            dependsOn(compileTask, skiaDirProvider)
+            buildTargetOS.set(os)
+            buildTargetArch.set(arch)
+            if (isSimulator) buildSuffix.set("sim")
+            buildVariant.set(buildType)
+            
+            linker.set("libtool")
+            flags.set(listOf("-static"))
+            
+            objectFiles = project.fileTree(compileTask.flatMap { it.outDir }) { include("**/*.o") }
+            libFiles = project.files() // Empty, so we don't pack Skia objects into libskiko.a
+            
+            outDir.set(targetDirs.bridgesStaticDir)
+            libOutputFileName.set("libskiko.a")
+        }
+    }
+}
+
+fun SkikoProjectContext.registerRoboVmLibsTask(
+    linkTasks: List<TaskProvider<LinkSkikoTask>>
+): TaskProvider<out org.gradle.api.Task> = project.tasks.register("createRoboVmLibs") {
+    dependsOn(linkTasks)
+    
+    val outDir = project.layout.buildDirectory.dir("robovm/packaged_libs").get().asFile
+    outputs.dir(outDir)
+    
+    doLast {
+        outDir.deleteRecursively()
+        outDir.mkdirs()
+        
+        val libIphoneDir = File(outDir, "libs_iphone")
+        val libSimDir = File(outDir, "libs_sim")
+        libIphoneDir.mkdirs()
+        libSimDir.mkdirs()
+        
+        // 1. Process skiko
+        for (taskProvider in linkTasks) {
+            val task = taskProvider.get()
+            val taskOutDir = task.outDir.get().asFile
+            val libFile = File(taskOutDir, "libskiko.a")
+            if (task.buildSuffix.orNull == "sim") {
+                libFile.copyTo(File(libSimDir, "libskiko.a"), overwrite = true)
+            } else {
+                libFile.copyTo(File(libIphoneDir, "libskiko.a"), overwrite = true)
+            }
+        }
+        
+        // 2. Process skia libraries
+        for (taskProvider in linkTasks) {
+            val task = taskProvider.get()
+            val isSim = task.buildSuffix.orNull == "sim"
+            val taskOs = task.buildTargetOS.get()
+            val taskArch = task.buildTargetArch.get()
+            val skiaDirProvider = registerOrGetSkiaDirProvider(taskOs, taskArch, isUikitSim = isSim)
+            val buildType = task.buildVariant.get()
+            val targetDirs = robovmDirsFor(taskOs, taskArch, isSim)
+            val skiaOutDir = skiaDirProvider.get().resolve("out/${buildType.id}-${targetDirs.targetString}")
+            
+            val libs = skiaOutDir.listFiles { _, name -> name.startsWith("lib") && name.endsWith(".a") } ?: emptyArray()
+            
+            for (libFile in libs) {
+                if (isSim) {
+                    libFile.copyTo(File(libSimDir, libFile.name), overwrite = true)
+                } else {
+                    libFile.copyTo(File(libIphoneDir, libFile.name), overwrite = true)
+                }
+            }
+        }
+    }
+}

--- a/skiko/gradle.properties
+++ b/skiko/gradle.properties
@@ -41,3 +41,12 @@ skiko.native.ios.enabled=false
 skiko.native.ios.arm64.enabled=false
 skiko.native.ios.simulatorArm64.enabled=false
 skiko.native.ios.x64.enabled=false
+skiko.robovm.enabled=true
+skiko.robovm.ios.enabled=true
+skiko.robovm.ios.arm64.enabled=false
+skiko.robovm.ios.simulatorArm64.enabled=true
+## The RoboVM targets are additional Kotlin/JVM targets next to "awt"; multiple jvm() targets are intentional here.
+kotlin.internal.suppressGradlePluginErrors=KotlinTargetAlreadyDeclaredError
+
+# RoboVM version used by the iosRobovm / iosRobovmSim targets
+dependencies.robovm=10.2.2.5-SNAPSHOT

--- a/skiko/src/jvmMain/cpp/common/awt_jni.cc
+++ b/skiko/src/jvmMain/cpp/common/awt_jni.cc
@@ -1,20 +1,20 @@
 #include <cstdint>
 #include <jni.h>
-#ifdef SK_BUILD_FOR_ANDROID
+#if defined(SK_BUILD_FOR_ANDROID) || defined(SK_BUILD_FOR_IOS)
 #include <stdlib.h>
 #else
 #include <jawt_md.h>
 #include "jni_helpers.h"
 #endif
 
-#ifndef SK_BUILD_FOR_ANDROID
+#if !defined(SK_BUILD_FOR_ANDROID) && !defined(SK_BUILD_FOR_IOS)
 extern "C" jboolean Skiko_GetAWT(JNIEnv *env, JAWT *awt);
 #endif
 extern "C"
 {
     JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_AWTKt_getAWT(JNIEnv *env, jobject obj)
     {
-    #ifdef SK_BUILD_FOR_ANDROID
+    #if defined(SK_BUILD_FOR_ANDROID) || defined(SK_BUILD_FOR_IOS)
         abort();
         return 0;
     #else
@@ -35,7 +35,7 @@ extern "C"
 
     JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_AWTKt_getDrawingSurface(JNIEnv *env, jobject obj, jlong awtPtr, jobject layer)
     {
-    #ifdef SK_BUILD_FOR_ANDROID
+    #if defined(SK_BUILD_FOR_ANDROID) || defined(SK_BUILD_FOR_IOS)
         abort();
         return 0;
     #else
@@ -47,7 +47,7 @@ extern "C"
 
     JNIEXPORT void JNICALL Java_org_jetbrains_skiko_AWTKt_freeDrawingSurface(JNIEnv *env, jobject obj, jlong awtPtr, jlong drawingSurfacePtr)
     {
-    #ifdef SK_BUILD_FOR_ANDROID
+    #if defined(SK_BUILD_FOR_ANDROID) || defined(SK_BUILD_FOR_IOS)
         abort();
         return;
     #else
@@ -59,7 +59,7 @@ extern "C"
 
     JNIEXPORT jint JNICALL Java_org_jetbrains_skiko_AWTKt_lockDrawingSurface(JNIEnv *env, jobject obj, jlong drawingSurfacePtr)
     {
-    #ifdef SK_BUILD_FOR_ANDROID
+    #if defined(SK_BUILD_FOR_ANDROID) || defined(SK_BUILD_FOR_IOS)
          abort();
          return 0;
     #else
@@ -70,7 +70,7 @@ extern "C"
 
     JNIEXPORT void JNICALL Java_org_jetbrains_skiko_AWTKt_unlockDrawingSurface(JNIEnv *env, jobject obj, jlong drawingSurfacePtr)
     {
-    #ifdef SK_BUILD_FOR_ANDROID
+    #if defined(SK_BUILD_FOR_ANDROID) || defined(SK_BUILD_FOR_IOS)
         abort();
         return;
     #else
@@ -81,7 +81,7 @@ extern "C"
 
     JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_AWTKt_getDrawingSurfaceInfo(JNIEnv *env, jobject obj, jlong drawingSurfacePtr)
     {
-     #ifdef SK_BUILD_FOR_ANDROID
+     #if defined(SK_BUILD_FOR_ANDROID) || defined(SK_BUILD_FOR_IOS)
          abort();
          return 0;
      #else
@@ -93,7 +93,7 @@ extern "C"
 
     JNIEXPORT void JNICALL Java_org_jetbrains_skiko_AWTKt_freeDrawingSurfaceInfo(JNIEnv *env, jobject obj, jlong drawingSurfacePtr, jlong drawingSurfaceInfoPtr)
     {
-    #ifdef SK_BUILD_FOR_ANDROID
+    #if defined(SK_BUILD_FOR_ANDROID) || defined(SK_BUILD_FOR_IOS)
          abort();
          return;
     #else
@@ -105,7 +105,7 @@ extern "C"
 
     JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_AWTKt_getPlatformInfo(JNIEnv *env, jobject obj, jlong drawingSurfaceInfoPtr)
     {
-    #ifdef SK_BUILD_FOR_ANDROID
+    #if defined(SK_BUILD_FOR_ANDROID) || defined(SK_BUILD_FOR_IOS)
         abort();
         return 0;
     #else

--- a/skiko/src/jvmMain/cpp/common/jawt.cc
+++ b/skiko/src/jvmMain/cpp/common/jawt.cc
@@ -1,4 +1,4 @@
-#ifndef SK_BUILD_FOR_ANDROID
+#if !defined(SK_BUILD_FOR_ANDROID) && !defined(SK_BUILD_FOR_IOS)
 #include <jawt.h>
 #include <jawt_md.h>
 

--- a/skiko/src/jvmMain/cpp/common/openglapi.cc
+++ b/skiko/src/jvmMain/cpp/common/openglapi.cc
@@ -6,6 +6,8 @@
 #import <OpenGL/gl3.h>
 #elif SK_BUILD_FOR_ANDROID
 #include <GLES/gl.h>
+#elif SK_BUILD_FOR_IOS
+// iOS uses Metal
 #else
 #include <GL/gl.h>
 #endif
@@ -16,22 +18,34 @@
 extern "C" {
 
 JNIEXPORT void JNICALL Java_org_jetbrains_skiko_OpenGLApi_glFinish(JNIEnv * env, jobject object) {
+#if !SK_BUILD_FOR_IOS
 	glFinish();
+#endif
 }
 
 JNIEXPORT void JNICALL Java_org_jetbrains_skiko_OpenGLApi_glFlush(JNIEnv * env, jobject object) {
+#if !SK_BUILD_FOR_IOS
 	glFlush();
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_org_jetbrains_skiko_OpenGLApi_glGetIntegerv(JNIEnv * env, jobject object, jint pname) {
+#if !SK_BUILD_FOR_IOS
 	GLint data;
 	glGetIntegerv(pname, &data);
 	return (jint)data;
+#else
+    return 0;
+#endif
 }
 
 JNIEXPORT jstring JNICALL Java_org_jetbrains_skiko_OpenGLApi_glGetString(JNIEnv * env, jobject object, jint value) {
+#if !SK_BUILD_FOR_IOS
 	const char *content = reinterpret_cast<const char *>(glGetString(value));
     return env->NewStringUTF(content);
+#else
+    return env->NewStringUTF("");
+#endif
 }
 
 }

--- a/skiko/src/jvmMain/cpp/common/render.cc
+++ b/skiko/src/jvmMain/cpp/common/render.cc
@@ -50,7 +50,7 @@ JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_RenderTargetsKt_makeMetalRender
 }
 
 JNIEXPORT jlong JNICALL Java_org_jetbrains_skiko_RenderTargetsKt_makeMetalContextNative(JNIEnv* env, jclass jclass) {
-#ifdef SK_METAL
+#if defined(SK_METAL) && !defined(SK_BUILD_FOR_IOS)
     void* device = nullptr;
     void* queue = nullptr;
     getMetalDeviceAndQueue(&device, &queue);

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/LibraryLoader.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/LibraryLoader.kt
@@ -117,7 +117,12 @@ internal class LibraryLoader(
     private fun findAndLoadLibrary(name: String, additionalFile: String? = null) {
         val platformName = System.mapLibraryName(name)
 
-        if (hostOs == OS.Android) {
+        if (hostOs == OS.Ios) {
+            // statically linked on RoboVM. Doesn't break line bellow for hostOd == Ios
+            // as this class is not being used for kotlin native (as its pure JVM)
+            return
+        }
+        if (hostOs == OS.Android || hostOs == OS.Ios || hostOs == OS.Tvos) {
             System.loadLibrary(name)
             return
         }

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/OsArch.jvm.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/OsArch.jvm.kt
@@ -5,6 +5,8 @@ actual val hostOs: OS by lazy {
     when {
         osName == "Mac OS X" -> OS.MacOS
         osName.startsWith("Win") -> OS.Windows
+        // RoboVM (JVM on iOS) reports "iOS" on devices and "iOS Simulator" on the simulator
+        osName.startsWith("iOS") -> OS.Ios
         "The Android Project" == System.getProperty("java.specification.vendor") -> OS.Android
         osName == "Linux" -> OS.Linux
         else -> throw Error("Unknown OS $osName")

--- a/skiko/src/robovmMain/kotlin/org/jetbrains/skiko/Actuals.robovm.kt
+++ b/skiko/src/robovmMain/kotlin/org/jetbrains/skiko/Actuals.robovm.kt
@@ -1,0 +1,15 @@
+package org.jetbrains.skiko
+
+// No look and feel on iOS; only reachable if the `skiko.rendering.laf.global`
+// system property is explicitly set, so a no-op is safe.
+actual fun setSystemLookAndFeel(): Unit = Unit
+
+// The jvmMain rendering pipeline (RenderFactory/Redrawer) is AWT-oriented and is not
+// used by the RoboVM flavor: rendering goes through SkikoUIView + MetalRedrawer,
+// like in the Kotlin/Native iOS flavor. RenderFactory.Default is never touched here.
+internal actual fun makeDefaultRenderFactory(): RenderFactory =
+    RenderFactory { _, _, _, _ ->
+        throw UnsupportedOperationException(
+            "RenderFactory is not used on RoboVM/iOS; use SkikoUIView instead"
+        )
+    }

--- a/skiko/src/robovmMain/kotlin/org/jetbrains/skiko/Dispatchers.kt
+++ b/skiko/src/robovmMain/kotlin/org/jetbrains/skiko/Dispatchers.kt
@@ -1,0 +1,44 @@
+package org.jetbrains.skiko
+
+import kotlinx.coroutines.*
+import org.robovm.apple.dispatch.DispatchBlock
+import org.robovm.apple.dispatch.DispatchBlockFlags
+import org.robovm.apple.dispatch.DispatchQueue
+import java.util.concurrent.TimeUnit
+import kotlin.coroutines.CoroutineContext
+
+// This is the only dispatcher that shall be used in Skiko on iOS.
+object SkikoDispatchers {
+    val Main: CoroutineDispatcher = NsQueueDispatcher(DispatchQueue.getMainQueue())
+    val IO: CoroutineDispatcher = NsQueueDispatcher(
+        DispatchQueue.getGlobalQueue(DispatchQueue.PRIORITY_BACKGROUND.toLong(), 0)
+    )
+}
+
+@OptIn(InternalCoroutinesApi::class, ExperimentalCoroutinesApi::class)
+internal class NsQueueDispatcher(
+    private val dispatchQueue: DispatchQueue
+) : CoroutineDispatcher(), Delay {
+    override fun dispatch(context: CoroutineContext, block: Runnable) {
+        dispatchQueue.async(block)
+    }
+
+    override fun scheduleResumeAfterDelay(timeMillis: Long, continuation: CancellableContinuation<Unit>) {
+        val block = Runnable {
+            continuation.resume(Unit) { t -> t.printStackTrace() }
+        }
+        val dispatchBlock = DispatchBlock.create(DispatchBlockFlags.None, block)
+        dispatchQueue.after(timeMillis, TimeUnit.MILLISECONDS, dispatchBlock)
+        continuation.invokeOnCancellation { DispatchBlock.cancel(dispatchBlock) }
+    }
+
+    override fun invokeOnTimeout(timeMillis: Long, block: Runnable, context: CoroutineContext): DisposableHandle {
+        val dispatchBlock = DispatchBlock.create(DispatchBlockFlags.None, block)
+        dispatchQueue.after(timeMillis, TimeUnit.MILLISECONDS, dispatchBlock)
+        return object : DisposableHandle {
+            override fun dispose() {
+                DispatchBlock.cancel(dispatchBlock)
+            }
+        }
+    }
+}

--- a/skiko/src/robovmMain/kotlin/org/jetbrains/skiko/MainUIDispatcher.awt.kt
+++ b/skiko/src/robovmMain/kotlin/org/jetbrains/skiko/MainUIDispatcher.awt.kt
@@ -1,0 +1,7 @@
+package org.jetbrains.skiko
+
+import kotlinx.coroutines.CoroutineDispatcher
+
+// FIXME: have to keep it at .awt name as .desktop implementations uses actual that point to it
+val MainUIDispatcher: CoroutineDispatcher
+    get() = SkikoDispatchers.Main

--- a/skiko/src/robovmMain/kotlin/org/jetbrains/skiko/SkiaLayer.robovm.kt
+++ b/skiko/src/robovmMain/kotlin/org/jetbrains/skiko/SkiaLayer.robovm.kt
@@ -1,0 +1,68 @@
+package org.jetbrains.skiko
+
+import org.jetbrains.skia.Canvas
+import org.jetbrains.skia.Color
+import org.jetbrains.skia.PixelGeometry
+import org.jetbrains.skia.Surface
+
+actual open class SkiaLayer {
+    internal var needRedrawCallback: () -> Unit = {}
+
+    actual var renderApi: GraphicsApi
+        get() = GraphicsApi.METAL
+        set(_) { throw UnsupportedOperationException() }
+
+    actual val contentScale: Float
+        get() = view!!.contentScaleFactor.toFloat()
+
+    actual var fullscreen: Boolean
+        get() = true
+        set(_) { throw UnsupportedOperationException() }
+
+    actual fun needRender(throttledToVsync: Boolean) {
+        needRedrawCallback.invoke()
+    }
+
+    @Deprecated(
+        message = "Use needRender() instead",
+        replaceWith = ReplaceWith("needRender()")
+    )
+    actual fun needRedraw() = needRender()
+
+    actual val component: Any?
+        get() = this.view
+
+    val width: Float
+        get() = view!!.frame.width.toFloat()
+
+    val height: Float
+        get() = view!!.frame.height.toFloat()
+
+    internal var view: SkikoUIView? = null
+
+    actual fun attachTo(container: Any) {
+        view = container as SkikoUIView
+    }
+
+    actual fun detach() {
+        view?.detach()
+
+        view = null
+        renderDelegate = null
+    }
+
+    actual var renderDelegate: SkikoRenderDelegate? = null
+
+    internal actual fun draw(canvas: Canvas) {
+        throw UnsupportedOperationException("Don't call it, artifact of wrong abstraction")
+    }
+
+    internal fun draw(surface: Surface) {
+        val canvas = surface.canvas
+        canvas.clear(Color.WHITE)
+        renderDelegate?.onRender(canvas, surface.width, surface.height, currentNanoTime())
+    }
+
+    actual val pixelGeometry: PixelGeometry
+        get() = PixelGeometry.UNKNOWN
+}

--- a/skiko/src/robovmMain/kotlin/org/jetbrains/skiko/SkikoUIView.kt
+++ b/skiko/src/robovmMain/kotlin/org/jetbrains/skiko/SkikoUIView.kt
@@ -1,0 +1,102 @@
+package org.jetbrains.skiko
+
+import org.jetbrains.skiko.redrawer.MetalRedrawer
+import org.robovm.apple.coreanimation.CALayer
+import org.robovm.apple.coreanimation.CAMetalLayer
+import org.robovm.apple.coregraphics.CGColor
+import org.robovm.apple.coregraphics.CGColorSpace
+import org.robovm.apple.coregraphics.CGRect
+import org.robovm.apple.coregraphics.CGSize
+import org.robovm.apple.metal.MTLDevice
+import org.robovm.apple.metal.MTLPixelFormat
+import org.robovm.apple.uikit.UIView
+import org.robovm.objc.annotation.CustomClass
+import org.robovm.objc.annotation.Property
+import java.lang.ref.WeakReference
+
+@CustomClass("SkikoUIView")
+open class SkikoUIView : UIView {
+
+    companion object {
+        /**
+         * Backs this view with a [CAMetalLayer].
+         * Note: must not be named `getLayerClass` — that would clash with the JVM
+         * signature of the inherited static [UIView.getLayerClass].
+         */
+        @JvmStatic
+        @Property(selector = "layerClass")
+        fun layerClass(): Class<out CALayer> {
+            return CAMetalLayer::class.java
+        }
+    }
+
+    private val _device: MTLDevice = MTLDevice.getSystemDefaultDevice()
+        ?: throw IllegalStateException("Metal is not supported on this system")
+    private val _metalLayer: CAMetalLayer get() = layer as CAMetalLayer
+    private var _skiaLayer: SkiaLayer? = null
+    private lateinit var _redrawer: MetalRedrawer
+
+    init {
+        skikoInitializeUIView()
+        isOpaque = false // For UIKit interop through a "Hole"
+
+        _metalLayer.also {
+            it.device = _device
+            it.pixelFormat = MTLPixelFormat.BGRA8Unorm
+            it.backgroundColor = CGColor.create(CGColorSpace.createDeviceRGB(), doubleArrayOf(0.0, 0.0, 0.0, 0.0))
+            it.isFramebufferOnly = false
+        }
+    }
+    constructor(
+        skiaLayer: SkiaLayer,
+        frame: CGRect = CGRect.Null()
+    ) : super(frame) {
+        _skiaLayer = skiaLayer
+
+        val weakSkiaLayer = WeakReference(skiaLayer)
+
+        _redrawer = MetalRedrawer(
+            _metalLayer,
+            drawCallback = { surface ->
+                weakSkiaLayer.get()?.draw(surface)
+            }
+        )
+
+        skiaLayer.needRedrawCallback = _redrawer::needRender
+        skiaLayer.view = this
+    }
+
+    internal fun detach() {
+        _redrawer.dispose()
+    }
+
+    fun load(): SkikoUIView {
+        // TODO: redundant, remove in next refactor pass
+        return this
+    }
+
+    override fun didMoveToWindow() {
+        super.didMoveToWindow()
+
+        window?.screen?.let {
+            contentScaleFactor = it.scale
+            _redrawer.maximumFramesPerSecond = it.maximumFramesPerSecond
+        }
+    }
+
+    override fun layoutSubviews() {
+        super.layoutSubviews()
+
+        val scaledSize = CGSize(
+            bounds.width * contentScaleFactor,
+            bounds.height * contentScaleFactor
+        )
+
+        _metalLayer.drawableSize = scaledSize
+    }
+}
+
+private fun UIView.skikoInitializeUIView() {
+    isMultipleTouchEnabled = true
+    isUserInteractionEnabled = true
+}

--- a/skiko/src/robovmMain/kotlin/org/jetbrains/skiko/SkikoViewController.kt
+++ b/skiko/src/robovmMain/kotlin/org/jetbrains/skiko/SkikoViewController.kt
@@ -1,0 +1,17 @@
+package org.jetbrains.skiko
+
+import org.robovm.apple.foundation.NSBundle
+import org.robovm.apple.uikit.UIViewController
+import org.robovm.objc.annotation.CustomClass
+
+/**
+ * Convenience [UIViewController] that hosts a [SkikoUIView],
+ * mirroring the API of the Kotlin/Native iOS Skiko flavor.
+ */
+@CustomClass("SkikoViewController")
+open class SkikoViewController(private val viewBuilder: () -> SkikoUIView) : UIViewController(null as String?, null as NSBundle?) {
+
+    override fun loadView() {
+        view = viewBuilder()
+    }
+}

--- a/skiko/src/robovmMain/kotlin/org/jetbrains/skiko/SystemTheme.awt.kt
+++ b/skiko/src/robovmMain/kotlin/org/jetbrains/skiko/SystemTheme.awt.kt
@@ -1,0 +1,21 @@
+package org.jetbrains.skiko
+
+import org.robovm.apple.foundation.NSProcessInfo
+import org.robovm.apple.uikit.UITraitCollection
+import org.robovm.apple.uikit.UIUserInterfaceStyle
+
+// FIXME: have to keep it at .awt name as .desktop implementations uses actual that point to it
+actual val currentSystemTheme: SystemTheme
+    get() = if (NSProcessInfo.getSharedProcessInfo().operatingSystemVersion.majorVersion >= 13) {
+        /*
+         * Getting trait collection for the current execution context supports only on iOS 13.0+
+         * https://developer.apple.com/documentation/uikit/uitraitcollection/3238080-currenttraitcollection?language=objc
+         */
+        when (UITraitCollection.getCurrentTraitCollection().userInterfaceStyle) {
+            UIUserInterfaceStyle.Dark -> SystemTheme.DARK
+            UIUserInterfaceStyle.Light -> SystemTheme.LIGHT
+            else -> SystemTheme.UNKNOWN
+        }
+    } else {
+        SystemTheme.LIGHT
+    }

--- a/skiko/src/robovmMain/kotlin/org/jetbrains/skiko/URIManager.kt
+++ b/skiko/src/robovmMain/kotlin/org/jetbrains/skiko/URIManager.kt
@@ -1,0 +1,6 @@
+package org.jetbrains.skiko
+
+// FIXME: stub as expected by -desktop implementation to be present s
+class URIManager {
+    fun openUri(uri: String) = Unit
+}

--- a/skiko/src/robovmMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.robovm.kt
+++ b/skiko/src/robovmMain/kotlin/org/jetbrains/skiko/redrawer/MetalRedrawer.robovm.kt
@@ -1,0 +1,257 @@
+package org.jetbrains.skiko.redrawer
+
+import org.jetbrains.skia.*
+import org.jetbrains.skiko.Logger
+import org.jetbrains.skiko.internal.fastForEach
+import org.robovm.apple.coreanimation.CADisplayLink
+import org.robovm.apple.coreanimation.CAMetalLayer
+import org.robovm.apple.foundation.*
+import org.robovm.apple.metal.MTLCommandBuffer
+import org.robovm.apple.uikit.UIApplication
+import org.robovm.apple.uikit.UIApplicationState
+import org.robovm.objc.annotation.NativeClass
+import org.robovm.objc.annotation.Property
+import org.robovm.rt.bro.annotation.Pointer
+import java.util.concurrent.Semaphore
+import kotlin.math.roundToInt
+
+private class DisplayLinkConditions(
+    val setPausedCallback: (Boolean) -> Unit
+) {
+    /**
+     * see [MetalRedrawer.needsProactiveDisplayLink]
+     */
+    var needsToBeProactive: Boolean = false
+        set(value) {
+            field = value
+
+            update()
+        }
+
+    /**
+     * Indicates that scene is invalidated and next display link callback will draw
+     */
+    var needsRedrawOnNextVsync: Boolean = false
+        set(value) {
+            field = value
+
+            update()
+        }
+
+    /**
+     * Indicates that application is running foreground now
+     */
+    var isApplicationActive: Boolean = false
+        set(value) {
+            field = value
+
+            update()
+        }
+
+    private fun update() {
+        val isUnpaused = isApplicationActive && (needsToBeProactive || needsRedrawOnNextVsync)
+        setPausedCallback(!isUnpaused)
+    }
+}
+
+private class ApplicationStateListener(
+    /**
+     * Callback which will be called with `true` when the app becomes active, and `false` when the app goes background
+     */
+    private val callback: (Boolean) -> Unit
+) {
+    private val notificationCenter = NSNotificationCenter.getDefaultCenter()
+
+    private val foregroundObserver: NSObject = notificationCenter.addObserver(
+        UIApplication.WillEnterForegroundNotification(),
+        null,
+        NSOperationQueue.getMainQueue()
+    ) { callback(true) }
+
+    private val backgroundObserver: NSObject = notificationCenter.addObserver(
+        UIApplication.DidEnterBackgroundNotification(),
+        null,
+        NSOperationQueue.getMainQueue()
+    ) { callback(false) }
+
+    /**
+     * Deregister from [NSNotificationCenter]
+     */
+    fun dispose() {
+        notificationCenter.removeObserver(foregroundObserver)
+        notificationCenter.removeObserver(backgroundObserver)
+    }
+}
+
+internal class MetalRedrawer(
+    private val metalLayer: CAMetalLayer,
+    private val drawCallback: (Surface) -> Unit,
+
+    // Used for tests, access to NSRunLoop crashes in test environment
+    addDisplayLinkToRunLoop: ((CADisplayLink) -> Unit)? = null,
+    private val disposeCallback: (MetalRedrawer) -> Unit = { }
+) {
+    private val device = metalLayer.device
+        ?: throw IllegalStateException("CAMetalLayer.device can not be null")
+    private val queue = device.newCommandQueue() ?: throw IllegalStateException("Couldn't create Metal command queue")
+    private val context = DirectContext.makeMetal(device.handle, queue.handle)
+    private val inflightCommandBuffers = mutableListOf<MTLCommandBuffer>()
+
+    // Semaphore for preventing command buffers count more than swapchain size to be scheduled/executed at the same time
+    private val inflightSemaphore = Semaphore(metalLayer.maximumDrawableCount.toInt())
+
+    internal var maximumFramesPerSecond: Long
+        get() = caDisplayLink?.preferredFramesPerSecond ?: 0
+        set(value) {
+            caDisplayLink?.preferredFramesPerSecond = value
+        }
+
+    /**
+     * Needs scheduling displayLink for forcing UITouch events to come at the fastest possible cadence.
+     * Otherwise, touch events can come at rate lower than actual display refresh rate.
+     */
+    var needsProactiveDisplayLink: Boolean
+        get() = displayLinkConditions.needsToBeProactive
+        set(value) {
+            displayLinkConditions.needsToBeProactive = value
+        }
+
+    internal var caDisplayLink: CADisplayLink? = CADisplayLink(
+        CADisplayLink.OnUpdateListener { handleDisplayLinkTick() }
+    )
+
+    private val displayLinkConditions = DisplayLinkConditions { paused ->
+        caDisplayLink?.isPaused = paused
+    }
+
+    private val applicationStateListener = ApplicationStateListener { isApplicationActive ->
+        displayLinkConditions.isApplicationActive = isApplicationActive
+        if (!isApplicationActive) {
+            // If application goes background, synchronously schedule all inflightCommandBuffers, as per
+            // https://developer.apple.com/documentation/metal/gpu_devices_and_work_submission/preparing_your_metal_app_to_run_in_the_background?language=objc
+            inflightCommandBuffers.fastForEach { commandBuffer ->
+                // Will immediately return for MTLCommandBuffer's which are not in `Commited` status
+                commandBuffer.waitUntilCompleted()
+            }
+        }
+    }
+
+    init {
+        val caDisplayLink = caDisplayLink ?: throw IllegalStateException("caDisplayLink is null during redrawer init")
+
+        // UIApplication can be in UIApplicationStateInactive state (during app launch before it gives control back to run loop)
+        // and won't receive UIApplicationWillEnterForegroundNotification
+        // so we compare the state with UIApplicationStateBackground instead of UIApplicationStateActive
+        displayLinkConditions.isApplicationActive = UIApplication.getSharedApplication().applicationState != UIApplicationState.Background
+
+        if (addDisplayLinkToRunLoop == null) {
+            caDisplayLink.addToRunLoop(NSRunLoop.getMain(), NSRunLoop.getMain().currentMode)
+        } else {
+            addDisplayLinkToRunLoop.invoke(caDisplayLink)
+        }
+    }
+
+    internal fun dispose() {
+        check(caDisplayLink != null) { "MetalRedrawer.dispose() was called more than once" }
+
+        disposeCallback(this)
+
+        applicationStateListener.dispose()
+
+        caDisplayLink?.invalidate()
+        caDisplayLink = null
+
+        context.flush()
+        context.close()
+    }
+
+    internal fun needRender() {
+        displayLinkConditions.needsRedrawOnNextVsync = true
+    }
+
+    private fun handleDisplayLinkTick() {
+        if (displayLinkConditions.needsRedrawOnNextVsync) {
+            displayLinkConditions.needsRedrawOnNextVsync = false
+
+            draw()
+        }
+    }
+
+    private fun draw() {
+        if (caDisplayLink == null) {
+            Logger.warn { "caDisplayLink callback called after it was invalidated " }
+            return
+        }
+
+        NSAutoreleasePool().use {
+            val width = metalLayer.drawableSize.width.roundToInt()
+            val height = metalLayer.drawableSize.height.roundToInt()
+
+            if (width <= 0 || height <= 0) {
+                return@use
+            }
+
+            inflightSemaphore.acquireUninterruptibly()
+
+            val metalDrawable = metalLayer.nextDrawable()
+
+            if (metalDrawable == null) {
+                Logger.warn { "'metalLayer.nextDrawable()' returned null. 'metalLayer.allowsNextDrawableTimeout' should be set to false. Skipping the frame." }
+                inflightSemaphore.release()
+                return@use
+            }
+
+            // FIXME: this is dirty workaround to get texture raw pointer
+            // as metalDrawable.texture seems to be not returning proper ObjC protocol/Class at lease at Sim
+            // that cause ClassCastException (to be investigated)
+            @NativeClass
+            class WORKAROUND(handle: Long): NSObject(handle) {
+                init { retain() }
+                @Property(selector = "texture")
+                @Pointer
+                external fun getTexture(): Long
+            }
+            val metalDrawableShadow = WORKAROUND((metalDrawable as NSObject).handle)
+            val renderTarget = BackendRenderTarget.makeMetal(width, height, metalDrawableShadow.getTexture()) //metalDrawable.texture.handle)
+
+            val surface = Surface.makeFromBackendRenderTarget(
+                context,
+                renderTarget,
+                SurfaceOrigin.TOP_LEFT,
+                SurfaceColorFormat.BGRA_8888,
+                ColorSpace.sRGB,
+                SurfaceProps(pixelGeometry = PixelGeometry.UNKNOWN)
+            )
+
+            if (surface == null) {
+                Logger.warn { "'Surface.makeFromBackendRenderTarget' returned null. Skipping the frame." }
+                renderTarget.close()
+                inflightSemaphore.release()
+                return@use
+            }
+
+            surface.canvas.clear(Color.WHITE)
+            drawCallback(surface)
+            surface.flushAndSubmit()
+
+            val commandBuffer = queue.commandBuffer!!
+            commandBuffer.label = "Present"
+            commandBuffer.presentDrawable(metalDrawable)
+            commandBuffer.addCompletedHandler {
+                // Signal work finish, allow a new command buffer to be scheduled
+                inflightSemaphore.release()
+            }
+            commandBuffer.commit()
+
+            surface.close()
+            renderTarget.close()
+
+            // Track current inflight command buffers to synchronously wait for their schedule in case app goes background
+            if (inflightCommandBuffers.size == metalLayer.maximumDrawableCount.toInt()) {
+                inflightCommandBuffers.removeAt(0)
+            }
+
+            inflightCommandBuffers.add(commandBuffer)
+        }
+    }
+}


### PR DESCRIPTION
hello, 
this PR demonstrates ability to run skiko and compose on iOS using RoboVM/JVM target that allows to use Java ecosystem with compose application. disclaimer and sorry:
- intentionally targeted wrong release as POC was done around v0.144.6 that matches compose 1.11.0 release;
- it is not intended to be merged, I completely understand that it is not going to be maintained by JetBrains team;
- can be closed as soon as required. intended to demonstrate ability to use it with officially not supported platform.

most changes was done to buildSrc infrastructure to incorporate RoboVM target with following changes:
- use JVM skia bindings;
- exclude AWT code (not available on robovm);
- port native/iOS SkiaLayer/View using RoboVM bindings while maintaing  existing logic.

test work without issues, library packs binary into recognisable  RoboVM format and pushed to sonatype for quick demo.
```groovy
  dependencies {
      implementation("io.github.dkimitsa.robovm:skiko-iosrobovm:0.144.6-SNAPSHOT")
  }
```

## compose
it is possible to run compose-desktop using this skiko on iOS, few tweaks to be done (like skiko-awt to be excluded, missing  actuals that are picked from awt to be provided through mock files). 
tweaks and Compose Destop dependency management grouped into single interop library: 
https://github.com/dkimitsa/robovm-compose-interop

## ready to use sample
https://github.com/dkimitsa/codesnippets/tree/sample/compose-demo-app

## preview in IntelliJ IDEA 
it will not work with it directly but there is way to create multi platform compose app and use desktop/android preview in shared module as explained [here](https://dkimitsa.github.io/2026/08/05/compose-and-robovm/)