### PR TITLE
Move GLTexture.wasm.kt to webMain

### DIFF
--- a/skiko/src/webMain/kotlin/org/jetbrains/skiko/GLTexture.web.kt
+++ b/skiko/src/webMain/kotlin/org/jetbrains/skiko/GLTexture.web.kt
@@ -1,4 +1,4 @@
-@file:OptIn(kotlin.js.ExperimentalWasmJsInterop::class)
+@file:OptIn(ExperimentalWasmJsInterop::class)
 
 package org.jetbrains.skiko
 


### PR DESCRIPTION
A follow up for https://github.com/JetBrains/skiko/pull/1219/

Having it in webMain will simplify writing common code in Compose for web. 