### PR TITLE
Return null from `ColorFilter.makeBlend` for no-op blends

### DIFF
--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/ColorFilter.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/ColorFilter.kt
@@ -28,9 +28,18 @@ class ColorFilter : RefCnt {
             }
         }
 
-        fun makeBlend(color: Int, mode: BlendMode): ColorFilter {
+        /**
+         * Returns a filter that blends [color] into the filtered color with [mode], or null when
+         * that combination leaves the color untouched. Skia collapses such no-ops away, so a null
+         * result means "apply no filter": [BlendMode.DST] with any color, a fully transparent
+         * [color] with [BlendMode.SRC_OVER], [BlendMode.DST_OVER], [BlendMode.DST_OUT],
+         * [BlendMode.SRC_ATOP], [BlendMode.XOR] or [BlendMode.DARKEN], and an opaque [color] with
+         * [BlendMode.DST_IN].
+         */
+        fun makeBlend(color: Int, mode: BlendMode): ColorFilter? {
             Stats.onNativeCall()
-            return ColorFilter(_nMakeBlend(color, mode.ordinal))
+            val ptr = _nMakeBlend(color, mode.ordinal)
+            return if (ptr == NullPointer) null else ColorFilter(ptr)
         }
 
         fun makeMatrix(matrix: ColorMatrix): ColorFilter {

--- a/skiko/src/commonTest/kotlin/org/jetbrains/skia/ColorFilterTest.kt
+++ b/skiko/src/commonTest/kotlin/org/jetbrains/skia/ColorFilterTest.kt
@@ -2,6 +2,8 @@ package org.jetbrains.skia
 
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 class ColorFilterTest {
     @Test
@@ -24,6 +26,38 @@ class ColorFilterTest {
 
         ColorFilter.makeComposed(src, dst)
         ColorFilter.makeLerp(dst, src, 0.4f)
+    }
+
+    @Test
+    fun makeBlendReturnsNullForNoOpCombinations() {
+        // Skia collapses these away: the filtered color would come out unchanged.
+        assertNull(ColorFilter.makeBlend(Color.RED, BlendMode.DST), "DST is a no-op")
+        assertNull(ColorFilter.makeBlend(Color.TRANSPARENT, BlendMode.DST), "DST is a no-op")
+        for (mode in listOf(
+            BlendMode.SRC_OVER,
+            BlendMode.DST_OVER,
+            BlendMode.DST_OUT,
+            BlendMode.SRC_ATOP,
+            BlendMode.XOR,
+            BlendMode.DARKEN,
+        )) {
+            assertNull(
+                ColorFilter.makeBlend(Color.TRANSPARENT, mode),
+                "a transparent color with $mode is a no-op"
+            )
+        }
+        assertNull(
+            ColorFilter.makeBlend(Color.RED, BlendMode.DST_IN),
+            "an opaque color with DST_IN is a no-op"
+        )
+    }
+
+    @Test
+    fun makeBlendReturnsFilterForBlendsThatChangeTheColor() {
+        assertNotNull(ColorFilter.makeBlend(Color.RED, BlendMode.SRC_ATOP))
+        assertNotNull(ColorFilter.makeBlend(Color.RED, BlendMode.SRC_OVER))
+        assertNotNull(ColorFilter.makeBlend(Color.TRANSPARENT, BlendMode.SRC))
+        assertNotNull(ColorFilter.makeBlend(Color.TRANSPARENT, BlendMode.DST_IN))
     }
 
     @Test


### PR DESCRIPTION
`SkColorFilters::Blend` returns nullptr whenever the requested blend would leave the filtered color untouched, and collapses such no-ops away rather than allocating a filter: `DST` with any color, a fully transparent color with `SRC_OVER`/`DST_OVER`/`DST_OUT`/`SRC_ATOP`/`XOR`/`DARKEN`, and an opaque color with `DST_IN`. `makeBlend` wrapped that pointer unconditionally, so `RefCnt`'s constructor rejected it with "Can't wrap nullptr" and a legal request became a crash.

Return null instead, matching Skia's own signature and the convention already used by the other bindings over `nullptr`-returning factories (`Path.makeCombining`, `FontMgr.matchFamilyStyle`, `Surface.makeImageSnapshot`). Callers read `null` as "apply no filter", which is what Skia means by it.

The return type changes from `ColorFilter` to `ColorFilter?`, which is source- incompatible for callers that use the result without a null check.

[CMP-9226](https://youtrack.jetbrains.com/issue/CMP-9226) Crash when using a transparent tint with SrcAtop (Can't wrap nullptr)
[CMP-10677](https://youtrack.jetbrains.com/issue/CMP-10677) iOS: process aborts from `MetalRedrawer.draw` when a `Canvas` draws a gradient `Brush` under a per-draw `BlendModeColorFilter`

Requires Compose-side adoption after the release