### PR TITLE
Fix Linux system theme detection returning unknown

### DIFF
--- a/skiko/src/awtMain/cpp/linux/theme.cc
+++ b/skiko/src/awtMain/cpp/linux/theme.cc
@@ -12,7 +12,10 @@ static dbus_bool_t initDbusThreads(void* lib) {
 }
 
 static void* loadLibDbus() {
-    static void* dlOpenResult = dlopen("libdbus-1.so", RTLD_LAZY | RTLD_LOCAL);
+    static void* dlOpenResult = dlopen("libdbus-1.so.3", RTLD_LAZY | RTLD_LOCAL);
+    if (!dlOpenResult) {
+        dlOpenResult = dlopen("libdbus-1.so", RTLD_LAZY | RTLD_LOCAL);
+    }
     static bool initSuccess = dlOpenResult && initDbusThreads(dlOpenResult);
     if (initSuccess) {
         return dlOpenResult;

--- a/skiko/src/awtMain/cpp/linux/theme.cc
+++ b/skiko/src/awtMain/cpp/linux/theme.cc
@@ -11,17 +11,18 @@ static dbus_bool_t initDbusThreads(void* lib) {
     return false;
 }
 
+static void* initializeLibDbus() {
+    void* handle = dlopen("libdbus-1.so.3", RTLD_LAZY | RTLD_LOCAL);
+    if (!handle) {
+        handle = dlopen("libdbus-1.so", RTLD_LAZY | RTLD_LOCAL);
+    }
+
+    return handle && initDbusThreads(handle) ? handle : nullptr;
+}
+
 static void* loadLibDbus() {
-    static void* dlOpenResult = dlopen("libdbus-1.so.3", RTLD_LAZY | RTLD_LOCAL);
-    if (!dlOpenResult) {
-        dlOpenResult = dlopen("libdbus-1.so", RTLD_LAZY | RTLD_LOCAL);
-    }
-    static bool initSuccess = dlOpenResult && initDbusThreads(dlOpenResult);
-    if (initSuccess) {
-        return dlOpenResult;
-    } else {
-        return nullptr;
-    }
+    static void* const lib = initializeLibDbus();
+    return lib;
 }
 
 static DBusMessage* dbus_message_new_method_call_dynamic(const char *bus_name, const char *path, const char *iface, const char *method) {


### PR DESCRIPTION
`libdbus-1.so` is a symlink to `libdbus-1.so.3` and is only available when the `libdbus-1-dev` package is installed. This PR updates the load logic to search for `libdbus-1.so.3` first with `libdbus-1.so` as a fallback.

Fixes - [SKIKO-1177](https://youtrack.jetbrains.com/issue/SKIKO-1177)