### PR TITLE
Refactor FontMgrDefaultFactory and introduce dedicated tests

### DIFF
--- a/samples/SkiaWebSample/src/webMain/kotlin/org/jetbrains/skiko/sample/js/App.web.kt
+++ b/samples/SkiaWebSample/src/webMain/kotlin/org/jetbrains/skiko/sample/js/App.web.kt
@@ -1,8 +1,15 @@
 package org.jetbrains.skiko.sample.js
 
 import org.jetbrains.skia.Canvas
+import org.jetbrains.skia.Color
+import org.jetbrains.skia.Font
+import org.jetbrains.skia.FontMgr
+import org.jetbrains.skia.FontStyle
 import org.jetbrains.skia.Paint
 import org.jetbrains.skia.Rect
+import org.jetbrains.skia.TextLine
+import org.jetbrains.skia.Typeface
+import org.jetbrains.skia.impl.use
 import org.jetbrains.skiko.SkiaLayer
 import org.jetbrains.skiko.SkiaLayerRenderDelegate
 import org.jetbrains.skiko.SkikoRenderDelegate
@@ -11,6 +18,15 @@ import kotlinx.browser.document
 private class DemoApp: SkikoRenderDelegate {
     private val paint = Paint()
 
+    private val textPaint = Paint().apply {
+        color = Color.RED
+        setStroke(false)
+    }
+
+    private val typeface: Typeface? = FontMgr.default.matchFamilyStyle(null, FontStyle.NORMAL)
+
+    private val font: Font? = typeface?.let { Font(it, 36f) }
+
     override fun onRender(canvas: Canvas, width: Int, height: Int, nanoTime: Long) {
         canvas.drawCircle(200f, 50f, 25f, paint)
         canvas.drawLine(100f, 100f, 200f, 200f, paint)
@@ -18,6 +34,13 @@ private class DemoApp: SkikoRenderDelegate {
         canvas.drawRect(Rect(10f, 20f, 50f, 70f), paint)
         canvas.drawOval(Rect(110f, 220f, 50f, 70f), paint)
         canvas.drawOval(Rect(110f, 220f, 50f, 70f), paint)
+
+        // https://youtrack.jetbrains.com/issue/CMP-7439
+        font?.let { f ->
+            TextLine.make("Hello, drawTextLine!", f).use { line ->
+                canvas.drawTextLine(line, 10f, 300f, textPaint)
+            }
+        }
     }
 }
 

--- a/samples/SkiaWebSample/src/webMain/kotlin/org/jetbrains/skiko/sample/js/App.web.kt
+++ b/samples/SkiaWebSample/src/webMain/kotlin/org/jetbrains/skiko/sample/js/App.web.kt
@@ -23,7 +23,7 @@ private class DemoApp: SkikoRenderDelegate {
         setStroke(false)
     }
 
-    private val typeface: Typeface? = FontMgr.default.matchFamilyStyle(null, FontStyle.NORMAL)
+    private val typeface: Typeface? = FontMgr.default.matchFamilyStyle( "Roboto", FontStyle.NORMAL)
 
     private val font: Font? = typeface?.let { Font(it, 36f) }
 

--- a/skiko/src/commonMain/cpp/common/FontMgrDefaultFactory.cc
+++ b/skiko/src/commonMain/cpp/common/FontMgrDefaultFactory.cc
@@ -1,4 +1,5 @@
 #include "FontMgrDefaultFactory.hh"
+#include <iostream>
 
 
 #if defined(SK_BUILD_FOR_MAC) || defined(SK_BUILD_FOR_IOS)
@@ -29,29 +30,31 @@ extern "C" const SkEmbeddedResourceHeader SK_EMBEDDED_FONTS;
 #endif
 
 sk_sp<SkFontMgr> SkFontMgrSkikoDefault() {
-#if defined(SK_BUILD_FOR_MAC) || defined(SK_BUILD_FOR_IOS)
+#if defined(SKIKO_WASM)
+    if (SK_EMBEDDED_FONTS.count == 0) {
+        return nullptr;
+    }
+
+    std::vector<sk_sp<SkData>> fontDataVector;
+    fontDataVector.reserve(SK_EMBEDDED_FONTS.count);
+
+    for (size_t i = 0; i < SK_EMBEDDED_FONTS.count; ++i) {
+        fontDataVector.push_back(
+            SkData::MakeWithoutCopy(SK_EMBEDDED_FONTS.entries[i].data,
+                                    SK_EMBEDDED_FONTS.entries[i].size)
+        );
+    }
+
+    return SkFontMgr_New_Custom_Data(SkSpan<sk_sp<SkData>>(fontDataVector));
+#elif defined(SK_BUILD_FOR_MAC) || defined(SK_BUILD_FOR_IOS)
     return SkFontMgr_New_CoreText(nullptr);
-#endif
-
-#ifdef SK_BUILD_FOR_WIN
+#elif defined(SK_BUILD_FOR_WIN)
     return SkFontMgr_New_DirectWrite();
-#endif
-
-#if (defined(SK_BUILD_FOR_UNIX) || defined(SK_BUILD_FOR_LINUX)) && !defined(SKIKO_WASM)
+#elif defined(SK_BUILD_FOR_UNIX) || defined(SK_BUILD_FOR_LINUX)
     return SkFontMgr_New_FontConfig(nullptr, SkFontScanner_Make_FreeType());
-#endif
-
-#ifdef SK_BUILD_FOR_ANDROID
+#elif defined(SK_BUILD_FOR_ANDROID)
     return SkFontMgr_New_Android(nullptr, SkFontScanner_Make_FreeType());
-#endif
-
-#ifdef SKIKO_WASM
-    sk_sp<SkData> embeddedFontData =
-        SkData::MakeWithoutCopy(SK_EMBEDDED_FONTS.entries[0].data, SK_EMBEDDED_FONTS.entries[0].size);
-    std::vector<sk_sp<SkData>> fontDataVector = { embeddedFontData };
-    SkSpan<sk_sp<SkData>> dataSpan(fontDataVector);
-    return SkFontMgr_New_Custom_Data(dataSpan);
-#endif
-
+#else
     return nullptr;
+#endif
 }

--- a/skiko/src/commonMain/cpp/common/FontMgrDefaultFactory.cc
+++ b/skiko/src/commonMain/cpp/common/FontMgrDefaultFactory.cc
@@ -1,6 +1,4 @@
 #include "FontMgrDefaultFactory.hh"
-#include <iostream>
-
 
 #if defined(SK_BUILD_FOR_MAC) || defined(SK_BUILD_FOR_IOS)
 #include "ports/SkFontMgr_mac_ct.h"

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/FontMgr.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/FontMgr.kt
@@ -65,7 +65,8 @@ open class FontMgr : RefCnt {
      * object. Will return `null` if no 'good' match is found.
      *
      * Passing `null` as the value for [familyName] will return the
-     * default system font on JVM and null all the rest of the platforms.
+     * default system font on certain targets but it's not guaranteed
+     * to be available.
      *
      * It is possible that this will return a style set not accessible from
      * [makeStyleSet] or [matchFamily] due to hidden or

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/FontMgr.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/FontMgr.kt
@@ -65,7 +65,7 @@ open class FontMgr : RefCnt {
      * object. Will return `null` if no 'good' match is found.
      *
      * Passing `null` as the value for [familyName] will return the
-     * default system font.
+     * default system font on JVM and null all the rest of the platforms.
      *
      * It is possible that this will return a style set not accessible from
      * [makeStyleSet] or [matchFamily] due to hidden or

--- a/skiko/src/commonTest/kotlin/org/jetbrains/skia/FontMgrTest.kt
+++ b/skiko/src/commonTest/kotlin/org/jetbrains/skia/FontMgrTest.kt
@@ -94,17 +94,6 @@ class FontMgrTest {
         }
     }
 
-
-    @Test
-    @SkipJsTarget
-    @SkipWasmTarget
-    @SkipNativeTarget
-    fun matchFamilyStyleWithNullFamilyNameReturnsDefaultSystemFont() {
-        val typeface = FontMgr.default.matchFamilyStyle(null, FontStyle.NORMAL)
-        assertNotNull(typeface, "Expected default system font when passing null as familyName")
-        typeface.close()
-    }
-
     @Test
     @SkipJsTarget
     @SkipWasmTarget

--- a/skiko/src/commonTest/kotlin/org/jetbrains/skia/FontMgrTest.kt
+++ b/skiko/src/commonTest/kotlin/org/jetbrains/skia/FontMgrTest.kt
@@ -6,6 +6,7 @@ import org.jetbrains.skia.tests.makeFromResource
 import org.jetbrains.skiko.tests.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 class FontMgrTest {
@@ -93,6 +94,16 @@ class FontMgrTest {
         }
     }
 
+
+    @Test
+    @SkipJsTarget
+    @SkipWasmTarget
+    @SkipNativeTarget
+    fun matchFamilyStyleWithNullFamilyNameReturnsDefaultSystemFont() {
+        val typeface = FontMgr.default.matchFamilyStyle(null, FontStyle.NORMAL)
+        assertNotNull(typeface, "Expected default system font when passing null as familyName")
+        typeface.close()
+    }
 
     @Test
     @SkipJsTarget

--- a/skiko/src/webTest/kotlin/org/jetbrains/skia/FontMgrWebTest.kt
+++ b/skiko/src/webTest/kotlin/org/jetbrains/skia/FontMgrWebTest.kt
@@ -1,0 +1,14 @@
+package org.jetbrains.skia
+
+import org.jetbrains.skia.impl.use
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+class FontMgrWebTest {
+    @Test
+    fun matchFamilyStyleRobotoReturnsDefaultEmbeddedFont() {
+        val typeface = FontMgr.default.matchFamilyStyle("Roboto", FontStyle.NORMAL)
+        assertNotNull(typeface, "Expected default embedded 'Roboto' font on web")
+        typeface.close()
+    }
+}


### PR DESCRIPTION
This PR is related to https://youtrack.jetbrains.com/issue/CMP-7439 however it is not a fix, since there's a probability that nothing to be fixed. 

In framework of this PR following changes are introduced:
* skiko/src/commonMain/cpp/common/FontMgrDefaultFactory.cc refactored so no double-check for wasm class will occur (and also keeping in mind that there are mutually exclusive options)
* Two dedicated test introduced for verifying current behaviour 
* SkiaWebSample was updated