### PR TITLE
Pace SkiaSwingLayer repaints with the JBR FramePacing service

### DIFF
--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SkiaSwingLayer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SkiaSwingLayer.kt
@@ -74,6 +74,8 @@ open class SkiaSwingLayer(
     private val redrawer: SwingRedrawer?
         get() = redrawerManager.redrawer
 
+    private var repaintPacer: SwingRepaintPacer? = null
+
     val renderApi: GraphicsApi
         get() = redrawerManager.renderApi
 
@@ -97,16 +99,43 @@ open class SkiaSwingLayer(
     private fun init(recreation: Boolean = false) {
         isDisposed = false
         redrawerManager.findNextWorkingRenderApi(recreation)
+        repaintPacer?.dispose()
+        repaintPacer = if (SkikoProperties.swingFramePacingEnabled) SwingRepaintPacer(this) else null
         isInitialized = true
     }
 
     fun dispose() {
         check(isEventDispatchThread()) { "Method should be called from AWT event dispatch thread" }
         if (isInitialized && !isDisposed) {
+            repaintPacer?.dispose()
+            repaintPacer = null
             // we should dispose redrawer first (to cancel `draw` in rendering thread)
             redrawer?.dispose()
             redrawerManager.dispose()
             isDisposed = true
+        }
+    }
+
+    /**
+     * Requests a repaint of the layer content, like [repaint].
+     *
+     * When frame pacing is enabled ([SkikoProperties.swingFramePacingEnabled]) and the JetBrains
+     * Runtime `FramePacing` service can pace the layer's display, the repaint is deferred to the
+     * next display refresh tick, and multiple requests coalesce into at most one repaint per tick.
+     * Otherwise the request falls back to a plain [repaint].
+     *
+     * Use this instead of [repaint] for invalidation-driven rendering (e.g. animations), so that a
+     * continuously invalidating scene renders at most at the display refresh rate.
+     *
+     * Must be called on the AWT event dispatch thread.
+     */
+    fun needRender() {
+        check(isEventDispatchThread()) { "Method should be called from AWT event dispatch thread" }
+        val repaintPacer = repaintPacer
+        if (repaintPacer != null && !isDisposed) {
+            repaintPacer.requestRepaint()
+        } else {
+            repaint()
         }
     }
 

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SwingRepaintPacer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/swing/SwingRepaintPacer.kt
@@ -1,0 +1,317 @@
+package org.jetbrains.skiko.swing
+
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeout
+import org.jetbrains.skiko.FrameDispatcher
+import org.jetbrains.skiko.MainUIDispatcher
+import org.jetbrains.skiko.swing.SwingRepaintPacer.Companion.TICK_TIMEOUT_PERIODS
+import java.awt.Component
+import java.awt.GraphicsConfiguration
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.coroutines.resume
+import kotlin.math.ceil
+
+/**
+ * Paces invalidation-driven repaints of a Swing component to the display refresh, using the JBR `FramePacing` service
+ * (available in JetBrains Runtime builds that provide `com.jetbrains.FramePacing`).
+ *
+ * Without pacing, a continuously invalidating scene (e.g., a draw-phase animation) calls [Component.repaint] as fast as
+ * the EDT can complete paint cycles, rendering far above the display refresh rate and burning GPU on frames that are
+ * never shown.
+ *
+ * The pacer runs a [FrameDispatcher] frame loop on the EDT, in the same shape as the redrawers' frame schedulers: a
+ * requested frame is repainted immediately — a frame that is already wanted should never wait for vsync — and the
+ * loop then suspends in [awaitTickIfPaced] until the next FramePacing tick before it repaints again. So pacing only
+ * throttles a continuous stream of requests (to at most one repaint per tick), while a request arriving when the loop
+ * is idle paints with no added latency.
+ *
+ * Behavior:
+ * - If the JBR API or the FramePacing service is unavailable, or the component's display cannot be paced, requests
+ *   degrade to unpaced [Component.repaint]s.
+ * - The display id is re-resolved from the component's current [java.awt.GraphicsConfiguration] once per frame, and the
+ *   tick subscription is re-created when it changes, following the FramePacing javadoc guidance to compare the display
+ *   id per frame rather than listening to component hierarchy or property events.
+ * - A display that refuses a subscription is remembered and not retried until the component moves to a different
+ *   display, so an unpaceable display does not cost a subscription attempt per frame.
+ * - The tick wait is bounded by [withTimeout] (~[TICK_TIMEOUT_PERIODS] refresh periods), so a dead pacing clock can
+ *   never stall the frame loop: see [awaitTickIfPaced].
+ *
+ * Note: this only gates the [Component.repaint] path. Paints initiated by Swing itself — resize, expose,
+ * `paintImmediately` — are not affected.
+ *
+ * [requestRepaint] and [dispose] must be called on the event dispatch thread.
+ */
+internal class SwingRepaintPacer(
+    private val component: Component,
+    private val service: FramePacingService? = JbrFramePacingApi.instance
+) {
+    private var disposed = false
+
+    private var subscription: AutoCloseable? = null
+    private var subscribedDisplayId = UNKNOWN_DISPLAY_ID
+
+    /**
+     * The display that most recently refused a subscription; frames are not paced while on it. Kept so that an
+     * unpaceable display does not cost a subscription attempt on every frame; cleared when the component moves to
+     * another display, or when a tick timeout suggests the stall was transient.
+     */
+    private var failedDisplayId = UNKNOWN_DISPLAY_ID
+
+    /**
+     * ~[TICK_TIMEOUT_PERIODS] refresh periods of the subscribed display.
+     */
+    private var tickTimeoutMillis = DEFAULT_TICK_TIMEOUT_MILLIS
+
+    /**
+     * Set on the EDT while the frame loop waits for a tick; resumed from the tick thread.
+     */
+    private val tickContinuation = AtomicReference<CancellableContinuation<Unit>?>(null)
+
+    private val frameDispatcher = FrameDispatcher(MainUIDispatcher) {
+        if (!disposed) {
+            component.repaint()
+            awaitTickIfPaced()
+        }
+    }
+
+    /**
+     * Requests a repaint of the component. If the frame loop is idle, the repaint is issued immediately; while pacing
+     * is active, a continuous stream of requests coalesces to at most one repaint per FramePacing tick.
+     */
+    fun requestRepaint() {
+        if (disposed || service == null) {
+            component.repaint()
+            return
+        }
+
+        frameDispatcher.scheduleFrame()
+    }
+
+    fun dispose() {
+        if (disposed) return
+
+        disposed = true
+        frameDispatcher.cancel()
+        closeSubscription()
+    }
+
+    /**
+     * Suspends until the next FramePacing tick, so that the frame just painted is the only one in this refresh
+     * interval. No-op when the display cannot be paced.
+     *
+     * The wait is bounded by [withTimeout] so that a dead pacing clock cannot stall the frame loop: a healthy clock
+     * always beats a ~3-period deadline, so the timeout only fires when the clock died mid-interval (display
+     * unplugged, service stall). The loop never owes a repaint at that point — the frame was already painted before
+     * the wait — so on timeout it simply stops waiting and drops the suspected-stale subscription; the next frame
+     * re-creates it, retrying even a previously refused display.
+     */
+    private suspend fun awaitTickIfPaced() {
+        val service = service ?: return
+
+        ensureSubscription(service)
+        if (subscription == null) return
+
+        try {
+            withTimeout(tickTimeoutMillis) {
+                suspendCancellableCoroutine { continuation ->
+                    tickContinuation.set(continuation)
+                    continuation.invokeOnCancellation {
+                        tickContinuation.compareAndSet(continuation, null)
+                    }
+                }
+            }
+        } catch (_: TimeoutCancellationException) {
+            failedDisplayId = UNKNOWN_DISPLAY_ID
+            closeSubscription()
+        }
+    }
+
+    /**
+     * The per-frame display check: re-resolves the component's display and re-creates the tick subscription if the
+     * display changed. If the display cannot be resolved or paced, any live subscription is closed — its ticks belong
+     * to a display the component is no longer on — and frames are not paced until the display can be resolved again.
+     */
+    private fun ensureSubscription(service: FramePacingService) {
+        val displayId = resolveDisplayId(service)
+        if (displayId == UNKNOWN_DISPLAY_ID || displayId == failedDisplayId) {
+            closeSubscription()
+            return
+        }
+
+        if (subscription != null && displayId == subscribedDisplayId) return
+
+        subscribe(service, displayId)
+    }
+
+    private fun subscribe(service: FramePacingService, displayId: Long) {
+        closeSubscription()
+
+        tickTimeoutMillis = tickTimeoutMillisFor(service.refreshPeriodNanos(displayId))
+
+        val subscription = service.subscribe(displayId) { _, _ -> onTick() }
+        if (subscription == null) {
+            failedDisplayId = displayId
+            return
+        }
+
+        this.subscription = subscription
+        subscribedDisplayId = displayId
+        failedDisplayId = UNKNOWN_DISPLAY_ID
+    }
+
+    /**
+     * Called by the FramePacing service on a non-EDT thread; must return immediately.
+     */
+    private fun onTick() {
+        // A resume racing with cancellation (tick timeout, dispose) is benign: resuming a canceled continuation
+        // is ignored.
+        tickContinuation.getAndSet(null)?.resume(Unit)
+    }
+
+    private fun resolveDisplayId(service: FramePacingService): Long {
+        val graphicsConfiguration = component.graphicsConfiguration ?: return UNKNOWN_DISPLAY_ID
+        return service.displayId(graphicsConfiguration)
+    }
+
+    private fun closeSubscription() {
+        subscription?.close()
+        subscription = null
+        subscribedDisplayId = UNKNOWN_DISPLAY_ID
+    }
+
+    private fun tickTimeoutMillisFor(periodNanos: Long): Long =
+        if (periodNanos > 0) {
+            ceil(TICK_TIMEOUT_PERIODS * periodNanos / 1_000_000.0)
+                .toLong()
+                .coerceAtLeast(MIN_TICK_TIMEOUT_MILLIS)
+        } else {
+            DEFAULT_TICK_TIMEOUT_MILLIS
+        }
+
+    companion object {
+        private const val UNKNOWN_DISPLAY_ID = -1L
+        private const val TICK_TIMEOUT_PERIODS = 3
+
+        /**
+         * Tick timeout when the refresh period is unknown: 3 periods at 60 Hz.
+         */
+        private const val DEFAULT_TICK_TIMEOUT_MILLIS = 50L
+        private const val MIN_TICK_TIMEOUT_MILLIS = 10L
+    }
+}
+
+/**
+ * The subset of the JBR `com.jetbrains.FramePacing` service that [SwingRepaintPacer] uses. Abstracted so that tests
+ * can drive the pacer with a controllable tick source; production code uses [JbrFramePacingApi], which adapts the real
+ * service reflectively until a jbr-api release ships the FramePacing service accessor.
+ *
+ * TODO replace with a direct FramePacing service accessor once a jbr-api 1.11 release ships it.
+ */
+internal interface FramePacingService {
+    /**
+     * Returns the stable id of the display showing [graphicsConfiguration], or -1 if unknown.
+     */
+    fun displayId(graphicsConfiguration: GraphicsConfiguration): Long
+
+    /**
+     * Returns the nominal refresh period of the display in nanoseconds, or 0 if unknown.
+     */
+    fun refreshPeriodNanos(displayId: Long): Long
+
+    /**
+     * Subscribes [onTick] to refresh ticks of [displayId]. [onTick] is invoked on an arbitrary non-EDT thread. Returns
+     * a handle that closes the subscription, or null if the display cannot be paced.
+     */
+    fun subscribe(
+        displayId: Long,
+        onTick: (displayId: Long, timeNanos: Long) -> Unit
+    ): AutoCloseable?
+}
+
+/**
+ * Reflection-based access to the JBR `com.jetbrains.FramePacing` service, so that Skiko does not need a compile-time
+ * dependency on a jbr-api version that provides it. Resolved once; [instance] is null when the API classes are absent
+ * from the classpath or the runtime does not provide the service.
+ *
+ * TODO replace with a direct FramePacing service accessor once a jbr-api 1.11 release ships it.
+ */
+private class JbrFramePacingApi private constructor(
+    private val service: Any,
+    private val displayIdMethod: Method,
+    private val refreshPeriodNanosMethod: Method,
+    private val subscribeMethod: Method,
+    private val listenerClass: Class<*>,
+    private val subscriptionCloseMethod: Method
+) : FramePacingService {
+
+    override fun displayId(graphicsConfiguration: GraphicsConfiguration): Long =
+        displayIdMethod.invoke(service, graphicsConfiguration) as Long
+
+    override fun refreshPeriodNanos(displayId: Long): Long =
+        refreshPeriodNanosMethod.invoke(service, displayId) as Long
+
+    override fun subscribe(
+        displayId: Long,
+        onTick: (displayId: Long, timeNanos: Long) -> Unit
+    ): AutoCloseable? {
+        val listener = Proxy.newProxyInstance(
+            listenerClass.classLoader,
+            arrayOf(listenerClass)
+        ) { proxy, method, args ->
+            when (method.name) {
+                "onTick" -> {
+                    onTick(args[0] as Long, args[1] as Long)
+                    null
+                }
+
+                "equals" -> proxy === args[0]
+                "hashCode" -> System.identityHashCode(proxy)
+                "toString" -> "SwingRepaintPacer.Listener"
+                else -> null
+            }
+        }
+        val subscription = subscribeMethod.invoke(service, displayId, listener) ?: return null
+        return AutoCloseable {
+            subscriptionCloseMethod.invoke(subscription)
+        }
+    }
+
+    companion object {
+        val instance: FramePacingService? by lazy {
+            try {
+                val jbrClass = Class.forName("com.jetbrains.JBR")
+                val service = jbrClass.getMethod("getFramePacing").invoke(null)
+                    ?: return@lazy null
+
+                val serviceClass = Class.forName("com.jetbrains.FramePacing")
+                val listenerClass = Class.forName("com.jetbrains.FramePacing\$Listener")
+                val subscriptionClass = Class.forName("com.jetbrains.FramePacing\$Subscription")
+
+                JbrFramePacingApi(
+                    service = service,
+                    displayIdMethod = serviceClass.getMethod(
+                        "displayId",
+                        GraphicsConfiguration::class.java
+                    ),
+                    refreshPeriodNanosMethod = serviceClass.getMethod(
+                        "refreshPeriodNanos",
+                        Long::class.javaPrimitiveType
+                    ),
+                    subscribeMethod = serviceClass.getMethod(
+                        "subscribe",
+                        Long::class.javaPrimitiveType,
+                        listenerClass
+                    ),
+                    listenerClass = listenerClass,
+                    subscriptionCloseMethod = subscriptionClass.getMethod("close")
+                )
+            } catch (_: Throwable) {
+                null
+            }
+        }
+    }
+}

--- a/skiko/src/awtTest/kotlin/org/jetbrains/skiko/swing/SwingRepaintPacerTest.kt
+++ b/skiko/src/awtTest/kotlin/org/jetbrains/skiko/swing/SwingRepaintPacerTest.kt
@@ -1,0 +1,359 @@
+package org.jetbrains.skiko.swing
+
+import org.jetbrains.skiko.SkikoProperties
+import java.awt.GraphicsConfiguration
+import java.awt.GraphicsEnvironment
+import java.util.concurrent.atomic.AtomicInteger
+import javax.swing.JFrame
+import javax.swing.JPanel
+import javax.swing.SwingUtilities
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.After
+import org.junit.Assume.assumeFalse
+import org.junit.Before
+import org.junit.Test
+
+class SwingRepaintPacerTest {
+    private lateinit var frame: JFrame
+    private lateinit var panel: RepaintCountingPanel
+    private var pacer: SwingRepaintPacer? = null
+
+    @Before
+    fun setUp() {
+        assumeFalse(GraphicsEnvironment.getLocalGraphicsEnvironment().isHeadlessInstance)
+        onEdt {
+            frame = JFrame()
+            panel = RepaintCountingPanel()
+        }
+    }
+
+    /**
+     * Adds the panel to the frame and makes it displayable. Kept out of [setUp] so that tests can
+     * exercise the pacer while the panel has no graphics configuration yet (a parentless
+     * component).
+     */
+    private fun attachAndPack() {
+        frame.contentPane.add(panel)
+        frame.pack()
+    }
+
+    @After
+    fun tearDown() {
+        if (::frame.isInitialized) {
+            onEdt {
+                pacer?.dispose()
+                frame.dispose()
+            }
+        }
+    }
+
+    @Test
+    fun passesThroughDirectlyWhenServiceIsAbsent() {
+        onEdt {
+            pacer = SwingRepaintPacer(panel, service = null)
+            attachAndPack()
+        }
+        onEdt {
+            val before = panel.repaintCount.get()
+            pacer?.requestRepaint()
+            assertEquals(before + 1, panel.repaintCount.get())
+        }
+    }
+
+    @Test
+    fun paintsUnpacedWhileComponentHasNoDisplay() {
+        val service = FakeFramePacingService()
+        val before = onEdtGet {
+            pacer = SwingRepaintPacer(panel, service)
+            // A parentless component has no graphics configuration, so there is nothing to
+            // subscribe to; the frame loop must repaint without pacing.
+            val count = panel.repaintCount.get()
+            pacer?.requestRepaint()
+            count
+        }
+        waitUntil { onEdtGet { panel.repaintCount.get() } == before + 1 }
+        assertEquals(0, service.subscribeAttempts)
+    }
+
+    @Test
+    fun paintsFirstFrameImmediatelyAndSubscribesOnce() {
+        val service = FakeFramePacingService().apply { periodNanos = HUGE_PERIOD_NANOS }
+        onEdt {
+            pacer = SwingRepaintPacer(panel, service)
+            attachAndPack()
+        }
+        val baseline = onEdtGet { panel.repaintCount.get() }
+
+        // Multiple requests while the loop is idle coalesce into one immediate repaint...
+        onEdt { repeat(3) { pacer?.requestRepaint() } }
+        waitUntil { onEdtGet { panel.repaintCount.get() } == baseline + 1 }
+
+        // ...after which the loop waits for a tick instead of repainting again.
+        settle()
+        assertEquals(baseline + 1, onEdtGet { panel.repaintCount.get() })
+        assertEquals(1, service.subscribeCount)
+        assertEquals(listOf(DISPLAY_A), service.subscribedDisplayIds)
+        assertEquals(0, service.closeCount)
+    }
+
+    @Test
+    fun pacesContinuousRequestsToOneRepaintPerTick() {
+        val service = FakeFramePacingService().apply { periodNanos = HUGE_PERIOD_NANOS }
+        onEdt {
+            pacer = SwingRepaintPacer(panel, service)
+            attachAndPack()
+        }
+        val baseline = onEdtGet { panel.repaintCount.get() }
+
+        // First frame paints immediately, then the loop waits for a tick.
+        onEdt { pacer?.requestRepaint() }
+        waitUntil { onEdtGet { panel.repaintCount.get() } == baseline + 1 }
+
+        // A request while the loop is waiting must not paint before the tick...
+        onEdt { pacer?.requestRepaint() }
+        settle()
+        assertEquals(baseline + 1, onEdtGet { panel.repaintCount.get() })
+
+        // ...and the tick releases exactly one repaint.
+        service.tick()
+        waitUntil { onEdtGet { panel.repaintCount.get() } == baseline + 2 }
+
+        // A tick with nothing requested releases nothing; it just ends the wait.
+        service.tick()
+        settle()
+        assertEquals(baseline + 2, onEdtGet { panel.repaintCount.get() })
+
+        // The loop is idle again, so the next request paints immediately, without a tick.
+        onEdt { pacer?.requestRepaint() }
+        waitUntil { onEdtGet { panel.repaintCount.get() } == baseline + 3 }
+    }
+
+    @Test
+    fun paintsUnpacedWhenDisplayCannotBePaced() {
+        val service = FakeFramePacingService().apply { refuseSubscriptions = true }
+        onEdt {
+            pacer = SwingRepaintPacer(panel, service)
+            attachAndPack()
+        }
+        val baseline = onEdtGet { panel.repaintCount.get() }
+
+        onEdt { pacer?.requestRepaint() }
+        waitUntil { onEdtGet { panel.repaintCount.get() } == baseline + 1 }
+        assertEquals(1, service.subscribeAttempts)
+        assertEquals(0, service.subscribeCount)
+
+        // The refused display is remembered: later frames must not retry the subscription.
+        onEdt { pacer?.requestRepaint() }
+        waitUntil { onEdtGet { panel.repaintCount.get() } == baseline + 2 }
+        assertEquals(1, service.subscribeAttempts)
+    }
+
+    @Test
+    fun tickTimeoutStopsWaitingAndResubscribesOnTheNextFrame() {
+        // 5 ms period puts the tick timeout at ~15 ms.
+        val service = FakeFramePacingService().apply { periodNanos = 5_000_000L }
+        onEdt {
+            pacer = SwingRepaintPacer(panel, service)
+            attachAndPack()
+        }
+        val baseline = onEdtGet { panel.repaintCount.get() }
+
+        onEdt { pacer?.requestRepaint() }
+        waitUntil { onEdtGet { panel.repaintCount.get() } == baseline + 1 }
+        assertEquals(1, service.subscribeCount)
+
+        // No ticks arrive: the timeout must drop the suspected-stale subscription...
+        waitUntil { onEdtGet { service.closeCount } == 1 }
+        // ...without issuing any repaint — the frame was already painted before the wait.
+        settle()
+        assertEquals(baseline + 1, onEdtGet { panel.repaintCount.get() })
+
+        // The next frame paints immediately and re-creates the subscription.
+        onEdt { pacer?.requestRepaint() }
+        waitUntil { onEdtGet { panel.repaintCount.get() } == baseline + 2 }
+        waitUntil { onEdtGet { service.subscribeCount } == 2 }
+    }
+
+    @Test
+    fun resubscribesWhenTheDisplayChanges() {
+        val service = FakeFramePacingService().apply { periodNanos = HUGE_PERIOD_NANOS }
+        onEdt {
+            pacer = SwingRepaintPacer(panel, service)
+            attachAndPack()
+        }
+        val baseline = onEdtGet { panel.repaintCount.get() }
+
+        onEdt { pacer?.requestRepaint() }
+        waitUntil { onEdtGet { panel.repaintCount.get() } == baseline + 1 }
+        assertEquals(listOf(DISPLAY_A), service.subscribedDisplayIds)
+        service.tick() // end the wait; the loop goes idle
+
+        // The per-frame display check picks up the change on the next frame.
+        service.displayIdToReturn = DISPLAY_B
+        onEdt { pacer?.requestRepaint() }
+        waitUntil { onEdtGet { panel.repaintCount.get() } == baseline + 2 }
+        assertEquals(listOf(DISPLAY_A, DISPLAY_B), service.subscribedDisplayIds)
+        assertEquals(1, service.closeCount)
+        service.tick()
+
+        // Unchanged display: no subscription churn.
+        onEdt { pacer?.requestRepaint() }
+        waitUntil { onEdtGet { panel.repaintCount.get() } == baseline + 3 }
+        assertEquals(2, service.subscribeCount)
+        assertEquals(1, service.closeCount)
+    }
+
+    @Test
+    fun closesSubscriptionWhenTheDisplayBecomesUnresolvable() {
+        val service = FakeFramePacingService().apply { periodNanos = HUGE_PERIOD_NANOS }
+        onEdt {
+            pacer = SwingRepaintPacer(panel, service)
+            attachAndPack()
+        }
+        val baseline = onEdtGet { panel.repaintCount.get() }
+
+        onEdt { pacer?.requestRepaint() }
+        waitUntil { onEdtGet { panel.repaintCount.get() } == baseline + 1 }
+        assertEquals(1, service.subscribeCount)
+        service.tick() // end the wait; the loop goes idle
+
+        // The display id can no longer be resolved (per the service contract, -1 means unknown);
+        // the next frame must drop the subscription and paint unpaced.
+        service.displayIdToReturn = UNKNOWN_DISPLAY
+        onEdt { pacer?.requestRepaint() }
+        waitUntil { onEdtGet { panel.repaintCount.get() } == baseline + 2 }
+        assertEquals(1, service.closeCount)
+    }
+
+    @Test
+    fun closesSubscriptionOnDisposeAndPassesThroughAfterwards() {
+        val service = FakeFramePacingService().apply { periodNanos = HUGE_PERIOD_NANOS }
+        onEdt {
+            pacer = SwingRepaintPacer(panel, service)
+            attachAndPack()
+        }
+        val baseline = onEdtGet { panel.repaintCount.get() }
+
+        onEdt { pacer?.requestRepaint() }
+        waitUntil { onEdtGet { panel.repaintCount.get() } == baseline + 1 }
+        assertEquals(1, service.subscribeCount)
+
+        // Disposing mid-wait cancels the frame loop and closes the subscription.
+        onEdt { pacer?.dispose() }
+        waitUntil { onEdtGet { service.closeCount } == 1 }
+
+        onEdt {
+            val before = panel.repaintCount.get()
+            pacer?.requestRepaint()
+            assertEquals(before + 1, panel.repaintCount.get())
+        }
+        // A disposed pacer must not re-subscribe.
+        settle()
+        assertEquals(1, service.subscribeAttempts)
+    }
+
+    @Test
+    fun framePacingPropertyDefaultsToFalse() {
+        assertFalse(SkikoProperties.swingFramePacingEnabled)
+    }
+
+    private fun onEdt(block: () -> Unit) = SwingUtilities.invokeAndWait(block)
+
+    private fun <T> onEdtGet(block: () -> T): T {
+        var result: T? = null
+        SwingUtilities.invokeAndWait { result = block() }
+        @Suppress("UNCHECKED_CAST")
+        return result as T
+    }
+
+    /**
+     * Lets in-flight frame-loop dispatches settle, for asserting that something did NOT happen.
+     * The loop hops the EDT several times per frame (channel receive, resume, yield), so a single
+     * queue drain is not enough.
+     */
+    private fun settle() {
+        repeat(5) {
+            Thread.sleep(20)
+            SwingUtilities.invokeAndWait {}
+        }
+    }
+
+    private fun waitUntil(timeoutMillis: Long = 5_000, condition: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + timeoutMillis
+        while (System.currentTimeMillis() < deadline) {
+            if (condition()) return
+            Thread.sleep(10)
+        }
+        assertTrue(condition(), "Condition not met within $timeoutMillis ms")
+    }
+
+    /** Counts the no-argument [java.awt.Component.repaint] calls the pacer issues. */
+    private class RepaintCountingPanel : JPanel() {
+        val repaintCount = AtomicInteger()
+
+        override fun repaint() {
+            // JPanel's constructor calls repaint() before this class's fields are initialized.
+            @Suppress("UNNECESSARY_SAFE_CALL", "SENSELESS_COMPARISON")
+            repaintCount?.incrementAndGet()
+            super.repaint()
+        }
+    }
+
+    private class FakeFramePacingService : FramePacingService {
+        var displayIdToReturn = DISPLAY_A
+        var periodNanos = 1_000_000_000L
+        var refuseSubscriptions = false
+
+        @Volatile
+        var subscribeAttempts = 0
+
+        @Volatile
+        var subscribeCount = 0
+
+        @Volatile
+        var closeCount = 0
+
+        val subscribedDisplayIds = mutableListOf<Long>()
+
+        private var listener: ((Long, Long) -> Unit)? = null
+
+        override fun displayId(graphicsConfiguration: GraphicsConfiguration): Long =
+            displayIdToReturn
+
+        override fun refreshPeriodNanos(displayId: Long): Long = periodNanos
+
+        override fun subscribe(
+            displayId: Long,
+            onTick: (displayId: Long, timeNanos: Long) -> Unit
+        ): AutoCloseable? {
+            subscribeAttempts++
+            if (refuseSubscriptions) return null
+            subscribedDisplayIds += displayId
+            listener = onTick
+            subscribeCount++
+            return AutoCloseable {
+                if (listener === onTick) {
+                    listener = null
+                }
+                closeCount++
+            }
+        }
+
+        /** Delivers a tick the way the real service does: from a non-EDT thread. */
+        fun tick() {
+            check(!SwingUtilities.isEventDispatchThread())
+            listener?.invoke(displayIdToReturn, System.nanoTime())
+        }
+    }
+
+    private companion object {
+        const val DISPLAY_A = 1L
+        const val DISPLAY_B = 2L
+        const val UNKNOWN_DISPLAY = -1L
+
+        /** Keeps the tick timeout far beyond test duration where the wait must stay alive. */
+        const val HUGE_PERIOD_NANOS = 100_000_000_000L
+    }
+}

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/SkikoProperties.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/SkikoProperties.kt
@@ -39,6 +39,16 @@ object SkikoProperties {
 
     val vsyncEnabled: Boolean get() = getProperty("skiko.vsync.enabled")?.toBoolean() ?: true
 
+    /**
+     * Whether `SkiaSwingLayer` paces invalidation-driven repaints (`needRender`) to the display
+     * refresh using the JetBrains Runtime `FramePacing` service.
+     *
+     * Has no effect when the runtime does not provide the service; repaint requests then pass
+     * through unchanged. Read when the layer is initialized (added to a component hierarchy).
+     */
+    val swingFramePacingEnabled: Boolean get() =
+        getProperty("skiko.swing.frame.pacing")?.toBoolean() ?: false
+
     val frameBuffering: FrameBuffering get() {
         return when (getProperty("skiko.buffering")) {
             "DOUBLE" -> FrameBuffering.DOUBLE


### PR DESCRIPTION
A continuously invalidating scene rendered through `SkiaSwingLayer` (e.g. a Compose draw-phase animation in SwingGraphics mode) calls `repaint()` as fast as the EDT can complete paint cycles, rendering far above the display refresh rate and burning GPU on frames that are never shown. This adds an opt-in frame pacer that gates invalidation-driven repaints on display refresh ticks from the JetBrains Runtime `FramePacing` service.

> [!NOTE]
> Draft until [JetBrainsRuntimeApi#31](https://github.com/JetBrains/JetBrainsRuntimeApi/pull/31) lands and jbr-api 1.11 is published on Maven Central. The reflective `FramePacingService`/`JbrFramePacingApi` seam exists only to avoid a compile-time dependency on the unreleased API; once 1.11 is available it will be replaced with a direct `JBR.getFramePacing()` dependency and removed from this PR.

## Changes

* New `SkiaSwingLayer.needRender()`: requests a repaint like `repaint()`, but paced to the display refresh when pacing is available. Plain `repaint()` is untouched — it is thread-safe, region-carrying, and called by Swing internals, and the pacer needs it as the unpaced primitive.
* New internal `SwingRepaintPacer`: a `FrameDispatcher` frame loop that repaints a requested frame immediately, then suspends until the next FramePacing tick — a continuous stream of requests coalesces to one repaint per tick, while a request arriving when the loop is idle paints with no added latency. The tick wait is bounded by `withTimeout` (~3 refresh periods) so a dead pacing clock cannot stall the loop.
* The display id is re-resolved from the layer's `GraphicsConfiguration` once per frame and the tick subscription re-created when it changes, per the jbr-api javadoc guidance; a display that refuses a subscription is cached and not retried until the layer moves to another display.
* Gated behind `skiko.swing.frame.pacing` (default **false**). When the property is off, the JBR API or service is absent, or the display cannot be paced, behavior is unchanged: requests degrade to plain `repaint()`.
* 10 unit tests drive the pacer through the `FramePacingService` seam with a fake tick source.

## Measured results

Plain-Swing `SkiaSwingLayer` spinner scene, invalidation-driven via `needRender()`, on JBR builds providing the FramePacing service:

| | renders/sec, unpaced → paced | power |
|---|---|---|
| macOS, 120 Hz ProMotion | ~500–570 → **120–121, locked** | scene too cheap to move the GPU off min clock |
| Linux, 1920x1080@120 (UHD 630) | 325.3 → **120.0, locked** | package **11.22 → 3.61 W (−68%)** |

Below the refresh rate pacing is a no-op by design: a render-bound scene (71.5 renders/sec unpaced) is not degraded (72.3 paced).
