### PR TITLE
Support `SkMesh` API

### DIFF
--- a/skiko/src/commonMain/cpp/common/include/MeshInterop.hh
+++ b/skiko/src/commonMain/cpp/common/include/MeshInterop.hh
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "SkBlender.h"
+#include "SkColorFilter.h"
+#include "SkData.h"
+#include "SkMesh.h"
+#include "SkRuntimeEffect.h"
+#include "SkRefCnt.h"
+#include "SkShader.h"
+
+// Accumulates values for the uniforms declared by an SkMeshSpecification into the flat buffer that
+// SkMesh::Make expects. The buffer is sized from the specification and zero-filled, so uniforms that
+// are never written read as zero.
+class MeshUniformBuilder {
+public:
+    // Status codes shared with the Kotlin peer.
+    enum Status : int32_t {
+        kOk = 0,
+        kUnknownUniform = 1,
+        kSizeMismatch = 2,
+        kKindMismatch = 3,
+    };
+
+    // The two kinds of value a uniform holds. An int and a float are the same width, so a write
+    // states which kind it carries and the declared type decides whether it fits.
+    enum class ValueKind {
+        kInt,
+        kFloat,
+    };
+
+    explicit MeshUniformBuilder(sk_sp<SkMeshSpecification> specification)
+        : fSpecification(std::move(specification))
+        , fUniforms(fSpecification->uniformSize(), 0) {}
+
+    // Overwrites the named uniform with sizeInBytes bytes of kind read from values.
+    Status write(std::string_view name, ValueKind kind, const void* values, size_t sizeInBytes) {
+        const SkMeshSpecification::Uniform* uniform = fSpecification->findUniform(name);
+        if (!uniform) {
+            return kUnknownUniform;
+        }
+        if (uniform->sizeInBytes() != sizeInBytes) {
+            return kSizeMismatch;
+        }
+        if (uniformValueKind(uniform->type) != kind) {
+            return kKindMismatch;
+        }
+        memcpy(fUniforms.data() + uniform->offset, values, sizeInBytes);
+        return kOk;
+    }
+
+    sk_sp<SkData> build() const {
+        if (fUniforms.empty()) {
+            return SkData::MakeEmpty();
+        }
+        return SkData::MakeWithCopy(fUniforms.data(), fUniforms.size());
+    }
+
+private:
+    static ValueKind uniformValueKind(SkMeshSpecification::Uniform::Type type) {
+        switch (type) {
+            case SkMeshSpecification::Uniform::Type::kInt:
+            case SkMeshSpecification::Uniform::Type::kInt2:
+            case SkMeshSpecification::Uniform::Type::kInt3:
+            case SkMeshSpecification::Uniform::Type::kInt4:
+                return ValueKind::kInt;
+            case SkMeshSpecification::Uniform::Type::kFloat:
+            case SkMeshSpecification::Uniform::Type::kFloat2:
+            case SkMeshSpecification::Uniform::Type::kFloat3:
+            case SkMeshSpecification::Uniform::Type::kFloat4:
+            case SkMeshSpecification::Uniform::Type::kFloat2x2:
+            case SkMeshSpecification::Uniform::Type::kFloat3x3:
+            case SkMeshSpecification::Uniform::Type::kFloat4x4:
+                return ValueKind::kFloat;
+        }
+        return ValueKind::kFloat;
+    }
+
+    sk_sp<SkMeshSpecification> fSpecification;
+    std::vector<uint8_t> fUniforms;
+};
+
+// The number of ints the Kotlin peer reads per uniform out of the reflection buffer: offset, type,
+// count, size and flags, in that order.
+inline constexpr int32_t kMeshUniformFields = 5;
+
+// SkMesh::Make reads the uniform data while validating the mesh, so an absent uniform buffer becomes
+// empty data rather than null. A specification that declares uniforms then reports the shortfall as
+// an error instead of dereferencing null.
+inline sk_sp<const SkData> meshUniforms(const SkData* uniforms) {
+    return uniforms ? sk_ref_sp(uniforms) : SkData::MakeEmpty();
+}
+
+// A pointer alone cannot say which SkFlattenable subclass a child must be upcast from, so the Kotlin
+// peer sends an SkRuntimeEffect::ChildType alongside each one. This value stands for a child left
+// unbound, which no ChildType names.
+inline constexpr int32_t kUnboundMeshChild = -1;
+
+inline SkMesh::ChildPtr meshChild(void* child, int32_t type) {
+    if (type == kUnboundMeshChild) {
+        return SkMesh::ChildPtr();
+    }
+    switch (static_cast<SkRuntimeEffect::ChildType>(type)) {
+        case SkRuntimeEffect::ChildType::kShader:
+            return SkMesh::ChildPtr(sk_ref_sp(static_cast<SkShader*>(child)));
+        case SkRuntimeEffect::ChildType::kColorFilter:
+            return SkMesh::ChildPtr(sk_ref_sp(static_cast<SkColorFilter*>(child)));
+        case SkRuntimeEffect::ChildType::kBlender:
+            return SkMesh::ChildPtr(sk_ref_sp(static_cast<SkBlender*>(child)));
+    }
+    return SkMesh::ChildPtr();
+}

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Blender.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Blender.kt
@@ -10,7 +10,7 @@ import org.jetbrains.skia.impl.interopScope
  * Blender represents a custom blend function in the Skia pipeline.  A blender combines a source
  * color (the result of our paint) and destination color (from the canvas) into a final color.
  */
-class Blender internal constructor(ptr: NativePointer) : RefCnt(ptr) {
+class Blender internal constructor(ptr: NativePointer) : RefCnt(ptr), RuntimeEffect.Child {
     companion object {
         init {
             staticLoad()

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Canvas.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Canvas.kt
@@ -1019,6 +1019,62 @@ open class Canvas internal constructor(ptr: NativePointer, managed: Boolean, int
     }
 
     /**
+     * Experimental, under active development, and subject to change without notice.
+     *
+     * Draws a mesh using a user-defined specification (see [MeshSpecification]). Requires a GPU
+     * backend or SkSL to be compiled in.
+     *
+     * [blender] is ignored if [mesh]'s specification does not output fragment shader color.
+     * Otherwise, it combines
+     *  - the [Shader] if [paint] contains [Shader]
+     *  - or the opaque [paint] color if [paint] does not contain [Shader]
+     *
+     * as the src of the blend and the mesh's fragment color as the dst.
+     *
+     * [MaskFilter], [PathEffect], and antialiasing on [paint] are ignored.
+     *
+     * A canvas backed by a raster [Surface] accepts the draw and produces no pixels for it.
+     *
+     * @param mesh    the mesh vertices and compatible specification.
+     * @param blender combines vertices colors with [Shader] if present or [paint] opaque color if
+     *                not. Ignored if the custom mesh does not output color.
+     * @param paint   specifies the [Shader], used as mesh texture.
+     *
+     * @return this
+     */
+    fun drawMesh(mesh: Mesh, blender: Blender, paint: Paint): Canvas {
+        Stats.onNativeCall()
+        try {
+            _nDrawMesh(_ptr, getPtr(mesh), getPtr(blender), getPtr(paint))
+        } finally {
+            reachabilityBarrier(this)
+            reachabilityBarrier(mesh)
+            reachabilityBarrier(blender)
+            reachabilityBarrier(paint)
+        }
+        return this
+    }
+
+    /**
+     * Draws [mesh] with a [Blender] built from [blendMode].
+     *
+     * @see drawMesh
+     *
+     * @return this
+     */
+    fun drawMesh(mesh: Mesh, blendMode: BlendMode, paint: Paint): Canvas {
+        Stats.onNativeCall()
+        try {
+            _nDrawMeshBlendMode(_ptr, getPtr(mesh), blendMode.ordinal, getPtr(paint))
+        } finally {
+            reachabilityBarrier(this)
+            reachabilityBarrier(mesh)
+            reachabilityBarrier(paint)
+        }
+        return this
+    }
+
+    /**
      *
      * Draws Drawable drawable using clip and matrix.
      *
@@ -1772,6 +1828,12 @@ private external fun _nDrawPatch(
     blendMode: Int,
     paintPtr: NativePointer
 )
+
+@ExternalSymbolName("org_jetbrains_skia_Canvas__1nDrawMesh")
+private external fun _nDrawMesh(ptr: NativePointer, meshPtr: NativePointer, blenderPtr: NativePointer, paintPtr: NativePointer)
+
+@ExternalSymbolName("org_jetbrains_skia_Canvas__1nDrawMeshBlendMode")
+private external fun _nDrawMeshBlendMode(ptr: NativePointer, meshPtr: NativePointer, blendMode: Int, paintPtr: NativePointer)
 
 
 @ExternalSymbolName("org_jetbrains_skia_Canvas__1nDrawDrawable")

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/ColorFilter.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/ColorFilter.kt
@@ -11,7 +11,7 @@ import org.jetbrains.skia.impl.*
  *  All subclasses are required to be reentrant-safe : it must be legal to share
  *  the same instance between several threads.
  */
-class ColorFilter : RefCnt {
+class ColorFilter : RefCnt, RuntimeEffect.Child {
     companion object {
         fun makeComposed(outer: ColorFilter?, inner: ColorFilter?): ColorFilter {
             return try {

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Mesh.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Mesh.kt
@@ -1,0 +1,381 @@
+package org.jetbrains.skia
+
+import org.jetbrains.skia.impl.*
+import org.jetbrains.skia.impl.Library.Companion.staticLoad
+
+/**
+ * A vertex buffer, a topology, optionally an index buffer, and a compatible [MeshSpecification].
+ *
+ * The data in the vertex buffer is expected to contain the attributes described by the specification
+ * for [vertexCount] vertices, beginning at [vertexOffset]. [vertexOffset] must be aligned to the
+ * [MeshSpecification]'s vertex stride. The size of the buffer must be at least
+ * `vertexOffset + specification.stride * vertexCount` (even if vertex attributes contain pad at the
+ * end of the stride). If the specified bounds do not contain all the points output by the
+ * specification's vertex program when applied to the vertices in the custom mesh, then the result is
+ * undefined.
+ *
+ * [makeIndexed] may be used to create an indexed mesh. [indexCount] indices are read from the index
+ * buffer at the specified offset, which must be aligned to 2. The indices are always unsigned 16-bit
+ * integers. The index count must be at least 3.
+ *
+ * If [make] is used, the implicit index sequence is 0, 1, 2, 3, ... and [vertexCount] must be at
+ * least 3.
+ *
+ * Both [make] and [makeIndexed] take a [Data] with the uniform values. See
+ * [MeshSpecification.uniformSize] and [MeshSpecification.uniforms] for sizing and packing uniforms
+ * into the [Data]; [MeshUniformBuilder] does that packing.
+ *
+ * [specification], [vertexBuffer], [indexBuffer] and [uniforms] each return a fresh reference to the
+ * object the mesh holds, which the caller closes.
+ *
+ * Draw it with [Canvas.drawMesh].
+ */
+class Mesh internal constructor(ptr: NativePointer) : Managed(ptr, _FinalizerHolder.PTR) {
+    /** How consecutive vertices are assembled into triangles. */
+    enum class Mode {
+        /** Each group of three vertices forms one triangle. */
+        TRIANGLES,
+
+        /** Each vertex forms a triangle with the two preceding it. */
+        TRIANGLE_STRIP;
+    }
+
+    companion object {
+        /**
+         * Creates a non-indexed mesh.
+         *
+         * @param children values for the children the two programs declare, in the order
+         *                 [MeshSpecification.children] reports. Each must match the kind its
+         *                 [MeshSpecification.Child.type] names.
+         *
+         * @throws IllegalArgumentException carrying the reason the mesh was rejected, for example
+         *                                  that the uniform data was too small
+         */
+        fun make(
+            specification: MeshSpecification,
+            mode: Mode,
+            vertexBuffer: MeshVertexBuffer,
+            vertexCount: Int,
+            bounds: Rect,
+            vertexOffset: Int = 0,
+            uniforms: Data? = null,
+            children: Array<RuntimeEffect.Child?>? = null
+        ): Mesh {
+            Stats.onNativeCall()
+            val encodedChildren = encodeChildren(children)
+            return try {
+                interopScope {
+                    Mesh(
+                        meshFromResult(
+                            Mesh_nMake(
+                                getPtr(specification),
+                                mode.ordinal,
+                                getPtr(vertexBuffer),
+                                vertexCount,
+                                vertexOffset,
+                                getPtr(uniforms),
+                                toInterop(encodedChildren.pointers),
+                                toInterop(encodedChildren.types),
+                                encodedChildren.types.size,
+                                bounds.left,
+                                bounds.top,
+                                bounds.right,
+                                bounds.bottom
+                            )
+                        )
+                    )
+                }
+            } finally {
+                reachabilityBarrier(specification)
+                reachabilityBarrier(vertexBuffer)
+                reachabilityBarrier(uniforms)
+                reachabilityBarrier(children)
+            }
+        }
+
+        /**
+         * Creates an indexed mesh.
+         *
+         * @throws IllegalArgumentException carrying the reason the mesh was rejected, for example
+         *                                  that the index buffer was too small
+         */
+        fun makeIndexed(
+            specification: MeshSpecification,
+            mode: Mode,
+            vertexBuffer: MeshVertexBuffer,
+            vertexCount: Int,
+            indexBuffer: MeshIndexBuffer,
+            indexCount: Int,
+            bounds: Rect,
+            vertexOffset: Int = 0,
+            indexOffset: Int = 0,
+            uniforms: Data? = null,
+            children: Array<RuntimeEffect.Child?>? = null
+        ): Mesh {
+            Stats.onNativeCall()
+            val encodedChildren = encodeChildren(children)
+            return try {
+                interopScope {
+                    Mesh(
+                        meshFromResult(
+                            Mesh_nMakeIndexed(
+                                getPtr(specification),
+                                mode.ordinal,
+                                getPtr(vertexBuffer),
+                                vertexCount,
+                                vertexOffset,
+                                getPtr(indexBuffer),
+                                indexCount,
+                                indexOffset,
+                                getPtr(uniforms),
+                                toInterop(encodedChildren.pointers),
+                                toInterop(encodedChildren.types),
+                                encodedChildren.types.size,
+                                bounds.left,
+                                bounds.top,
+                                bounds.right,
+                                bounds.bottom
+                            )
+                        )
+                    )
+                }
+            } finally {
+                reachabilityBarrier(specification)
+                reachabilityBarrier(vertexBuffer)
+                reachabilityBarrier(indexBuffer)
+                reachabilityBarrier(uniforms)
+                reachabilityBarrier(children)
+            }
+        }
+
+        init {
+            staticLoad()
+        }
+    }
+
+    /** The specification the mesh was made with. */
+    val specification: MeshSpecification
+        get() = try {
+            Stats.onNativeCall()
+            MeshSpecification(Mesh_nGetSpecification(_ptr))
+        } finally {
+            reachabilityBarrier(this)
+        }
+
+    /** How the mesh assembles its vertices into triangles. */
+    val mode: Mode
+        get() = try {
+            Stats.onNativeCall()
+            Mode.entries[Mesh_nGetMode(_ptr)]
+        } finally {
+            reachabilityBarrier(this)
+        }
+
+    /** The buffer the vertex data is read from. */
+    val vertexBuffer: MeshVertexBuffer
+        get() = try {
+            Stats.onNativeCall()
+            MeshVertexBuffer(Mesh_nGetVertexBuffer(_ptr))
+        } finally {
+            reachabilityBarrier(this)
+        }
+
+    /** Byte offset of the first vertex in [vertexBuffer]. */
+    val vertexOffset: Int
+        get() = try {
+            Stats.onNativeCall()
+            Mesh_nGetVertexOffset(_ptr)
+        } finally {
+            reachabilityBarrier(this)
+        }
+
+    /** The number of vertices read from [vertexBuffer]. */
+    val vertexCount: Int
+        get() = try {
+            Stats.onNativeCall()
+            Mesh_nGetVertexCount(_ptr)
+        } finally {
+            reachabilityBarrier(this)
+        }
+
+    /** The buffer the indices are read from, or `null` when the mesh is not indexed. */
+    val indexBuffer: MeshIndexBuffer?
+        get() = try {
+            Stats.onNativeCall()
+            val ptr = Mesh_nGetIndexBuffer(_ptr)
+            if (ptr == Native.NullPointer) null else MeshIndexBuffer(ptr)
+        } finally {
+            reachabilityBarrier(this)
+        }
+
+    /** Byte offset of the first index in [indexBuffer]; zero when the mesh is not indexed. */
+    val indexOffset: Int
+        get() = try {
+            Stats.onNativeCall()
+            Mesh_nGetIndexOffset(_ptr)
+        } finally {
+            reachabilityBarrier(this)
+        }
+
+    /** The number of indices read from [indexBuffer]; zero when the mesh is not indexed. */
+    val indexCount: Int
+        get() = try {
+            Stats.onNativeCall()
+            Mesh_nGetIndexCount(_ptr)
+        } finally {
+            reachabilityBarrier(this)
+        }
+
+    /**
+     * The packed uniform values the programs read. Empty when the mesh was made without uniforms.
+     */
+    val uniforms: Data
+        get() = try {
+            Stats.onNativeCall()
+            Data(Mesh_nGetUniforms(_ptr))
+        } finally {
+            reachabilityBarrier(this)
+        }
+
+    /** The device-space bounds the mesh was made with. */
+    val bounds: Rect
+        get() = try {
+            Stats.onNativeCall()
+            Rect.fromInteropPointer { Mesh_nGetBounds(_ptr, it) }
+        } finally {
+            reachabilityBarrier(this)
+        }
+
+    private object _FinalizerHolder {
+        val PTR = Mesh_nGetFinalizer()
+    }
+}
+
+/**
+ * Children reach the native binding as parallel arrays of a pointer and the kind it must be upcast
+ * from, which the pointer alone cannot say.
+ */
+private class EncodedChildren(val pointers: NativePointerArray, val types: IntArray)
+
+/** The kind sent for a child left unbound, which no [MeshSpecification.Child.Type] names. */
+private const val UNBOUND_CHILD = -1
+
+private fun encodeChildren(children: Array<RuntimeEffect.Child?>?): EncodedChildren {
+    val count = children?.size ?: 0
+    val pointers = NativePointerArray(count)
+    val types = IntArray(count)
+    for (i in 0 until count) {
+        when (val child = children!![i]) {
+            null -> types[i] = UNBOUND_CHILD
+            is Shader -> {
+                pointers[i] = getPtr(child)
+                types[i] = MeshSpecification.Child.Type.SHADER.ordinal
+            }
+            is ColorFilter -> {
+                pointers[i] = getPtr(child)
+                types[i] = MeshSpecification.Child.Type.COLOR_FILTER.ordinal
+            }
+            is Blender -> {
+                pointers[i] = getPtr(child)
+                types[i] = MeshSpecification.Child.Type.BLENDER.ordinal
+            }
+        }
+    }
+    return EncodedChildren(pointers, types)
+}
+
+/**
+ * Unwraps the native `SkMesh::Result`, always destroying it, and translates a non-empty error into
+ * an exception.
+ */
+private fun meshFromResult(resultPtr: NativePointer): NativePointer {
+    try {
+        val errorPtr = Mesh_nResultGetError(resultPtr)
+        if (errorPtr != Native.NullPointer) {
+            // The error string is owned by the result.
+            throw IllegalArgumentException(withStringReferenceResult { errorPtr })
+        }
+        return Mesh_nResultGetMesh(resultPtr)
+    } finally {
+        Mesh_nResultDestroy(resultPtr)
+    }
+}
+
+@ExternalSymbolName("org_jetbrains_skia_Mesh__1nGetFinalizer")
+private external fun Mesh_nGetFinalizer(): NativePointer
+
+@ExternalSymbolName("org_jetbrains_skia_Mesh__1nMake")
+private external fun Mesh_nMake(
+    specificationPtr: NativePointer,
+    mode: Int,
+    vertexBufferPtr: NativePointer,
+    vertexCount: Int,
+    vertexOffset: Int,
+    uniformsPtr: NativePointer,
+    childrenPtrs: InteropPointer,
+    childTypes: InteropPointer,
+    childCount: Int,
+    left: Float,
+    top: Float,
+    right: Float,
+    bottom: Float
+): NativePointer
+
+@ExternalSymbolName("org_jetbrains_skia_Mesh__1nMakeIndexed")
+private external fun Mesh_nMakeIndexed(
+    specificationPtr: NativePointer,
+    mode: Int,
+    vertexBufferPtr: NativePointer,
+    vertexCount: Int,
+    vertexOffset: Int,
+    indexBufferPtr: NativePointer,
+    indexCount: Int,
+    indexOffset: Int,
+    uniformsPtr: NativePointer,
+    childrenPtrs: InteropPointer,
+    childTypes: InteropPointer,
+    childCount: Int,
+    left: Float,
+    top: Float,
+    right: Float,
+    bottom: Float
+): NativePointer
+
+@ExternalSymbolName("org_jetbrains_skia_Mesh__1nGetSpecification")
+private external fun Mesh_nGetSpecification(ptr: NativePointer): NativePointer
+
+@ExternalSymbolName("org_jetbrains_skia_Mesh__1nGetMode")
+private external fun Mesh_nGetMode(ptr: NativePointer): Int
+
+@ExternalSymbolName("org_jetbrains_skia_Mesh__1nGetVertexBuffer")
+private external fun Mesh_nGetVertexBuffer(ptr: NativePointer): NativePointer
+
+@ExternalSymbolName("org_jetbrains_skia_Mesh__1nGetVertexOffset")
+private external fun Mesh_nGetVertexOffset(ptr: NativePointer): Int
+
+@ExternalSymbolName("org_jetbrains_skia_Mesh__1nGetVertexCount")
+private external fun Mesh_nGetVertexCount(ptr: NativePointer): Int
+
+@ExternalSymbolName("org_jetbrains_skia_Mesh__1nGetIndexBuffer")
+private external fun Mesh_nGetIndexBuffer(ptr: NativePointer): NativePointer
+
+@ExternalSymbolName("org_jetbrains_skia_Mesh__1nGetIndexOffset")
+private external fun Mesh_nGetIndexOffset(ptr: NativePointer): Int
+
+@ExternalSymbolName("org_jetbrains_skia_Mesh__1nGetIndexCount")
+private external fun Mesh_nGetIndexCount(ptr: NativePointer): Int
+
+@ExternalSymbolName("org_jetbrains_skia_Mesh__1nGetUniforms")
+private external fun Mesh_nGetUniforms(ptr: NativePointer): NativePointer
+
+@ExternalSymbolName("org_jetbrains_skia_Mesh__1nGetBounds")
+private external fun Mesh_nGetBounds(ptr: NativePointer, bounds: InteropPointer)
+
+@ExternalSymbolName("org_jetbrains_skia_Mesh__1nResultGetMesh")
+private external fun Mesh_nResultGetMesh(resultPtr: NativePointer): NativePointer
+
+@ExternalSymbolName("org_jetbrains_skia_Mesh__1nResultGetError")
+private external fun Mesh_nResultGetError(resultPtr: NativePointer): NativePointer
+
+@ExternalSymbolName("org_jetbrains_skia_Mesh__1nResultDestroy")
+private external fun Mesh_nResultDestroy(resultPtr: NativePointer)

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/MeshIndexBuffer.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/MeshIndexBuffer.kt
@@ -1,0 +1,41 @@
+package org.jetbrains.skia
+
+import org.jetbrains.skia.impl.*
+import org.jetbrains.skia.impl.Library.Companion.staticLoad
+
+/**
+ * A CPU-backed index buffer to be used with [Mesh.makeIndexed]. The indices are always unsigned
+ * 16-bit integers.
+ */
+class MeshIndexBuffer internal constructor(ptr: NativePointer) : RefCnt(ptr) {
+    companion object {
+        /** @param indices The data used to populate the buffer. */
+        fun make(indices: ShortArray): MeshIndexBuffer {
+            Stats.onNativeCall()
+            val ptr = interopScope {
+                MeshIndexBuffer_nMake(toInterop(indices), indices.size)
+            }
+            check(ptr != Native.NullPointer) { "Failed to allocate an index buffer of ${indices.size} indices" }
+            return MeshIndexBuffer(ptr)
+        }
+
+        init {
+            staticLoad()
+        }
+    }
+
+    /** The size of the buffer, in bytes. */
+    val size: Int
+        get() = try {
+            Stats.onNativeCall()
+            MeshIndexBuffer_nGetSize(_ptr)
+        } finally {
+            reachabilityBarrier(this)
+        }
+}
+
+@ExternalSymbolName("org_jetbrains_skia_MeshIndexBuffer__1nMake")
+private external fun MeshIndexBuffer_nMake(indices: InteropPointer, indexCount: Int): NativePointer
+
+@ExternalSymbolName("org_jetbrains_skia_MeshIndexBuffer__1nGetSize")
+private external fun MeshIndexBuffer_nGetSize(ptr: NativePointer): Int

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/MeshSpecification.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/MeshSpecification.kt
@@ -1,0 +1,456 @@
+package org.jetbrains.skia
+
+import org.jetbrains.skia.impl.*
+import org.jetbrains.skia.impl.Library.Companion.staticLoad
+
+/**
+ * A specification for custom meshes. Specifies the vertex buffer attributes and stride, the
+ * vertex program that produces a user-defined set of varyings, and a fragment program that ingests
+ * the interpolated varyings and produces local coordinates for shading and optionally a color.
+ *
+ * The varyings must include a `float2` named `position`. If the passed varyings does not
+ * contain such a varying then one is implicitly added to the final specification and the SkSL
+ * `Varyings` struct described below. It is an error to have a varying named `position` that has a
+ * type other than `float2`.
+ *
+ * The provided attributes and varyings are used to create `Attributes` and `Varyings` structs in
+ * SkSL that are used by the shaders. Each attribute from the [Attribute] array becomes a member of
+ * the SkSL `Attributes` struct and likewise for the varyings.
+ *
+ * The signature of the vertex program must be `Varyings main(const Attributes)`.
+ *
+ * The signature of the fragment program must be either `float2 main(const Varyings)` or
+ * `float2 main(const Varyings, out (half4|float4) color)`, where the return value is the local
+ * coordinates that will be used to access [Shader]. If the color variant is used, the returned
+ * color will be blended with [Paint]'s [Shader] (or [Paint] color in absence of a [Shader]) using
+ * the [Blender] passed to [Canvas.drawMesh]. To use interpolated local space positions as the
+ * shader coordinates, equivalent to how [Path]s are shaded, return the position field from the
+ * `Varyings` struct as the coordinates.
+ *
+ * The vertex and fragment programs may both contain uniforms. Uniforms with the same name are
+ * assumed to be shared between stages. It is an error to specify uniforms in the vertex and
+ * fragment program with the same name but different types, dimensionality, or layouts.
+ */
+class MeshSpecification internal constructor(ptr: NativePointer) : Managed(ptr, _FinalizerHolder.PTR) {
+    /**
+     * A vertex attribute that will be consumed by the vertex program. Attributes need not be
+     * tightly packed but attribute offsets must be aligned to [OFFSET_ALIGNMENT] and
+     * `offset + size` may not be greater than the vertex stride.
+     */
+    data class Attribute(val type: Type, val offset: Int, val name: String) {
+        /** The CPU representation of an [Attribute] and its type in the shader. */
+        enum class Type {
+            /** float; `float` in the shader. */
+            FLOAT,
+
+            /** Two floats; `float2` in the shader. */
+            FLOAT2,
+
+            /** Three floats; `float3` in the shader. */
+            FLOAT3,
+
+            /** Four floats; `float4` in the shader. */
+            FLOAT4,
+
+            /** Four bytes; `half4` in the shader. */
+            UBYTE4_UNORM;
+        }
+    }
+
+    /** A varying that will be written by the vertex program and read by the fragment program. */
+    data class Varying(val type: Type, val name: String) {
+        /** The SkSL type of a [Varying]. */
+        enum class Type {
+            FLOAT,
+            FLOAT2,
+            FLOAT3,
+            FLOAT4,
+            HALF,
+            HALF2,
+            HALF3,
+            HALF4;
+        }
+    }
+
+    /**
+     * Reflected description of a uniform variable in the specification's SkSL, including the offset
+     * into the [Data] where its value should be placed.
+     */
+    data class Uniform(
+        val name: String,
+        val offset: Int,
+        val type: Type,
+        val count: Int,
+        val sizeInBytes: Int,
+        val flags: Int
+    ) {
+        /** The SkSL type of a [Uniform]. */
+        enum class Type {
+            FLOAT,
+            FLOAT2,
+            FLOAT3,
+            FLOAT4,
+            FLOAT2X2,
+            FLOAT3X3,
+            FLOAT4X4,
+            INT,
+            INT2,
+            INT3,
+            INT4;
+        }
+
+        /** The uniform is declared as an array. [count] contains the array length. */
+        val isArray: Boolean
+            get() = flags and ARRAY_FLAG != 0
+
+        /**
+         * The uniform is declared with `layout(color)`. Colors should be supplied as unpremultiplied,
+         * extended-range (unclamped) sRGB, that is, as [Color4f]. The uniform will be automatically
+         * transformed to unpremultiplied extended-range working-space colors.
+         */
+        val isColor: Boolean
+            get() = flags and COLOR_FLAG != 0
+
+        /** The uniform is present in the vertex shader. */
+        val isVertex: Boolean
+            get() = flags and VERTEX_FLAG != 0
+
+        /** The uniform is present in the fragment shader. */
+        val isFragment: Boolean
+            get() = flags and FRAGMENT_FLAG != 0
+
+        /** The SkSL uniform uses a medium-precision type, that is, `half` instead of `float`. */
+        val isHalfPrecision: Boolean
+            get() = flags and HALF_PRECISION_FLAG != 0
+
+        // The bits SkRuntimeEffect::Uniform::Flags defines.
+        private companion object {
+            const val ARRAY_FLAG = 0x1
+            const val COLOR_FLAG = 0x2
+            const val VERTEX_FLAG = 0x4
+            const val FRAGMENT_FLAG = 0x8
+            const val HALF_PRECISION_FLAG = 0x10
+        }
+    }
+
+    /** Reflected description of a uniform child in the specification's SkSL. */
+    data class Child(val name: String, val type: Type, val index: Int) {
+        /** The runtime effect type of a [Child]. */
+        enum class Type {
+            SHADER,
+            COLOR_FILTER,
+            BLENDER;
+        }
+    }
+
+    companion object {
+        /** Enforced when creating a specification. */
+        const val MAX_STRIDE = 1024
+
+        /** Enforced when creating a specification. */
+        const val MAX_ATTRIBUTES = 8
+
+        /** Enforced when creating a specification. */
+        const val STRIDE_ALIGNMENT = 4
+
+        /** Enforced when creating a specification. */
+        const val OFFSET_ALIGNMENT = 4
+
+        /** Enforced when creating a specification. */
+        const val MAX_VARYINGS = 6
+
+        /**
+         * @param attributes     The vertex attributes that will be consumed by [vertexShader].
+         *                       Attributes need not be tightly packed but attribute offsets must be
+         *                       aligned to [OFFSET_ALIGNMENT] and `offset + size` may not be greater
+         *                       than [vertexStride]. At least one attribute is required.
+         * @param vertexStride   The offset between successive attribute values. This must be aligned
+         *                       to [STRIDE_ALIGNMENT].
+         * @param varyings       The varyings that will be written by [vertexShader] and read by
+         *                       [fragmentShader]. This may be empty.
+         * @param vertexShader   The vertex shader code that computes a vertex position and the
+         *                       varyings from the attributes.
+         * @param fragmentShader The fragment code that computes a local coordinate and optionally a
+         *                       color from the varyings. The local coordinate is used to sample
+         *                       [Shader].
+         * @param colorSpace     The color space of the color produced by [fragmentShader]. Ignored
+         *                       if the fragment program's `main()` function does not have a color
+         *                       out param. `null` means sRGB.
+         * @param alphaType      The alpha type of the color produced by [fragmentShader]. Ignored if
+         *                       the fragment program's `main()` function does not have a color out
+         *                       param. Cannot be [ColorAlphaType.UNKNOWN].
+         *
+         * @throws IllegalArgumentException carrying the reason the specification was rejected
+         */
+        fun make(
+            attributes: Array<Attribute>,
+            vertexStride: Int,
+            varyings: Array<Varying>,
+            vertexShader: String,
+            fragmentShader: String,
+            colorSpace: ColorSpace? = null,
+            alphaType: ColorAlphaType = ColorAlphaType.PREMUL
+        ): MeshSpecification {
+            require(attributes.isNotEmpty()) { "At least one attribute is required" }
+            require(alphaType != ColorAlphaType.UNKNOWN) { "alphaType may not be ColorAlphaType.UNKNOWN" }
+
+            // Every attribute contributes two ints: its type ordinal and its byte offset.
+            val attributeTypesAndOffsets = IntArray(attributes.size * 2)
+            for (i in attributes.indices) {
+                attributeTypesAndOffsets[i * 2] = attributes[i].type.ordinal
+                attributeTypesAndOffsets[i * 2 + 1] = attributes[i].offset
+            }
+            val attributeNames = Array(attributes.size) { attributes[it].name }
+            val varyingTypes = IntArray(varyings.size) { varyings[it].type.ordinal }
+            val varyingNames = Array(varyings.size) { varyings[it].name }
+
+            Stats.onNativeCall()
+            return try {
+                interopScope {
+                    MeshSpecification(
+                        specificationFromResult(
+                            MeshSpecification_nMake(
+                                toInterop(attributeTypesAndOffsets),
+                                toInterop(attributeNames),
+                                attributes.size,
+                                vertexStride,
+                                toInterop(varyingTypes),
+                                toInterop(varyingNames),
+                                varyings.size,
+                                toInterop(vertexShader),
+                                toInterop(fragmentShader),
+                                getPtr(colorSpace),
+                                alphaType.ordinal
+                            )
+                        )
+                    )
+                }
+            } finally {
+                reachabilityBarrier(colorSpace)
+            }
+        }
+
+        init {
+            staticLoad()
+        }
+    }
+
+    /** The offset between successive attribute values in a buffer laid out for this specification. */
+    val stride: Int
+        get() = try {
+            Stats.onNativeCall()
+            MeshSpecification_nGetStride(_ptr)
+        } finally {
+            reachabilityBarrier(this)
+        }
+
+    /**
+     * The color space of the color produced by the fragment program, or `null` if its `main()`
+     * function does not have a color out param.
+     */
+    val colorSpace: ColorSpace?
+        get() = try {
+            Stats.onNativeCall()
+            val ptr = MeshSpecification_nGetColorSpace(_ptr)
+            if (ptr == Native.NullPointer) null else ColorSpace(ptr)
+        } finally {
+            reachabilityBarrier(this)
+        }
+
+    /** The vertex attributes consumed by the vertex program. */
+    val attributes: List<Attribute>
+        get() {
+            Stats.onNativeCall()
+            try {
+                val count = MeshSpecification_nGetAttributeCount(_ptr)
+                if (count == 0) return emptyList()
+                // Every attribute contributes two ints: its type ordinal and its byte offset.
+                val fields = withResult(IntArray(count * 2)) { MeshSpecification_nGetAttributeFields(_ptr, it) }
+                return List(count) { i ->
+                    Attribute(
+                        type = Attribute.Type.entries[fields[i * 2]],
+                        offset = fields[i * 2 + 1],
+                        name = withStringResult { MeshSpecification_nGetAttributeName(_ptr, i) }
+                    )
+                }
+            } finally {
+                reachabilityBarrier(this)
+            }
+        }
+
+    /**
+     * Combined size of all `uniform` variables. When creating a [Mesh] with this specification
+     * provide a [Data] of this size, containing values for all of those variables. Use [uniforms]
+     * to get the offset of each uniform within the [Data].
+     */
+    val uniformSize: Int
+        get() = try {
+            Stats.onNativeCall()
+            MeshSpecification_nGetUniformSize(_ptr)
+        } finally {
+            reachabilityBarrier(this)
+        }
+
+    /**
+     * Provides info about individual uniforms including the offset into a [Data] where each uniform
+     * value should be placed.
+     */
+    val uniforms: List<Uniform>
+        get() {
+            Stats.onNativeCall()
+            try {
+                val count = MeshSpecification_nGetUniformCount(_ptr)
+                if (count == 0) return emptyList()
+                // Every uniform contributes five ints: offset, type ordinal, count, size and flags.
+                val fields = withResult(IntArray(count * UNIFORM_FIELDS)) {
+                    MeshSpecification_nGetUniformFields(_ptr, it)
+                }
+                return List(count) { i ->
+                    val base = i * UNIFORM_FIELDS
+                    Uniform(
+                        name = withStringResult { MeshSpecification_nGetUniformName(_ptr, i) },
+                        offset = fields[base],
+                        type = Uniform.Type.entries[fields[base + 1]],
+                        count = fields[base + 2],
+                        sizeInBytes = fields[base + 3],
+                        flags = fields[base + 4]
+                    )
+                }
+            } finally {
+                reachabilityBarrier(this)
+            }
+        }
+
+    /** Provides basic info about individual children: names, indices and runtime effect type. */
+    val children: List<Child>
+        get() {
+            Stats.onNativeCall()
+            try {
+                val count = MeshSpecification_nGetChildCount(_ptr)
+                if (count == 0) return emptyList()
+                // Every child contributes two ints: its type ordinal and its index.
+                val fields = withResult(IntArray(count * 2)) { MeshSpecification_nGetChildFields(_ptr, it) }
+                return List(count) { i ->
+                    Child(
+                        name = withStringResult { MeshSpecification_nGetChildName(_ptr, i) },
+                        type = Child.Type.entries[fields[i * 2]],
+                        index = fields[i * 2 + 1]
+                    )
+                }
+            } finally {
+                reachabilityBarrier(this)
+            }
+        }
+
+    /** Returns the named attribute, or `null` if not found. */
+    fun findAttribute(name: String): Attribute? = attributes.firstOrNull { it.name == name }
+
+    /** Returns the named uniform variable's description, or `null` if not found. */
+    fun findUniform(name: String): Uniform? = uniforms.firstOrNull { it.name == name }
+
+    /** Returns the named child's description, or `null` if not found. */
+    fun findChild(name: String): Child? = children.firstOrNull { it.name == name }
+
+    /**
+     * Returns the named varying, or `null` if not found. This finds the `position` varying that is
+     * added implicitly as well as the ones the specification was given.
+     */
+    fun findVarying(name: String): Varying? {
+        Stats.onNativeCall()
+        val type = try {
+            interopScope { MeshSpecification_nFindVaryingType(_ptr, toInterop(name)) }
+        } finally {
+            reachabilityBarrier(this)
+        }
+        return if (type < 0) null else Varying(Varying.Type.entries[type], name)
+    }
+
+    private object _FinalizerHolder {
+        val PTR = MeshSpecification_nGetFinalizer()
+    }
+}
+
+private const val UNIFORM_FIELDS = 5
+
+/**
+ * Unwraps the native `SkMeshSpecification::Result`, always destroying it, and translates a non-empty
+ * error into an exception.
+ */
+private fun specificationFromResult(resultPtr: NativePointer): NativePointer {
+    try {
+        val errorPtr = MeshSpecification_nResultGetError(resultPtr)
+        if (errorPtr != Native.NullPointer) {
+            // The error string is owned by the result.
+            throw IllegalArgumentException(withStringReferenceResult { errorPtr })
+        }
+        return MeshSpecification_nResultGetSpecification(resultPtr)
+    } finally {
+        MeshSpecification_nResultDestroy(resultPtr)
+    }
+}
+
+@ExternalSymbolName("org_jetbrains_skia_MeshSpecification__1nGetFinalizer")
+private external fun MeshSpecification_nGetFinalizer(): NativePointer
+
+@ExternalSymbolName("org_jetbrains_skia_MeshSpecification__1nMake")
+private external fun MeshSpecification_nMake(
+    attributeTypesAndOffsets: InteropPointer,
+    attributeNames: InteropPointer,
+    attributeCount: Int,
+    vertexStride: Int,
+    varyingTypes: InteropPointer,
+    varyingNames: InteropPointer,
+    varyingCount: Int,
+    vertexShader: InteropPointer,
+    fragmentShader: InteropPointer,
+    colorSpacePtr: NativePointer,
+    alphaType: Int
+): NativePointer
+
+@ExternalSymbolName("org_jetbrains_skia_MeshSpecification__1nGetStride")
+private external fun MeshSpecification_nGetStride(ptr: NativePointer): Int
+
+@ExternalSymbolName("org_jetbrains_skia_MeshSpecification__1nGetColorSpace")
+private external fun MeshSpecification_nGetColorSpace(ptr: NativePointer): NativePointer
+
+@ExternalSymbolName("org_jetbrains_skia_MeshSpecification__1nGetAttributeCount")
+private external fun MeshSpecification_nGetAttributeCount(ptr: NativePointer): Int
+
+@ExternalSymbolName("org_jetbrains_skia_MeshSpecification__1nGetAttributeFields")
+private external fun MeshSpecification_nGetAttributeFields(ptr: NativePointer, fields: InteropPointer)
+
+@ExternalSymbolName("org_jetbrains_skia_MeshSpecification__1nGetAttributeName")
+private external fun MeshSpecification_nGetAttributeName(ptr: NativePointer, index: Int): NativePointer
+
+@ExternalSymbolName("org_jetbrains_skia_MeshSpecification__1nGetUniformSize")
+private external fun MeshSpecification_nGetUniformSize(ptr: NativePointer): Int
+
+@ExternalSymbolName("org_jetbrains_skia_MeshSpecification__1nGetUniformCount")
+private external fun MeshSpecification_nGetUniformCount(ptr: NativePointer): Int
+
+@ExternalSymbolName("org_jetbrains_skia_MeshSpecification__1nGetUniformFields")
+private external fun MeshSpecification_nGetUniformFields(ptr: NativePointer, fields: InteropPointer)
+
+@ExternalSymbolName("org_jetbrains_skia_MeshSpecification__1nGetUniformName")
+private external fun MeshSpecification_nGetUniformName(ptr: NativePointer, index: Int): NativePointer
+
+@ExternalSymbolName("org_jetbrains_skia_MeshSpecification__1nGetChildCount")
+private external fun MeshSpecification_nGetChildCount(ptr: NativePointer): Int
+
+@ExternalSymbolName("org_jetbrains_skia_MeshSpecification__1nGetChildFields")
+private external fun MeshSpecification_nGetChildFields(ptr: NativePointer, fields: InteropPointer)
+
+@ExternalSymbolName("org_jetbrains_skia_MeshSpecification__1nGetChildName")
+private external fun MeshSpecification_nGetChildName(ptr: NativePointer, index: Int): NativePointer
+
+@ExternalSymbolName("org_jetbrains_skia_MeshSpecification__1nFindVaryingType")
+private external fun MeshSpecification_nFindVaryingType(ptr: NativePointer, name: InteropPointer): Int
+
+@ExternalSymbolName("org_jetbrains_skia_MeshSpecification__1nResultGetSpecification")
+private external fun MeshSpecification_nResultGetSpecification(resultPtr: NativePointer): NativePointer
+
+@ExternalSymbolName("org_jetbrains_skia_MeshSpecification__1nResultGetError")
+private external fun MeshSpecification_nResultGetError(resultPtr: NativePointer): NativePointer
+
+@ExternalSymbolName("org_jetbrains_skia_MeshSpecification__1nResultDestroy")
+private external fun MeshSpecification_nResultDestroy(resultPtr: NativePointer)

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/MeshUniformBuilder.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/MeshUniformBuilder.kt
@@ -1,0 +1,171 @@
+package org.jetbrains.skia
+
+import org.jetbrains.skia.impl.*
+import org.jetbrains.skia.impl.Library.Companion.staticLoad
+
+/**
+ * Packs values for the uniforms declared by a [MeshSpecification]'s programs into the single [Data]
+ * that [Mesh.make] and [Mesh.makeIndexed] accept.
+ *
+ * Uniforms left unset hold zeroes. Each `uniform` call writes at the offset the specification
+ * assigns to that name, so the same builder may be reused and individual uniforms overwritten;
+ * [build] copies the current values and can be called any number of times.
+ *
+ * [MeshSpecification.uniformSize] and [MeshSpecification.uniforms] describe the same layout, for
+ * callers that would rather assemble the [Data] themselves.
+ *
+ * ```
+ * val uniforms = MeshUniformBuilder(specification).use {
+ *     it.uniform("time", 0.25f)
+ *     it.uniform("resolution", 800f, 600f)
+ *     it.build()
+ * }
+ * ```
+ */
+class MeshUniformBuilder internal constructor(ptr: NativePointer) : Managed(ptr, _FinalizerHolder.PTR) {
+    companion object {
+        init {
+            staticLoad()
+        }
+    }
+
+    constructor(specification: MeshSpecification) : this(MeshUniformBuilder_nMake(getPtr(specification))) {
+        Stats.onNativeCall()
+        reachabilityBarrier(specification)
+    }
+
+    /** Writes an `int` uniform. */
+    fun uniform(name: String, value: Int) = uniform(name, intArrayOf(value))
+
+    /** Writes an `int2` uniform. */
+    fun uniform(name: String, value1: Int, value2: Int) = uniform(name, intArrayOf(value1, value2))
+
+    /** Writes an `int3` uniform. */
+    fun uniform(name: String, value1: Int, value2: Int, value3: Int) =
+        uniform(name, intArrayOf(value1, value2, value3))
+
+    /** Writes an `int4` uniform. */
+    fun uniform(name: String, value1: Int, value2: Int, value3: Int, value4: Int) =
+        uniform(name, intArrayOf(value1, value2, value3, value4))
+
+    /**
+     * Writes an integer uniform, or an array of them, from [value].
+     *
+     * @throws IllegalArgumentException if the specification declares no uniform called [name], or
+     *                                  declares it with a different size, or declares it as a
+     *                                  floating point uniform
+     */
+    fun uniform(name: String, value: IntArray) {
+        Stats.onNativeCall()
+        val status = try {
+            interopScope {
+                MeshUniformBuilder_nUniformInts(_ptr, toInterop(name), toInterop(value), value.size)
+            }
+        } finally {
+            reachabilityBarrier(this)
+        }
+        checkStatus(status, name, value.size, "integer")
+    }
+
+    /** Writes a `float` uniform. */
+    fun uniform(name: String, value: Float) = uniform(name, floatArrayOf(value))
+
+    /** Writes a `float2` uniform. */
+    fun uniform(name: String, value1: Float, value2: Float) = uniform(name, floatArrayOf(value1, value2))
+
+    /** Writes a `float3` uniform. */
+    fun uniform(name: String, value1: Float, value2: Float, value3: Float) =
+        uniform(name, floatArrayOf(value1, value2, value3))
+
+    /** Writes a `float4` uniform. */
+    fun uniform(name: String, value1: Float, value2: Float, value3: Float, value4: Float) =
+        uniform(name, floatArrayOf(value1, value2, value3, value4))
+
+    /** Writes a `float2x2` uniform. */
+    fun uniform(name: String, value: Matrix22) = uniform(name, value.mat)
+
+    /** Writes a `float3x3` uniform. */
+    fun uniform(name: String, value: Matrix33) = uniform(name, value.mat)
+
+    /** Writes a `float4x4` uniform. */
+    fun uniform(name: String, value: Matrix44) = uniform(name, value.mat)
+
+    /**
+     * Writes a floating point uniform, or an array or matrix of them, from [value].
+     *
+     * `half` uniforms are written as floats too: the specification stores every floating point
+     * uniform at full precision and narrows it when the shader runs.
+     *
+     * @throws IllegalArgumentException if the specification declares no uniform called [name], or
+     *                                  declares it with a different size, or declares it as an
+     *                                  integer uniform
+     */
+    fun uniform(name: String, value: FloatArray) {
+        Stats.onNativeCall()
+        val status = try {
+            interopScope {
+                MeshUniformBuilder_nUniformFloats(_ptr, toInterop(name), toInterop(value), value.size)
+            }
+        } finally {
+            reachabilityBarrier(this)
+        }
+        checkStatus(status, name, value.size, "floating point")
+    }
+
+    /** Copies the values written so far into a [Data] sized for the specification. */
+    fun build(): Data {
+        Stats.onNativeCall()
+        return try {
+            Data(MeshUniformBuilder_nBuild(_ptr))
+        } finally {
+            reachabilityBarrier(this)
+        }
+    }
+
+    private fun checkStatus(status: Int, name: String, valueSize: Int, valueKind: String) {
+        when (status) {
+            STATUS_OK -> Unit
+            STATUS_UNKNOWN_UNIFORM ->
+                throw IllegalArgumentException("The specification declares no uniform called '$name'")
+            STATUS_SIZE_MISMATCH ->
+                throw IllegalArgumentException("Uniform '$name' is not $valueSize values wide")
+            STATUS_KIND_MISMATCH ->
+                throw IllegalArgumentException("Uniform '$name' does not hold $valueKind values")
+            else -> error("Writing uniform '$name' returned status $status")
+        }
+    }
+
+    private object _FinalizerHolder {
+        val PTR = MeshUniformBuilder_nGetFinalizer()
+    }
+}
+
+private const val STATUS_OK = 0
+private const val STATUS_UNKNOWN_UNIFORM = 1
+private const val STATUS_SIZE_MISMATCH = 2
+private const val STATUS_KIND_MISMATCH = 3
+
+@ExternalSymbolName("org_jetbrains_skia_MeshUniformBuilder__1nGetFinalizer")
+private external fun MeshUniformBuilder_nGetFinalizer(): NativePointer
+
+@ExternalSymbolName("org_jetbrains_skia_MeshUniformBuilder__1nMake")
+private external fun MeshUniformBuilder_nMake(specificationPtr: NativePointer): NativePointer
+
+@ExternalSymbolName("org_jetbrains_skia_MeshUniformBuilder__1nUniformInts")
+private external fun MeshUniformBuilder_nUniformInts(
+    builderPtr: NativePointer,
+    uniformName: InteropPointer,
+    values: InteropPointer,
+    count: Int
+): Int
+
+@ExternalSymbolName("org_jetbrains_skia_MeshUniformBuilder__1nUniformFloats")
+private external fun MeshUniformBuilder_nUniformFloats(
+    builderPtr: NativePointer,
+    uniformName: InteropPointer,
+    values: InteropPointer,
+    count: Int
+): Int
+
+@ExternalSymbolName("org_jetbrains_skia_MeshUniformBuilder__1nBuild")
+private external fun MeshUniformBuilder_nBuild(builderPtr: NativePointer): NativePointer

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/MeshVertexBuffer.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/MeshVertexBuffer.kt
@@ -1,0 +1,59 @@
+package org.jetbrains.skia
+
+import org.jetbrains.skia.impl.*
+import org.jetbrains.skia.impl.Library.Companion.staticLoad
+
+/** A CPU-backed vertex buffer to be used with [Mesh]. */
+class MeshVertexBuffer internal constructor(ptr: NativePointer) : RefCnt(ptr) {
+    companion object {
+        /**
+         * @param data The data used to populate the buffer. Both the size of the data and the size
+         *             of the resulting buffer, in bytes.
+         */
+        fun make(data: ByteArray): MeshVertexBuffer {
+            Stats.onNativeCall()
+            val ptr = interopScope {
+                MeshVertexBuffer_nMake(toInterop(data), data.size)
+            }
+            check(ptr != Native.NullPointer) { "Failed to allocate a vertex buffer of ${data.size} bytes" }
+            return MeshVertexBuffer(ptr)
+        }
+
+        /**
+         * Populates the buffer from [data], for a vertex layout made only of float attributes. The
+         * floats are stored in the host's byte order, the same bytes [make] would be given.
+         */
+        fun make(data: FloatArray): MeshVertexBuffer {
+            Stats.onNativeCall()
+            val ptr = interopScope {
+                MeshVertexBuffer_nMakeFromFloats(toInterop(data), data.size)
+            }
+            check(ptr != Native.NullPointer) {
+                "Failed to allocate a vertex buffer of ${data.size * 4} bytes"
+            }
+            return MeshVertexBuffer(ptr)
+        }
+
+        init {
+            staticLoad()
+        }
+    }
+
+    /** The size of the buffer, in bytes. */
+    val size: Int
+        get() = try {
+            Stats.onNativeCall()
+            MeshVertexBuffer_nGetSize(_ptr)
+        } finally {
+            reachabilityBarrier(this)
+        }
+}
+
+@ExternalSymbolName("org_jetbrains_skia_MeshVertexBuffer__1nMake")
+private external fun MeshVertexBuffer_nMake(data: InteropPointer, size: Int): NativePointer
+
+@ExternalSymbolName("org_jetbrains_skia_MeshVertexBuffer__1nMakeFromFloats")
+private external fun MeshVertexBuffer_nMakeFromFloats(data: InteropPointer, count: Int): NativePointer
+
+@ExternalSymbolName("org_jetbrains_skia_MeshVertexBuffer__1nGetSize")
+private external fun MeshVertexBuffer_nGetSize(ptr: NativePointer): Int

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/RuntimeEffect.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/RuntimeEffect.kt
@@ -5,8 +5,7 @@ import org.jetbrains.skia.impl.Library.Companion.staticLoad
 
 class RuntimeEffect internal constructor(ptr: NativePointer) : RefCnt(ptr) {
     /**
-     * A value that can be bound to a `uniform shader`, `uniform colorFilter` or `uniform blender`
-     * declaration in an SkSL program.
+     * A value that allows passing a [Shader], [ColorFilter] or [Blender] as a child.
      *
      * @see Mesh.make
      */

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/RuntimeEffect.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/RuntimeEffect.kt
@@ -4,6 +4,14 @@ import org.jetbrains.skia.impl.*
 import org.jetbrains.skia.impl.Library.Companion.staticLoad
 
 class RuntimeEffect internal constructor(ptr: NativePointer) : RefCnt(ptr) {
+    /**
+     * A value that can be bound to a `uniform shader`, `uniform colorFilter` or `uniform blender`
+     * declaration in an SkSL program.
+     *
+     * @see Mesh.make
+     */
+    sealed interface Child
+
     companion object {
         fun makeForShader(sksl: String): RuntimeEffect {
             Stats.onNativeCall()

--- a/skiko/src/commonMain/kotlin/org/jetbrains/skia/Shader.kt
+++ b/skiko/src/commonMain/kotlin/org/jetbrains/skia/Shader.kt
@@ -12,7 +12,7 @@ import org.jetbrains.skia.impl.Library.Companion.staticLoad
  *  w/o having to modify the original shader... only the paint's alpha needs
  *  to be modified.
  */
-class Shader internal constructor(ptr: NativePointer) : RefCnt(ptr) {
+class Shader internal constructor(ptr: NativePointer) : RefCnt(ptr), RuntimeEffect.Child {
     companion object {
         init {
             staticLoad()

--- a/skiko/src/commonTest/kotlin/org/jetbrains/skia/MeshTest.kt
+++ b/skiko/src/commonTest/kotlin/org/jetbrains/skia/MeshTest.kt
@@ -1,0 +1,716 @@
+package org.jetbrains.skia
+
+import org.jetbrains.skia.impl.use
+import org.jetbrains.skiko.tests.TestGlContext
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Covers [Mesh] and the types it is built from with a quad of two triangles, inset from the edges of
+ * a 16x16 surface and read from a vertex buffer whose stride is padded past the attributes it holds.
+ *
+ * Meshes are rasterized by GPU-backed canvases; a raster surface accepts a mesh draw and produces no
+ * pixels for it. What a drawing test can assert on every target is therefore that the draw reaches
+ * Skia and leaves the surface outside the mesh intact.
+ */
+class MeshTest {
+
+    @Test
+    fun specificationReportsDeclaredStride() {
+        makeSpecification().use { specification ->
+            assertEquals(VERTEX_STRIDE, specification.stride)
+        }
+    }
+
+    @Test
+    fun specificationRejectsMalformedShader() {
+        val exception = assertFailsWith<IllegalArgumentException> {
+            makeSpecification(fragmentShader = "float2 main(const Varyings v) { return not-sksl; }")
+        }
+        assertTrue(!exception.message.isNullOrEmpty(), "Expected the SkSL compiler error")
+    }
+
+    @Test
+    fun specificationRejectsMisalignedVertexStride() {
+        val exception = assertFailsWith<IllegalArgumentException> {
+            makeSpecification(vertexStride = VERTEX_STRIDE + 2)
+        }
+        assertTrue(!exception.message.isNullOrEmpty(), "Expected the reason the stride was rejected")
+    }
+
+    @Test
+    fun buffersReportSizeInBytes() {
+        MeshVertexBuffer.make(vertexData(QUAD_TRIANGLES)).use { vertexBuffer ->
+            assertEquals(6 * VERTEX_STRIDE, vertexBuffer.size)
+        }
+        MeshIndexBuffer.make(QUAD_INDICES).use { indexBuffer ->
+            assertEquals(2 * QUAD_INDICES.size, indexBuffer.size)
+        }
+    }
+
+    @Test
+    fun drawsMesh() {
+        makeSpecification().use { specification ->
+            MeshVertexBuffer.make(vertexData(QUAD_TRIANGLES)).use { vertexBuffer ->
+                brightnessUniforms(specification, 1f).use { uniforms ->
+                    Mesh.make(
+                        specification = specification,
+                        mode = Mesh.Mode.TRIANGLES,
+                        vertexBuffer = vertexBuffer,
+                        vertexCount = 6,
+                        bounds = BOUNDS,
+                        uniforms = uniforms
+                    ).use { mesh ->
+                        // An empty recording as the control for the op count below.
+                        assertEquals(0, recordedOpCount { })
+                        assertEquals(1, recordedOpCount { canvas ->
+                            canvas.drawMesh(mesh, BlendMode.SRC, Paint())
+                        })
+
+                        val pixels = drawOnRasterSurface { canvas ->
+                            canvas.drawMesh(mesh, BlendMode.SRC, Paint())
+                        }
+                        assertEquals(Color.WHITE, pixels.getColor(0, 0), "Drew outside the mesh bounds")
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun drawsIndexedMesh() {
+        makeSpecification().use { specification ->
+            MeshVertexBuffer.make(vertexData(QUAD_CORNERS)).use { vertexBuffer ->
+                MeshIndexBuffer.make(QUAD_INDICES).use { indexBuffer ->
+                    brightnessUniforms(specification, 1f).use { uniforms ->
+                        Blender.makeMode(BlendMode.SRC).use { blender ->
+                            Mesh.makeIndexed(
+                                specification = specification,
+                                mode = Mesh.Mode.TRIANGLES,
+                                vertexBuffer = vertexBuffer,
+                                vertexCount = 4,
+                                indexBuffer = indexBuffer,
+                                indexCount = QUAD_INDICES.size,
+                                bounds = BOUNDS,
+                                uniforms = uniforms
+                            ).use { mesh ->
+                                assertEquals(1, recordedOpCount { canvas ->
+                                    canvas.drawMesh(mesh, blender, Paint())
+                                })
+
+                                val pixels = drawOnRasterSurface { canvas ->
+                                    canvas.drawMesh(mesh, blender, Paint())
+                                }
+                                assertEquals(Color.WHITE, pixels.getColor(0, 0), "Drew outside the mesh bounds")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun uniformBuilderWritesEachUniformAtItsOwnOffset() {
+        makeSpecification().use { specification ->
+            MeshUniformBuilder(specification).use { builder ->
+                val unwritten = builder.build().use { it.bytes }
+                assertEquals(8, unwritten.size, "The specification declares two float uniforms")
+                assertContentEquals(ByteArray(8), unwritten, "Unset uniforms hold zeroes")
+
+                builder.uniform(BRIGHTNESS, 0.75f)
+                val written = builder.build().use { it.bytes }
+                assertEquals(8, written.size)
+                assertEquals(0f, written.floatAt(0), "'$BASE' was never written")
+                assertEquals(0.75f, written.floatAt(1))
+
+                builder.uniform(BASE, 0.5f)
+                builder.uniform(BRIGHTNESS, 0.25f)
+                val rewritten = builder.build().use { it.bytes }
+                assertEquals(0.5f, rewritten.floatAt(0))
+                assertEquals(0.25f, rewritten.floatAt(1))
+            }
+        }
+    }
+
+    @Test
+    fun uniformBuilderRejectsUnknownUniform() {
+        makeSpecification().use { specification ->
+            MeshUniformBuilder(specification).use { builder ->
+                val fromFloats = assertFailsWith<IllegalArgumentException> {
+                    builder.uniform("noSuchUniform", 1f)
+                }
+                assertTrue(
+                    fromFloats.message!!.contains("noSuchUniform"),
+                    "Expected the rejected name in: ${fromFloats.message}"
+                )
+
+                // Integer values reach Skia through an entry point of their own.
+                val fromInts = assertFailsWith<IllegalArgumentException> {
+                    builder.uniform("noSuchUniform", 1)
+                }
+                assertTrue(
+                    fromInts.message!!.contains("noSuchUniform"),
+                    "Expected the rejected name in: ${fromInts.message}"
+                )
+            }
+        }
+    }
+
+    @Test
+    fun uniformBuilderRejectsValueOfWrongWidth() {
+        makeSpecification().use { specification ->
+            MeshUniformBuilder(specification).use { builder ->
+                // Two values against a one-float uniform: the name resolves, the width does not.
+                val fromFloats = assertFailsWith<IllegalArgumentException> {
+                    builder.uniform(BRIGHTNESS, 1f, 1f)
+                }
+                assertTrue(
+                    fromFloats.message!!.contains("'$BRIGHTNESS' is not 2 values wide"),
+                    "Expected a width mismatch rather than an unknown name in: ${fromFloats.message}"
+                )
+
+                val fromInts = assertFailsWith<IllegalArgumentException> {
+                    builder.uniform(BRIGHTNESS, 1, 1)
+                }
+                assertTrue(
+                    fromInts.message!!.contains("'$BRIGHTNESS' is not 2 values wide"),
+                    "Expected a width mismatch rather than an unknown name in: ${fromInts.message}"
+                )
+            }
+        }
+    }
+
+    @Test
+    fun uniformBuilderRejectsValueOfTheWrongKind() {
+        makeLayoutSpecification().use { specification ->
+            MeshUniformBuilder(specification).use { builder ->
+                // An int and a float are both four bytes, so only the declared type separates them.
+                val intoInts = assertFailsWith<IllegalArgumentException> {
+                    builder.uniform("steps", 1f, 1f)
+                }
+                assertTrue(
+                    intoInts.message!!.contains("'steps' does not hold floating point values"),
+                    "Expected a kind mismatch rather than a width mismatch in: ${intoInts.message}"
+                )
+
+                val intoFloats = assertFailsWith<IllegalArgumentException> {
+                    builder.uniform("offset", 1, 1)
+                }
+                assertTrue(
+                    intoFloats.message!!.contains("'offset' does not hold integer values"),
+                    "Expected a kind mismatch rather than a width mismatch in: ${intoFloats.message}"
+                )
+
+                // A half uniform holds floating point values, so it takes floats.
+                builder.uniform("brightness", 1f)
+            }
+        }
+    }
+
+    @Test
+    fun meshRejectsMissingUniforms() {
+        makeSpecification().use { specification ->
+            MeshVertexBuffer.make(vertexData(QUAD_TRIANGLES)).use { vertexBuffer ->
+                val exception = assertFailsWith<IllegalArgumentException> {
+                    Mesh.make(
+                        specification = specification,
+                        mode = Mesh.Mode.TRIANGLES,
+                        vertexBuffer = vertexBuffer,
+                        vertexCount = 6,
+                        bounds = BOUNDS
+                    )
+                }
+                assertTrue(!exception.message.isNullOrEmpty(), "Expected the size the uniforms must have")
+            }
+        }
+    }
+
+    @Test
+    fun meshRejectsVertexCountOfZero() {
+        makeSpecification().use { specification ->
+            MeshVertexBuffer.make(vertexData(QUAD_TRIANGLES)).use { vertexBuffer ->
+                brightnessUniforms(specification, 1f).use { uniforms ->
+                    val exception = assertFailsWith<IllegalArgumentException> {
+                        Mesh.make(
+                            specification = specification,
+                            mode = Mesh.Mode.TRIANGLES,
+                            vertexBuffer = vertexBuffer,
+                            vertexCount = 0,
+                            bounds = BOUNDS,
+                            uniforms = uniforms
+                        )
+                    }
+                    assertTrue(!exception.message.isNullOrEmpty(), "Expected the reason the mesh was rejected")
+                }
+            }
+        }
+    }
+
+    @Test
+    fun specificationReportsItsAttributes() {
+        makeSpecification().use { specification ->
+            assertContentEquals(ATTRIBUTES.toList(), specification.attributes)
+            assertEquals(ATTRIBUTES[1], specification.findAttribute("color"))
+            assertNull(specification.findAttribute("noSuchAttribute"))
+        }
+    }
+
+    @Test
+    fun specificationReportsTheImplicitPositionVarying() {
+        makeSpecification().use { specification ->
+            assertEquals(VARYINGS[0], specification.findVarying("color"))
+            // The specification was not given a position varying, so Skia added one.
+            assertEquals(
+                MeshSpecification.Varying(MeshSpecification.Varying.Type.FLOAT2, "position"),
+                specification.findVarying("position")
+            )
+            assertNull(specification.findVarying("noSuchVarying"))
+        }
+    }
+
+    @Test
+    fun specificationReportsWhereEachUniformValueBelongs() {
+        makeLayoutSpecification().use { specification ->
+            val uniforms = specification.uniforms
+            assertEquals(uniforms.size, uniforms.map { it.name }.distinct().size, "Names repeat")
+            assertEquals(uniforms.sumOf { it.sizeInBytes }, specification.uniformSize)
+            for (uniform in uniforms) {
+                assertEquals(uniform, specification.findUniform(uniform.name))
+                assertEquals(0, uniform.offset % 4, "'${uniform.name}' is misaligned")
+                assertTrue(
+                    uniform.offset + uniform.sizeInBytes <= specification.uniformSize,
+                    "'${uniform.name}' runs past the end of the uniform data"
+                )
+            }
+            assertNull(specification.findUniform("noSuchUniform"))
+
+            val offset = specification.findUniform("offset")!!
+            assertEquals(MeshSpecification.Uniform.Type.FLOAT2, offset.type)
+            assertEquals(8, offset.sizeInBytes)
+            assertTrue(offset.isVertex, "'offset' is declared by the vertex program")
+
+            // Half precision values are stored at full width, so 'brightness' is four bytes.
+            val brightness = specification.findUniform("brightness")!!
+            assertEquals(MeshSpecification.Uniform.Type.FLOAT, brightness.type)
+            assertEquals(4, brightness.sizeInBytes)
+            assertTrue(brightness.isHalfPrecision, "'brightness' is declared half")
+            assertTrue(brightness.isFragment, "'brightness' is declared by the fragment program")
+
+            // Values are packed tightly rather than padded out to four components.
+            assertEquals(12, specification.findUniform("tintRgb")!!.sizeInBytes)
+            assertEquals(36, specification.findUniform("warp")!!.sizeInBytes)
+
+            val steps = specification.findUniform("steps")!!
+            assertEquals(MeshSpecification.Uniform.Type.INT2, steps.type)
+            assertEquals(8, steps.sizeInBytes)
+
+            val weights = specification.findUniform("weights")!!
+            assertTrue(weights.isArray, "'weights' is declared as an array")
+            assertEquals(3, weights.count)
+            assertEquals(12, weights.sizeInBytes)
+
+            assertTrue(specification.findUniform("tint")!!.isColor, "'tint' is declared layout(color)")
+        }
+    }
+
+    @Test
+    fun specificationWithoutUniformsReportsNone() {
+        makeMinimalSpecification().use { specification ->
+            assertEquals(0, specification.uniformSize)
+            assertEquals(emptyList(), specification.uniforms)
+            assertEquals(emptyList(), specification.children)
+        }
+    }
+
+    @Test
+    fun specificationReportsTheChildrenItsProgramsDeclare() {
+        makeChildSpecification().use { specification ->
+            assertEquals(
+                listOf(
+                    MeshSpecification.Child("tex", MeshSpecification.Child.Type.SHADER, 0),
+                    MeshSpecification.Child("filter", MeshSpecification.Child.Type.COLOR_FILTER, 1),
+                    MeshSpecification.Child("blend", MeshSpecification.Child.Type.BLENDER, 2),
+                ),
+                specification.children
+            )
+            assertEquals(specification.children[1], specification.findChild("filter"))
+            assertNull(specification.findChild("noSuchChild"))
+        }
+    }
+
+    @Test
+    fun specificationCarriesAColorSpaceOnlyWhenItsFragmentProgramOutputsColor() {
+        makeSpecification().use { specification ->
+            // The fragment program outputs a color and no color space was named, so it is sRGB.
+            val colorSpace = assertNotNull(specification.colorSpace)
+            colorSpace.use { assertTrue(it.isSRGB) }
+        }
+        makeMinimalSpecification().use { specification ->
+            assertNull(specification.colorSpace, "A fragment program without color needs no color space")
+        }
+    }
+
+    @Test
+    fun meshReportsWhatItWasMadeFrom() {
+        makeSpecification().use { specification ->
+            MeshVertexBuffer.make(vertexData(QUAD_TRIANGLES)).use { vertexBuffer ->
+                brightnessUniforms(specification, 1f).use { uniforms ->
+                    Mesh.make(
+                        specification = specification,
+                        mode = Mesh.Mode.TRIANGLE_STRIP,
+                        vertexBuffer = vertexBuffer,
+                        vertexCount = 4,
+                        bounds = BOUNDS,
+                        vertexOffset = VERTEX_STRIDE,
+                        uniforms = uniforms
+                    ).use { mesh ->
+                        assertEquals(Mesh.Mode.TRIANGLE_STRIP, mesh.mode, "mode")
+                        assertEquals(4, mesh.vertexCount, "vertexCount")
+                        assertEquals(VERTEX_STRIDE, mesh.vertexOffset, "vertexOffset")
+                        assertEquals(BOUNDS, mesh.bounds, "bounds")
+                        assertNull(mesh.indexBuffer, "The mesh is not indexed")
+                        assertEquals(0, mesh.indexCount, "indexCount of a mesh that is not indexed")
+                        assertEquals(0, mesh.indexOffset, "indexOffset of a mesh that is not indexed")
+                        mesh.specification.use { assertEquals(VERTEX_STRIDE, it.stride, "specification") }
+                        mesh.vertexBuffer.use { assertEquals(vertexBuffer.size, it.size, "vertexBuffer") }
+                        mesh.uniforms.use { assertContentEquals(uniforms.bytes, it.bytes, "uniforms") }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun indexedMeshReportsItsIndexBuffer() {
+        makeSpecification().use { specification ->
+            MeshVertexBuffer.make(vertexData(QUAD_CORNERS)).use { vertexBuffer ->
+                MeshIndexBuffer.make(QUAD_INDICES).use { indexBuffer ->
+                    brightnessUniforms(specification, 1f).use { uniforms ->
+                        Mesh.makeIndexed(
+                            specification = specification,
+                            mode = Mesh.Mode.TRIANGLES,
+                            vertexBuffer = vertexBuffer,
+                            vertexCount = 4,
+                            indexBuffer = indexBuffer,
+                            indexCount = QUAD_INDICES.size,
+                            bounds = BOUNDS,
+                            uniforms = uniforms
+                        ).use { mesh ->
+                            assertEquals(QUAD_INDICES.size, mesh.indexCount, "indexCount")
+                            assertEquals(0, mesh.indexOffset, "indexOffset")
+                            assertNotNull(mesh.indexBuffer).use {
+                                assertEquals(indexBuffer.size, it.size)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun meshBindsShaderColorFilterAndBlenderChildren() {
+        makeChildSpecification().use { specification ->
+            MeshVertexBuffer.make(vertexData(QUAD_TRIANGLES)).use { vertexBuffer ->
+                Shader.makeColor(Color.RED).use { shader ->
+                    ColorFilter.makeBlend(Color.GREEN, BlendMode.SRC_OVER)!!.use { colorFilter ->
+                        Blender.makeMode(BlendMode.SRC).use { blender ->
+                            Mesh.make(
+                                specification = specification,
+                                mode = Mesh.Mode.TRIANGLES,
+                                vertexBuffer = vertexBuffer,
+                                vertexCount = 6,
+                                bounds = BOUNDS,
+                                children = arrayOf(shader, colorFilter, blender)
+                            ).use { mesh ->
+                                assertEquals(1, recordedOpCount { canvas ->
+                                    canvas.drawMesh(mesh, BlendMode.SRC, Paint())
+                                })
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun meshRejectsAChildOfTheWrongKind() {
+        makeChildSpecification().use { specification ->
+            MeshVertexBuffer.make(vertexData(QUAD_TRIANGLES)).use { vertexBuffer ->
+                Blender.makeMode(BlendMode.SRC).use { blender ->
+                    val exception = assertFailsWith<IllegalArgumentException> {
+                        Mesh.make(
+                            specification = specification,
+                            mode = Mesh.Mode.TRIANGLES,
+                            vertexBuffer = vertexBuffer,
+                            vertexCount = 6,
+                            bounds = BOUNDS,
+                            // 'tex' is declared as a shader.
+                            children = arrayOf(blender, null, null)
+                        )
+                    }
+                    assertTrue(!exception.message.isNullOrEmpty(), "Expected the reason the child was rejected")
+                }
+            }
+        }
+    }
+
+    @Test
+    fun vertexBufferFilledFromFloatsDrawsTheSameMesh() {
+        makeSpecification().use { specification ->
+            MeshVertexBuffer.make(vertexFloats(QUAD_TRIANGLES)).use { vertexBuffer ->
+                assertEquals(6 * VERTEX_STRIDE, vertexBuffer.size)
+                brightnessUniforms(specification, 1f).use { uniforms ->
+                    // Skia checks the buffer against the stride and the vertex count, so a mesh it
+                    // accepts is one the floats were laid out correctly for.
+                    Mesh.make(
+                        specification = specification,
+                        mode = Mesh.Mode.TRIANGLES,
+                        vertexBuffer = vertexBuffer,
+                        vertexCount = 6,
+                        bounds = BOUNDS,
+                        uniforms = uniforms
+                    ).use { mesh ->
+                        assertEquals(1, recordedOpCount { canvas ->
+                            canvas.drawMesh(mesh, BlendMode.SRC, Paint())
+                        })
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun rasterizesMeshOnAGpuSurface() {
+        if (!TestGlContext.isAvailable()) return
+
+        makeSpecification().use { specification ->
+            MeshVertexBuffer.make(vertexData(QUAD_TRIANGLES)).use { vertexBuffer ->
+                brightnessUniforms(specification, 1f).use { uniforms ->
+                    Mesh.make(
+                        specification = specification,
+                        mode = Mesh.Mode.TRIANGLES,
+                        vertexBuffer = vertexBuffer,
+                        vertexCount = 6,
+                        bounds = BOUNDS,
+                        uniforms = uniforms
+                    ).use { mesh ->
+                        val pixels = TestGlContext.run {
+                            DirectContext.makeGL().useContext { context ->
+                                Surface.makeRenderTarget(
+                                    context,
+                                    budgeted = false,
+                                    ImageInfo.makeN32Premul(SURFACE_SIZE, SURFACE_SIZE)
+                                ).use { surface ->
+                                    surface.canvas.clear(Color.WHITE)
+                                    Paint().use { paint ->
+                                        surface.canvas.drawMesh(mesh, BlendMode.SRC, paint)
+                                    }
+                                    surface.makeImageSnapshot().use { Bitmap.makeFromImage(it, context) }
+                                }
+                            }
+                        }
+                        pixels.use {
+                            val inside = it.getColor(SURFACE_SIZE / 2, SURFACE_SIZE / 2)
+                            assertNotEquals(Color.WHITE, inside, "The mesh left the surface unchanged")
+                            assertEquals(0xFF, Color.getA(inside), "Expected an opaque mesh pixel")
+                            assertEquals(Color.WHITE, it.getColor(0, 0), "Drew outside the mesh bounds")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private const val SURFACE_SIZE = 16
+
+// The quad is inset far enough that the corners of the surface stay outside it.
+private const val QUAD_MIN = 2f
+private const val QUAD_MAX = 14f
+
+private val BOUNDS = Rect.makeLTRB(0f, 0f, SURFACE_SIZE.toFloat(), SURFACE_SIZE.toFloat())
+
+/** Two triangles in buffer order. */
+private val QUAD_TRIANGLES = floatArrayOf(
+    QUAD_MIN, QUAD_MIN, QUAD_MAX, QUAD_MIN, QUAD_MIN, QUAD_MAX,
+    QUAD_MAX, QUAD_MIN, QUAD_MAX, QUAD_MAX, QUAD_MIN, QUAD_MAX,
+)
+
+/** The same quad as four corners, for the indexed mesh. */
+private val QUAD_CORNERS = floatArrayOf(
+    QUAD_MIN, QUAD_MIN, QUAD_MAX, QUAD_MIN, QUAD_MIN, QUAD_MAX, QUAD_MAX, QUAD_MAX,
+)
+
+private val QUAD_INDICES = shortArrayOf(0, 1, 2, 1, 3, 2)
+
+// The fragment program declares "base" before "brightness" and uniforms are packed in declaration
+// order, so "brightness" sits at a non-zero offset in the buffer the builder produces.
+private const val BASE = "base"
+private const val BRIGHTNESS = "brightness"
+
+/** Eight bytes larger than the attributes it carries, so that the stride is not the packed size. */
+private const val VERTEX_STRIDE = 32
+
+private val ATTRIBUTES = arrayOf(
+    MeshSpecification.Attribute(MeshSpecification.Attribute.Type.FLOAT2, 0, "pos"),
+    MeshSpecification.Attribute(MeshSpecification.Attribute.Type.FLOAT4, 8, "color"),
+)
+
+private val VARYINGS = arrayOf(
+    MeshSpecification.Varying(MeshSpecification.Varying.Type.FLOAT4, "color"),
+)
+
+private const val VERTEX_SHADER = """
+    Varyings main(const Attributes a) {
+        Varyings v;
+        v.position = a.pos;
+        v.color = a.color;
+        return v;
+    }
+"""
+
+private const val FRAGMENT_SHADER = """
+    uniform float base;
+    uniform float brightness;
+    float2 main(const Varyings v, out float4 color) {
+        color = float4(v.color.rgb * brightness + base, v.color.a);
+        return v.position;
+    }
+"""
+
+private fun makeSpecification(
+    vertexShader: String = VERTEX_SHADER,
+    fragmentShader: String = FRAGMENT_SHADER,
+    vertexStride: Int = VERTEX_STRIDE
+): MeshSpecification = MeshSpecification.make(
+    attributes = ATTRIBUTES,
+    vertexStride = vertexStride,
+    varyings = VARYINGS,
+    vertexShader = vertexShader,
+    fragmentShader = fragmentShader
+    // The fragment program has a color out parameter, so Skia needs a color space: the default
+    // stands in for the sRGB one it would otherwise reject the specification for missing.
+)
+
+private fun brightnessUniforms(specification: MeshSpecification, brightness: Float): Data =
+    MeshUniformBuilder(specification).use { builder ->
+        builder.uniform(BRIGHTNESS, brightness)
+        builder.build()
+    }
+
+/**
+ * Lays out [positions], a sequence of x and y pairs, as vertices of [VERTEX_STRIDE] bytes: the
+ * position, an opaque red color, and padding the specification does not read.
+ */
+private fun vertexFloats(positions: FloatArray): FloatArray {
+    val floatsPerVertex = VERTEX_STRIDE / 4
+    val floats = FloatArray(positions.size / 2 * floatsPerVertex)
+    for (vertex in 0 until positions.size / 2) {
+        val base = vertex * floatsPerVertex
+        floats[base] = positions[vertex * 2]
+        floats[base + 1] = positions[vertex * 2 + 1]
+        floats[base + 2] = 1f  // red
+        floats[base + 5] = 1f  // alpha
+    }
+    return floats
+}
+
+private fun vertexData(positions: FloatArray): ByteArray = vertexFloats(positions).toBytes()
+
+/** A specification declaring one uniform of every shape the reflection has to describe. */
+private fun makeLayoutSpecification(): MeshSpecification = MeshSpecification.make(
+    attributes = ATTRIBUTES,
+    vertexStride = VERTEX_STRIDE,
+    varyings = VARYINGS,
+    vertexShader = """
+        uniform float2 offset;
+        Varyings main(const Attributes a) {
+            Varyings v;
+            v.position = a.pos + offset;
+            v.color = a.color;
+            return v;
+        }
+    """,
+    fragmentShader = """
+        uniform half brightness;
+        uniform float3 tintRgb;
+        uniform float3x3 warp;
+        uniform int2 steps;
+        uniform float weights[3];
+        layout(color) uniform float4 tint;
+        float2 main(const Varyings v, out float4 color) {
+            float3 warped = warp * tintRgb;
+            float weighted = weights[0] + weights[1] + weights[2] + float(steps.x + steps.y);
+            color = float4(warped * brightness + weighted, 1) * tint;
+            return v.position;
+        }
+    """
+)
+
+/** A specification declaring one child of every kind, in the order they are reported. */
+private fun makeChildSpecification(): MeshSpecification = MeshSpecification.make(
+    attributes = ATTRIBUTES,
+    vertexStride = VERTEX_STRIDE,
+    varyings = VARYINGS,
+    vertexShader = VERTEX_SHADER,
+    fragmentShader = """
+        uniform shader tex;
+        uniform colorFilter filter;
+        uniform blender blend;
+        float2 main(const Varyings v, out float4 color) {
+            color = blend.eval(filter.eval(tex.eval(v.position)), v.color);
+            return v.position;
+        }
+    """
+)
+
+/** A specification with no uniforms and no children, whose fragment program returns no color. */
+private fun makeMinimalSpecification(): MeshSpecification = MeshSpecification.make(
+    attributes = ATTRIBUTES,
+    vertexStride = VERTEX_STRIDE,
+    varyings = VARYINGS,
+    vertexShader = VERTEX_SHADER,
+    fragmentShader = "float2 main(const Varyings v) { return v.position; }"
+)
+
+private fun recordedOpCount(draw: (Canvas) -> Unit): Int = PictureRecorder().use { recorder ->
+    draw(recorder.beginRecording(BOUNDS))
+    recorder.finishRecordingAsPicture().use { it.approximateOpCount }
+}
+
+private fun drawOnRasterSurface(draw: (Canvas) -> Unit): Bitmap =
+    Surface.makeRasterN32Premul(SURFACE_SIZE, SURFACE_SIZE).use { surface ->
+        surface.canvas.clear(Color.WHITE)
+        draw(surface.canvas)
+        surface.makeImageSnapshot().use { Bitmap.makeFromImage(it) }
+    }
+
+/** Skia reads buffers and uniform data in the byte order of the host, which is little-endian. */
+private fun FloatArray.toBytes(): ByteArray {
+    val bytes = ByteArray(size * 4)
+    for (i in indices) {
+        val bits = this[i].toRawBits()
+        bytes[i * 4] = bits.toByte()
+        bytes[i * 4 + 1] = (bits ushr 8).toByte()
+        bytes[i * 4 + 2] = (bits ushr 16).toByte()
+        bytes[i * 4 + 3] = (bits ushr 24).toByte()
+    }
+    return bytes
+}
+
+private fun ByteArray.floatAt(index: Int): Float {
+    var bits = 0
+    for (byte in 3 downTo 0) {
+        bits = (bits shl 8) or (this[index * 4 + byte].toInt() and 0xFF)
+    }
+    return Float.fromBits(bits)
+}

--- a/skiko/src/jvmMain/cpp/common/Canvas.cc
+++ b/skiko/src/jvmMain/cpp/common/Canvas.cc
@@ -1,6 +1,8 @@
 #include <iostream>
 #include <jni.h>
+#include "SkBlender.h"
 #include "SkCanvas.h"
+#include "SkMesh.h"
 #include "SkRRect.h"
 #include "SkTextBlob.h"
 #include "SkVertices.h"
@@ -187,6 +189,25 @@ extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_CanvasKt__1nDrawVertic
         env->ReleaseShortArrayElements(indexArr, const_cast<jshort*>(indices), 0);
     }
     env->ReleaseFloatArrayElements(positionsArr, positions, 0);
+}
+
+extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_CanvasKt__1nDrawMesh
+  (JNIEnv* env, jclass jclass, jlong ptr, jlong meshPtr, jlong blenderPtr, jlong paintPtr) {
+    SkCanvas* canvas = reinterpret_cast<SkCanvas*>(static_cast<uintptr_t>(ptr));
+    SkMesh* mesh = reinterpret_cast<SkMesh*>(static_cast<uintptr_t>(meshPtr));
+    SkBlender* blender = reinterpret_cast<SkBlender*>(static_cast<uintptr_t>(blenderPtr));
+    SkPaint* paint = reinterpret_cast<SkPaint*>(static_cast<uintptr_t>(paintPtr));
+
+    canvas->drawMesh(*mesh, sk_ref_sp(blender), *paint);
+}
+
+extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_CanvasKt__1nDrawMeshBlendMode
+  (JNIEnv* env, jclass jclass, jlong ptr, jlong meshPtr, jint blendMode, jlong paintPtr) {
+    SkCanvas* canvas = reinterpret_cast<SkCanvas*>(static_cast<uintptr_t>(ptr));
+    SkMesh* mesh = reinterpret_cast<SkMesh*>(static_cast<uintptr_t>(meshPtr));
+    SkPaint* paint = reinterpret_cast<SkPaint*>(static_cast<uintptr_t>(paintPtr));
+
+    canvas->drawMesh(*mesh, SkBlender::Mode(static_cast<SkBlendMode>(blendMode)), *paint);
 }
 
 extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_CanvasKt__1nDrawPatch

--- a/skiko/src/jvmMain/cpp/common/Mesh.cc
+++ b/skiko/src/jvmMain/cpp/common/Mesh.cc
@@ -1,0 +1,404 @@
+#include <jni.h>
+#include <utility>
+#include <vector>
+
+#include "MeshInterop.hh"
+#include "SkColorSpace.h"
+#include "SkData.h"
+#include "SkMesh.h"
+#include "SkRect.h"
+#include "SkSpan.h"
+#include "interop.hh"
+
+// SkMeshSpecification is an SkNVRefCnt, so it cannot share the generic RefCnt finalizer.
+static void deleteMeshSpecification(SkMeshSpecification* specification) {
+    specification->unref();
+}
+
+extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_MeshSpecificationKt_MeshSpecification_1nGetFinalizer
+  (JNIEnv* env, jclass jclass) {
+    return static_cast<jlong>(reinterpret_cast<uintptr_t>(&deleteMeshSpecification));
+}
+
+extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_MeshSpecificationKt_MeshSpecification_1nMake
+  (JNIEnv* env, jclass jclass, jintArray attributeTypesAndOffsetsArr, jobjectArray attributeNamesArr, jint attributeCount,
+   jint vertexStride, jintArray varyingTypesArr, jobjectArray varyingNamesArr, jint varyingCount,
+   jstring vertexShader, jstring fragmentShader, jlong colorSpacePtr, jint alphaType) {
+    std::vector<SkString> attributeNames = skStringVector(env, attributeNamesArr);
+    std::vector<SkString> varyingNames = skStringVector(env, varyingNamesArr);
+
+    // Every attribute is encoded as 2 ints: its type ordinal and its byte offset.
+    jint* attributeTypesAndOffsets = env->GetIntArrayElements(attributeTypesAndOffsetsArr, 0);
+    std::vector<SkMeshSpecification::Attribute> attributes;
+    attributes.reserve(attributeCount);
+    for (jint i = 0; i < attributeCount; ++i) {
+        attributes.push_back({
+            static_cast<SkMeshSpecification::Attribute::Type>(attributeTypesAndOffsets[2 * i]),
+            static_cast<size_t>(attributeTypesAndOffsets[2 * i + 1]),
+            attributeNames[i]
+        });
+    }
+    env->ReleaseIntArrayElements(attributeTypesAndOffsetsArr, attributeTypesAndOffsets, 0);
+
+    jint* varyingTypes = env->GetIntArrayElements(varyingTypesArr, 0);
+    std::vector<SkMeshSpecification::Varying> varyings;
+    varyings.reserve(varyingCount);
+    for (jint i = 0; i < varyingCount; ++i) {
+        varyings.push_back({
+            static_cast<SkMeshSpecification::Varying::Type>(varyingTypes[i]),
+            varyingNames[i]
+        });
+    }
+    env->ReleaseIntArrayElements(varyingTypesArr, varyingTypes, 0);
+
+    // Skia rejects a null color space when the fragment program outputs a color, so a missing one
+    // becomes sRGB, which is what Skia's own shorter Make overloads pass.
+    SkColorSpace* colorSpace = jlongToPtr<SkColorSpace*>(colorSpacePtr);
+    SkMeshSpecification::Result result = SkMeshSpecification::Make(
+        SkSpan(attributes),
+        static_cast<size_t>(vertexStride),
+        SkSpan(varyings),
+        skString(env, vertexShader),
+        skString(env, fragmentShader),
+        colorSpace ? sk_ref_sp(colorSpace) : SkColorSpace::MakeSRGB(),
+        static_cast<SkAlphaType>(alphaType));
+    return ptrToJlong(new SkMeshSpecification::Result{std::move(result)});
+}
+
+extern "C" JNIEXPORT jint JNICALL Java_org_jetbrains_skia_MeshSpecificationKt_MeshSpecification_1nGetStride
+  (JNIEnv* env, jclass jclass, jlong ptr) {
+    SkMeshSpecification* instance = jlongToPtr<SkMeshSpecification*>(ptr);
+    return static_cast<jint>(instance->stride());
+}
+
+extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_MeshSpecificationKt_MeshSpecification_1nGetColorSpace
+  (JNIEnv* env, jclass jclass, jlong ptr) {
+    SkMeshSpecification* instance = jlongToPtr<SkMeshSpecification*>(ptr);
+    return ptrToJlong(sk_ref_sp(instance->colorSpace()).release());
+}
+
+extern "C" JNIEXPORT jint JNICALL Java_org_jetbrains_skia_MeshSpecificationKt_MeshSpecification_1nGetAttributeCount
+  (JNIEnv* env, jclass jclass, jlong ptr) {
+    SkMeshSpecification* instance = jlongToPtr<SkMeshSpecification*>(ptr);
+    return static_cast<jint>(instance->attributes().size());
+}
+
+extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_MeshSpecificationKt_MeshSpecification_1nGetAttributeFields
+  (JNIEnv* env, jclass jclass, jlong ptr, jintArray resultArray) {
+    SkMeshSpecification* instance = jlongToPtr<SkMeshSpecification*>(ptr);
+    SkSpan<const SkMeshSpecification::Attribute> attributes = instance->attributes();
+    jint* fields = env->GetIntArrayElements(resultArray, 0);
+    for (size_t i = 0; i < attributes.size(); ++i) {
+        fields[2 * i] = static_cast<jint>(attributes[i].type);
+        fields[2 * i + 1] = static_cast<jint>(attributes[i].offset);
+    }
+    env->ReleaseIntArrayElements(resultArray, fields, 0);
+}
+
+extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_MeshSpecificationKt_MeshSpecification_1nGetAttributeName
+  (JNIEnv* env, jclass jclass, jlong ptr, jint index) {
+    SkMeshSpecification* instance = jlongToPtr<SkMeshSpecification*>(ptr);
+    return ptrToJlong(new SkString(instance->attributes()[index].name));
+}
+
+extern "C" JNIEXPORT jint JNICALL Java_org_jetbrains_skia_MeshSpecificationKt_MeshSpecification_1nGetUniformSize
+  (JNIEnv* env, jclass jclass, jlong ptr) {
+    SkMeshSpecification* instance = jlongToPtr<SkMeshSpecification*>(ptr);
+    return static_cast<jint>(instance->uniformSize());
+}
+
+extern "C" JNIEXPORT jint JNICALL Java_org_jetbrains_skia_MeshSpecificationKt_MeshSpecification_1nGetUniformCount
+  (JNIEnv* env, jclass jclass, jlong ptr) {
+    SkMeshSpecification* instance = jlongToPtr<SkMeshSpecification*>(ptr);
+    return static_cast<jint>(instance->uniforms().size());
+}
+
+extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_MeshSpecificationKt_MeshSpecification_1nGetUniformFields
+  (JNIEnv* env, jclass jclass, jlong ptr, jintArray resultArray) {
+    SkMeshSpecification* instance = jlongToPtr<SkMeshSpecification*>(ptr);
+    SkSpan<const SkMeshSpecification::Uniform> uniforms = instance->uniforms();
+    jint* fields = env->GetIntArrayElements(resultArray, 0);
+    for (size_t i = 0; i < uniforms.size(); ++i) {
+        jint* uniform = fields + i * kMeshUniformFields;
+        uniform[0] = static_cast<jint>(uniforms[i].offset);
+        uniform[1] = static_cast<jint>(uniforms[i].type);
+        uniform[2] = static_cast<jint>(uniforms[i].count);
+        uniform[3] = static_cast<jint>(uniforms[i].sizeInBytes());
+        uniform[4] = static_cast<jint>(uniforms[i].flags);
+    }
+    env->ReleaseIntArrayElements(resultArray, fields, 0);
+}
+
+extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_MeshSpecificationKt_MeshSpecification_1nGetUniformName
+  (JNIEnv* env, jclass jclass, jlong ptr, jint index) {
+    SkMeshSpecification* instance = jlongToPtr<SkMeshSpecification*>(ptr);
+    // The name is a string view into the program's source, so it is not null terminated.
+    std::string_view name = instance->uniforms()[index].name;
+    return ptrToJlong(new SkString(name.data(), name.size()));
+}
+
+extern "C" JNIEXPORT jint JNICALL Java_org_jetbrains_skia_MeshSpecificationKt_MeshSpecification_1nGetChildCount
+  (JNIEnv* env, jclass jclass, jlong ptr) {
+    SkMeshSpecification* instance = jlongToPtr<SkMeshSpecification*>(ptr);
+    return static_cast<jint>(instance->children().size());
+}
+
+extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_MeshSpecificationKt_MeshSpecification_1nGetChildFields
+  (JNIEnv* env, jclass jclass, jlong ptr, jintArray resultArray) {
+    SkMeshSpecification* instance = jlongToPtr<SkMeshSpecification*>(ptr);
+    SkSpan<const SkMeshSpecification::Child> children = instance->children();
+    jint* fields = env->GetIntArrayElements(resultArray, 0);
+    for (size_t i = 0; i < children.size(); ++i) {
+        fields[2 * i] = static_cast<jint>(children[i].type);
+        fields[2 * i + 1] = static_cast<jint>(children[i].index);
+    }
+    env->ReleaseIntArrayElements(resultArray, fields, 0);
+}
+
+extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_MeshSpecificationKt_MeshSpecification_1nGetChildName
+  (JNIEnv* env, jclass jclass, jlong ptr, jint index) {
+    SkMeshSpecification* instance = jlongToPtr<SkMeshSpecification*>(ptr);
+    // The name is a string view into the program's source, so it is not null terminated.
+    std::string_view name = instance->children()[index].name;
+    return ptrToJlong(new SkString(name.data(), name.size()));
+}
+
+extern "C" JNIEXPORT jint JNICALL Java_org_jetbrains_skia_MeshSpecificationKt_MeshSpecification_1nFindVaryingType
+  (JNIEnv* env, jclass jclass, jlong ptr, jstring name) {
+    SkMeshSpecification* instance = jlongToPtr<SkMeshSpecification*>(ptr);
+    SkString varyingName = skString(env, name);
+    const SkMeshSpecification::Varying* varying = instance->findVarying(varyingName.c_str());
+    return varying ? static_cast<jint>(varying->type) : -1;
+}
+
+extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_MeshSpecificationKt_MeshSpecification_1nResultGetSpecification
+  (JNIEnv* env, jclass jclass, jlong resultPtr) {
+    SkMeshSpecification::Result* result = jlongToPtr<SkMeshSpecification::Result*>(resultPtr);
+    return ptrToJlong(result->specification.release());
+}
+
+extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_MeshSpecificationKt_MeshSpecification_1nResultGetError
+  (JNIEnv* env, jclass jclass, jlong resultPtr) {
+    SkMeshSpecification::Result* result = jlongToPtr<SkMeshSpecification::Result*>(resultPtr);
+    return result->error.isEmpty() ? 0 : ptrToJlong(&result->error);
+}
+
+extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_MeshSpecificationKt_MeshSpecification_1nResultDestroy
+  (JNIEnv* env, jclass jclass, jlong resultPtr) {
+    delete jlongToPtr<SkMeshSpecification::Result*>(resultPtr);
+}
+
+extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_MeshVertexBufferKt_MeshVertexBuffer_1nMake
+  (JNIEnv* env, jclass jclass, jbyteArray dataArr, jint size) {
+    jbyte* data = env->GetByteArrayElements(dataArr, 0);
+    sk_sp<SkMesh::VertexBuffer> buffer = SkMeshes::MakeVertexBuffer(data, static_cast<size_t>(size));
+    env->ReleaseByteArrayElements(dataArr, data, 0);
+    return ptrToJlong(buffer.release());
+}
+
+extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_MeshVertexBufferKt_MeshVertexBuffer_1nMakeFromFloats
+  (JNIEnv* env, jclass jclass, jfloatArray dataArr, jint count) {
+    jfloat* data = env->GetFloatArrayElements(dataArr, 0);
+    sk_sp<SkMesh::VertexBuffer> buffer = SkMeshes::MakeVertexBuffer(data, count * sizeof(float));
+    env->ReleaseFloatArrayElements(dataArr, data, 0);
+    return ptrToJlong(buffer.release());
+}
+
+extern "C" JNIEXPORT jint JNICALL Java_org_jetbrains_skia_MeshVertexBufferKt_MeshVertexBuffer_1nGetSize
+  (JNIEnv* env, jclass jclass, jlong ptr) {
+    SkMesh::VertexBuffer* instance = jlongToPtr<SkMesh::VertexBuffer*>(ptr);
+    return static_cast<jint>(instance->size());
+}
+
+extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_MeshIndexBufferKt_MeshIndexBuffer_1nMake
+  (JNIEnv* env, jclass jclass, jshortArray indicesArr, jint indexCount) {
+    jshort* indices = env->GetShortArrayElements(indicesArr, 0);
+    sk_sp<SkMesh::IndexBuffer> buffer = SkMeshes::MakeIndexBuffer(indices, indexCount * sizeof(uint16_t));
+    env->ReleaseShortArrayElements(indicesArr, indices, 0);
+    return ptrToJlong(buffer.release());
+}
+
+extern "C" JNIEXPORT jint JNICALL Java_org_jetbrains_skia_MeshIndexBufferKt_MeshIndexBuffer_1nGetSize
+  (JNIEnv* env, jclass jclass, jlong ptr) {
+    SkMesh::IndexBuffer* instance = jlongToPtr<SkMesh::IndexBuffer*>(ptr);
+    return static_cast<jint>(instance->size());
+}
+
+// SkMesh is a value type, so the Kotlin peer owns a heap copy.
+static void deleteMesh(SkMesh* mesh) {
+    delete mesh;
+}
+
+static std::vector<SkMesh::ChildPtr> meshChildren(JNIEnv* env, jlongArray childrenPtrsArr, jintArray childTypesArr,
+                                                  jint childCount) {
+    jlong* childrenPtrs = env->GetLongArrayElements(childrenPtrsArr, 0);
+    jint* childTypes = env->GetIntArrayElements(childTypesArr, 0);
+    std::vector<SkMesh::ChildPtr> children;
+    children.reserve(childCount);
+    for (jint i = 0; i < childCount; ++i) {
+        children.push_back(meshChild(jlongToPtr<void*>(childrenPtrs[i]), childTypes[i]));
+    }
+    env->ReleaseIntArrayElements(childTypesArr, childTypes, 0);
+    env->ReleaseLongArrayElements(childrenPtrsArr, childrenPtrs, 0);
+    return children;
+}
+
+extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_MeshKt_Mesh_1nGetFinalizer(JNIEnv* env, jclass jclass) {
+    return static_cast<jlong>(reinterpret_cast<uintptr_t>(&deleteMesh));
+}
+
+extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_MeshKt_Mesh_1nMake
+  (JNIEnv* env, jclass jclass, jlong specificationPtr, jint mode, jlong vertexBufferPtr, jint vertexCount, jint vertexOffset,
+   jlong uniformsPtr, jlongArray childrenPtrsArr, jintArray childTypesArr, jint childCount,
+   jfloat left, jfloat top, jfloat right, jfloat bottom) {
+    std::vector<SkMesh::ChildPtr> children = meshChildren(env, childrenPtrsArr, childTypesArr, childCount);
+    SkMesh::Result result = SkMesh::Make(
+        sk_ref_sp(jlongToPtr<SkMeshSpecification*>(specificationPtr)),
+        static_cast<SkMesh::Mode>(mode),
+        sk_ref_sp(jlongToPtr<SkMesh::VertexBuffer*>(vertexBufferPtr)),
+        static_cast<size_t>(vertexCount),
+        static_cast<size_t>(vertexOffset),
+        meshUniforms(jlongToPtr<const SkData*>(uniformsPtr)),
+        SkSpan(children),
+        SkRect::MakeLTRB(left, top, right, bottom));
+    return ptrToJlong(new SkMesh::Result{std::move(result)});
+}
+
+extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_MeshKt_Mesh_1nMakeIndexed
+  (JNIEnv* env, jclass jclass, jlong specificationPtr, jint mode, jlong vertexBufferPtr, jint vertexCount, jint vertexOffset,
+   jlong indexBufferPtr, jint indexCount, jint indexOffset, jlong uniformsPtr, jlongArray childrenPtrsArr,
+   jintArray childTypesArr, jint childCount, jfloat left, jfloat top, jfloat right, jfloat bottom) {
+    std::vector<SkMesh::ChildPtr> children = meshChildren(env, childrenPtrsArr, childTypesArr, childCount);
+    SkMesh::Result result = SkMesh::MakeIndexed(
+        sk_ref_sp(jlongToPtr<SkMeshSpecification*>(specificationPtr)),
+        static_cast<SkMesh::Mode>(mode),
+        sk_ref_sp(jlongToPtr<SkMesh::VertexBuffer*>(vertexBufferPtr)),
+        static_cast<size_t>(vertexCount),
+        static_cast<size_t>(vertexOffset),
+        sk_ref_sp(jlongToPtr<SkMesh::IndexBuffer*>(indexBufferPtr)),
+        static_cast<size_t>(indexCount),
+        static_cast<size_t>(indexOffset),
+        meshUniforms(jlongToPtr<const SkData*>(uniformsPtr)),
+        SkSpan(children),
+        SkRect::MakeLTRB(left, top, right, bottom));
+    return ptrToJlong(new SkMesh::Result{std::move(result)});
+}
+
+extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_MeshKt_Mesh_1nGetSpecification
+  (JNIEnv* env, jclass jclass, jlong ptr) {
+    SkMesh* instance = jlongToPtr<SkMesh*>(ptr);
+    return ptrToJlong(instance->refSpec().release());
+}
+
+extern "C" JNIEXPORT jint JNICALL Java_org_jetbrains_skia_MeshKt_Mesh_1nGetMode
+  (JNIEnv* env, jclass jclass, jlong ptr) {
+    SkMesh* instance = jlongToPtr<SkMesh*>(ptr);
+    return static_cast<jint>(instance->mode());
+}
+
+extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_MeshKt_Mesh_1nGetVertexBuffer
+  (JNIEnv* env, jclass jclass, jlong ptr) {
+    SkMesh* instance = jlongToPtr<SkMesh*>(ptr);
+    return ptrToJlong(instance->refVertexBuffer().release());
+}
+
+extern "C" JNIEXPORT jint JNICALL Java_org_jetbrains_skia_MeshKt_Mesh_1nGetVertexOffset
+  (JNIEnv* env, jclass jclass, jlong ptr) {
+    SkMesh* instance = jlongToPtr<SkMesh*>(ptr);
+    return static_cast<jint>(instance->vertexOffset());
+}
+
+extern "C" JNIEXPORT jint JNICALL Java_org_jetbrains_skia_MeshKt_Mesh_1nGetVertexCount
+  (JNIEnv* env, jclass jclass, jlong ptr) {
+    SkMesh* instance = jlongToPtr<SkMesh*>(ptr);
+    return static_cast<jint>(instance->vertexCount());
+}
+
+extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_MeshKt_Mesh_1nGetIndexBuffer
+  (JNIEnv* env, jclass jclass, jlong ptr) {
+    SkMesh* instance = jlongToPtr<SkMesh*>(ptr);
+    return ptrToJlong(instance->refIndexBuffer().release());
+}
+
+extern "C" JNIEXPORT jint JNICALL Java_org_jetbrains_skia_MeshKt_Mesh_1nGetIndexOffset
+  (JNIEnv* env, jclass jclass, jlong ptr) {
+    SkMesh* instance = jlongToPtr<SkMesh*>(ptr);
+    return static_cast<jint>(instance->indexOffset());
+}
+
+extern "C" JNIEXPORT jint JNICALL Java_org_jetbrains_skia_MeshKt_Mesh_1nGetIndexCount
+  (JNIEnv* env, jclass jclass, jlong ptr) {
+    SkMesh* instance = jlongToPtr<SkMesh*>(ptr);
+    return static_cast<jint>(instance->indexCount());
+}
+
+extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_MeshKt_Mesh_1nGetUniforms
+  (JNIEnv* env, jclass jclass, jlong ptr) {
+    SkMesh* instance = jlongToPtr<SkMesh*>(ptr);
+    // SkData is immutable, so the Kotlin peer may hold a reference to the very same object.
+    return ptrToJlong(const_cast<SkData*>(instance->refUniforms().release()));
+}
+
+extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_MeshKt_Mesh_1nGetBounds
+  (JNIEnv* env, jclass jclass, jlong ptr, jfloatArray resultArray) {
+    SkMesh* instance = jlongToPtr<SkMesh*>(ptr);
+    skija::Rect::copyToInterop(env, instance->bounds(), resultArray);
+}
+
+extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_MeshKt_Mesh_1nResultGetMesh
+  (JNIEnv* env, jclass jclass, jlong resultPtr) {
+    SkMesh::Result* result = jlongToPtr<SkMesh::Result*>(resultPtr);
+    return ptrToJlong(new SkMesh(result->mesh));
+}
+
+extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_MeshKt_Mesh_1nResultGetError
+  (JNIEnv* env, jclass jclass, jlong resultPtr) {
+    SkMesh::Result* result = jlongToPtr<SkMesh::Result*>(resultPtr);
+    return result->error.isEmpty() ? 0 : ptrToJlong(&result->error);
+}
+
+extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skia_MeshKt_Mesh_1nResultDestroy
+  (JNIEnv* env, jclass jclass, jlong resultPtr) {
+    delete jlongToPtr<SkMesh::Result*>(resultPtr);
+}
+
+static void deleteMeshUniformBuilder(MeshUniformBuilder* builder) {
+    delete builder;
+}
+
+extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_MeshUniformBuilderKt_MeshUniformBuilder_1nGetFinalizer
+  (JNIEnv* env, jclass jclass) {
+    return static_cast<jlong>(reinterpret_cast<uintptr_t>(&deleteMeshUniformBuilder));
+}
+
+extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_MeshUniformBuilderKt_MeshUniformBuilder_1nMake
+  (JNIEnv* env, jclass jclass, jlong specificationPtr) {
+    SkMeshSpecification* specification = jlongToPtr<SkMeshSpecification*>(specificationPtr);
+    return ptrToJlong(new MeshUniformBuilder(sk_ref_sp(specification)));
+}
+
+extern "C" JNIEXPORT jint JNICALL Java_org_jetbrains_skia_MeshUniformBuilderKt_MeshUniformBuilder_1nUniformInts
+  (JNIEnv* env, jclass jclass, jlong builderPtr, jstring uniformName, jintArray valuesArr, jint count) {
+    MeshUniformBuilder* builder = jlongToPtr<MeshUniformBuilder*>(builderPtr);
+    SkString name = skString(env, uniformName);
+    jint* values = env->GetIntArrayElements(valuesArr, 0);
+    MeshUniformBuilder::Status status = builder->write(name.c_str(), MeshUniformBuilder::ValueKind::kInt, values, count * sizeof(int32_t));
+    env->ReleaseIntArrayElements(valuesArr, values, 0);
+    return static_cast<jint>(status);
+}
+
+extern "C" JNIEXPORT jint JNICALL Java_org_jetbrains_skia_MeshUniformBuilderKt_MeshUniformBuilder_1nUniformFloats
+  (JNIEnv* env, jclass jclass, jlong builderPtr, jstring uniformName, jfloatArray valuesArr, jint count) {
+    MeshUniformBuilder* builder = jlongToPtr<MeshUniformBuilder*>(builderPtr);
+    SkString name = skString(env, uniformName);
+    jfloat* values = env->GetFloatArrayElements(valuesArr, 0);
+    MeshUniformBuilder::Status status = builder->write(name.c_str(), MeshUniformBuilder::ValueKind::kFloat, values, count * sizeof(float));
+    env->ReleaseFloatArrayElements(valuesArr, values, 0);
+    return static_cast<jint>(status);
+}
+
+extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skia_MeshUniformBuilderKt_MeshUniformBuilder_1nBuild
+  (JNIEnv* env, jclass jclass, jlong builderPtr) {
+    MeshUniformBuilder* builder = jlongToPtr<MeshUniformBuilder*>(builderPtr);
+    return ptrToJlong(builder->build().release());
+}

--- a/skiko/src/nativeJsMain/cpp/Canvas.cc
+++ b/skiko/src/nativeJsMain/cpp/Canvas.cc
@@ -1,5 +1,7 @@
 #include <iostream>
+#include "SkBlender.h"
 #include "SkCanvas.h"
+#include "SkMesh.h"
 #include "SkRRect.h"
 #include "SkTextBlob.h"
 #include "SkVertices.h"
@@ -189,6 +191,23 @@ SKIKO_EXPORT void org_jetbrains_skia_Canvas__1nDrawPatch
         static_cast<SkBlendMode>(blendMode),
         *paint
     );
+}
+
+SKIKO_EXPORT void org_jetbrains_skia_Canvas__1nDrawMesh
+  (KNativePointer ptr, KNativePointer meshPtr, KNativePointer blenderPtr, KNativePointer paintPtr) {
+    SkCanvas* canvas = reinterpret_cast<SkCanvas*>((ptr));
+    SkMesh* mesh = reinterpret_cast<SkMesh*>((meshPtr));
+    SkBlender* blender = reinterpret_cast<SkBlender*>((blenderPtr));
+    SkPaint* paint = reinterpret_cast<SkPaint*>((paintPtr));
+    canvas->drawMesh(*mesh, sk_ref_sp(blender), *paint);
+}
+
+SKIKO_EXPORT void org_jetbrains_skia_Canvas__1nDrawMeshBlendMode
+  (KNativePointer ptr, KNativePointer meshPtr, KInt blendMode, KNativePointer paintPtr) {
+    SkCanvas* canvas = reinterpret_cast<SkCanvas*>((ptr));
+    SkMesh* mesh = reinterpret_cast<SkMesh*>((meshPtr));
+    SkPaint* paint = reinterpret_cast<SkPaint*>((paintPtr));
+    canvas->drawMesh(*mesh, SkBlender::Mode(static_cast<SkBlendMode>(blendMode)), *paint);
 }
 
 SKIKO_EXPORT void org_jetbrains_skia_Canvas__1nDrawDrawable

--- a/skiko/src/nativeJsMain/cpp/Mesh.cc
+++ b/skiko/src/nativeJsMain/cpp/Mesh.cc
@@ -1,0 +1,391 @@
+#include <utility>
+#include <vector>
+
+#include "SkColorSpace.h"
+#include "SkData.h"
+#include "SkMesh.h"
+#include "MeshInterop.hh"
+#include "common.h"
+
+// SkMeshSpecification is an SkNVRefCnt, so it cannot share the generic RefCnt finalizer.
+static void deleteMeshSpecification(SkMeshSpecification* specification) {
+    specification->unref();
+}
+
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_MeshSpecification__1nGetFinalizer() {
+    return reinterpret_cast<KNativePointer>((&deleteMeshSpecification));
+}
+
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_MeshSpecification__1nMake
+  (KInt* attributeTypesAndOffsetsArr, KInteropPointerArray attributeNamesArr, KInt attributeCount, KInt vertexStride,
+   KInt* varyingTypesArr, KInteropPointerArray varyingNamesArr, KInt varyingCount,
+   KInteropPointer vertexShader, KInteropPointer fragmentShader, KNativePointer colorSpacePtr, KInt alphaType) {
+    std::vector<SkString> attributeNames = skStringVector(attributeNamesArr, attributeCount);
+    std::vector<SkMeshSpecification::Attribute> attributes(attributeCount);
+    for (size_t i = 0; i < attributeCount; i++) {
+        // Every attribute contributes two ints: its type ordinal and its byte offset.
+        attributes[i].type = static_cast<SkMeshSpecification::Attribute::Type>(attributeTypesAndOffsetsArr[i * 2]);
+        attributes[i].offset = attributeTypesAndOffsetsArr[i * 2 + 1];
+        attributes[i].name = attributeNames[i];
+    }
+
+    std::vector<SkString> varyingNames = skStringVector(varyingNamesArr, varyingCount);
+    std::vector<SkMeshSpecification::Varying> varyings(varyingCount);
+    for (size_t i = 0; i < varyingCount; i++) {
+        varyings[i].type = static_cast<SkMeshSpecification::Varying::Type>(varyingTypesArr[i]);
+        varyings[i].name = varyingNames[i];
+    }
+
+    // Skia rejects a null color space when the fragment program outputs a color, so a missing one
+    // becomes sRGB, which is what Skia's own shorter Make overloads pass.
+    SkColorSpace* colorSpace = reinterpret_cast<SkColorSpace*>(colorSpacePtr);
+    sk_sp<SkColorSpace> colorSpaceRef = colorSpace ? sk_ref_sp(colorSpace) : SkColorSpace::MakeSRGB();
+
+    SkMeshSpecification::Result* result = new SkMeshSpecification::Result {
+        SkMeshSpecification::Make(
+            SkSpan(attributes),
+            vertexStride,
+            SkSpan(varyings),
+            skString(vertexShader),
+            skString(fragmentShader),
+            std::move(colorSpaceRef),
+            static_cast<SkAlphaType>(alphaType))
+    };
+    return reinterpret_cast<KNativePointer>(result);
+}
+
+SKIKO_EXPORT KInt org_jetbrains_skia_MeshSpecification__1nGetStride
+  (KNativePointer ptr) {
+    SkMeshSpecification* specification = reinterpret_cast<SkMeshSpecification*>(ptr);
+    return specification->stride();
+}
+
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_MeshSpecification__1nGetColorSpace
+  (KNativePointer ptr) {
+    SkMeshSpecification* specification = reinterpret_cast<SkMeshSpecification*>(ptr);
+    return reinterpret_cast<KNativePointer>(sk_ref_sp(specification->colorSpace()).release());
+}
+
+SKIKO_EXPORT KInt org_jetbrains_skia_MeshSpecification__1nGetAttributeCount
+  (KNativePointer ptr) {
+    SkMeshSpecification* specification = reinterpret_cast<SkMeshSpecification*>(ptr);
+    return specification->attributes().size();
+}
+
+SKIKO_EXPORT void org_jetbrains_skia_MeshSpecification__1nGetAttributeFields
+  (KNativePointer ptr, KInt* resultArray) {
+    SkMeshSpecification* specification = reinterpret_cast<SkMeshSpecification*>(ptr);
+    SkSpan<const SkMeshSpecification::Attribute> attributes = specification->attributes();
+    for (size_t i = 0; i < attributes.size(); i++) {
+        resultArray[2 * i] = static_cast<KInt>(attributes[i].type);
+        resultArray[2 * i + 1] = static_cast<KInt>(attributes[i].offset);
+    }
+}
+
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_MeshSpecification__1nGetAttributeName
+  (KNativePointer ptr, KInt index) {
+    SkMeshSpecification* specification = reinterpret_cast<SkMeshSpecification*>(ptr);
+    return reinterpret_cast<KNativePointer>(new SkString(specification->attributes()[index].name));
+}
+
+SKIKO_EXPORT KInt org_jetbrains_skia_MeshSpecification__1nGetUniformSize
+  (KNativePointer ptr) {
+    SkMeshSpecification* specification = reinterpret_cast<SkMeshSpecification*>(ptr);
+    return specification->uniformSize();
+}
+
+SKIKO_EXPORT KInt org_jetbrains_skia_MeshSpecification__1nGetUniformCount
+  (KNativePointer ptr) {
+    SkMeshSpecification* specification = reinterpret_cast<SkMeshSpecification*>(ptr);
+    return specification->uniforms().size();
+}
+
+SKIKO_EXPORT void org_jetbrains_skia_MeshSpecification__1nGetUniformFields
+  (KNativePointer ptr, KInt* resultArray) {
+    SkMeshSpecification* specification = reinterpret_cast<SkMeshSpecification*>(ptr);
+    SkSpan<const SkMeshSpecification::Uniform> uniforms = specification->uniforms();
+    for (size_t i = 0; i < uniforms.size(); i++) {
+        KInt* uniform = resultArray + i * kMeshUniformFields;
+        uniform[0] = static_cast<KInt>(uniforms[i].offset);
+        uniform[1] = static_cast<KInt>(uniforms[i].type);
+        uniform[2] = static_cast<KInt>(uniforms[i].count);
+        uniform[3] = static_cast<KInt>(uniforms[i].sizeInBytes());
+        uniform[4] = static_cast<KInt>(uniforms[i].flags);
+    }
+}
+
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_MeshSpecification__1nGetUniformName
+  (KNativePointer ptr, KInt index) {
+    SkMeshSpecification* specification = reinterpret_cast<SkMeshSpecification*>(ptr);
+    // The name is a string view into the program's source, so it is not null terminated.
+    std::string_view name = specification->uniforms()[index].name;
+    return reinterpret_cast<KNativePointer>(new SkString(name.data(), name.size()));
+}
+
+SKIKO_EXPORT KInt org_jetbrains_skia_MeshSpecification__1nGetChildCount
+  (KNativePointer ptr) {
+    SkMeshSpecification* specification = reinterpret_cast<SkMeshSpecification*>(ptr);
+    return specification->children().size();
+}
+
+SKIKO_EXPORT void org_jetbrains_skia_MeshSpecification__1nGetChildFields
+  (KNativePointer ptr, KInt* resultArray) {
+    SkMeshSpecification* specification = reinterpret_cast<SkMeshSpecification*>(ptr);
+    SkSpan<const SkMeshSpecification::Child> children = specification->children();
+    for (size_t i = 0; i < children.size(); i++) {
+        resultArray[2 * i] = static_cast<KInt>(children[i].type);
+        resultArray[2 * i + 1] = static_cast<KInt>(children[i].index);
+    }
+}
+
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_MeshSpecification__1nGetChildName
+  (KNativePointer ptr, KInt index) {
+    SkMeshSpecification* specification = reinterpret_cast<SkMeshSpecification*>(ptr);
+    // The name is a string view into the program's source, so it is not null terminated.
+    std::string_view name = specification->children()[index].name;
+    return reinterpret_cast<KNativePointer>(new SkString(name.data(), name.size()));
+}
+
+SKIKO_EXPORT KInt org_jetbrains_skia_MeshSpecification__1nFindVaryingType
+  (KNativePointer ptr, KInteropPointer name) {
+    SkMeshSpecification* specification = reinterpret_cast<SkMeshSpecification*>(ptr);
+    SkString varyingName = skString(name);
+    const SkMeshSpecification::Varying* varying = specification->findVarying(varyingName.c_str());
+    return varying ? static_cast<KInt>(varying->type) : -1;
+}
+
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_MeshSpecification__1nResultGetSpecification
+  (KNativePointer resultPtr) {
+    auto result = reinterpret_cast<SkMeshSpecification::Result*>(resultPtr);
+    return reinterpret_cast<KNativePointer>(result->specification.release());
+}
+
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_MeshSpecification__1nResultGetError
+  (KNativePointer resultPtr) {
+    auto result = reinterpret_cast<SkMeshSpecification::Result*>(resultPtr);
+    if (result->error.isEmpty()) {
+        return static_cast<KNativePointer>(nullptr);
+    } else {
+        return reinterpret_cast<KNativePointer>(&(result->error));
+    }
+}
+
+SKIKO_EXPORT void org_jetbrains_skia_MeshSpecification__1nResultDestroy
+  (KNativePointer resultPtr) {
+    delete reinterpret_cast<SkMeshSpecification::Result*>(resultPtr);
+}
+
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_MeshVertexBuffer__1nMake
+  (KByte* dataArr, KInt size) {
+    sk_sp<SkMesh::VertexBuffer> buffer = SkMeshes::MakeVertexBuffer(dataArr, size);
+    return reinterpret_cast<KNativePointer>(buffer.release());
+}
+
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_MeshVertexBuffer__1nMakeFromFloats
+  (KFloat* dataArr, KInt count) {
+    sk_sp<SkMesh::VertexBuffer> buffer = SkMeshes::MakeVertexBuffer(dataArr, count * sizeof(float));
+    return reinterpret_cast<KNativePointer>(buffer.release());
+}
+
+SKIKO_EXPORT KInt org_jetbrains_skia_MeshVertexBuffer__1nGetSize
+  (KNativePointer ptr) {
+    SkMesh::VertexBuffer* buffer = reinterpret_cast<SkMesh::VertexBuffer*>(ptr);
+    return buffer->size();
+}
+
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_MeshIndexBuffer__1nMake
+  (KShort* indicesArr, KInt indexCount) {
+    sk_sp<SkMesh::IndexBuffer> buffer = SkMeshes::MakeIndexBuffer(indicesArr, indexCount * sizeof(uint16_t));
+    return reinterpret_cast<KNativePointer>(buffer.release());
+}
+
+SKIKO_EXPORT KInt org_jetbrains_skia_MeshIndexBuffer__1nGetSize
+  (KNativePointer ptr) {
+    SkMesh::IndexBuffer* buffer = reinterpret_cast<SkMesh::IndexBuffer*>(ptr);
+    return buffer->size();
+}
+
+// SkMesh is a value type, so the Kotlin peer owns a heap copy.
+static void deleteMesh(SkMesh* mesh) {
+    delete mesh;
+}
+
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_Mesh__1nGetFinalizer() {
+    return reinterpret_cast<KNativePointer>((&deleteMesh));
+}
+
+static std::vector<SkMesh::ChildPtr> meshChildren(KNativePointerArray childrenPtrsArr, KInt* childTypesArr,
+                                                 KInt childCount) {
+    KNativePointer* childrenPtrs = reinterpret_cast<KNativePointer*>(childrenPtrsArr);
+    std::vector<SkMesh::ChildPtr> children(childCount);
+    for (size_t i = 0; i < childCount; i++) {
+        children[i] = meshChild(childrenPtrs[i], childTypesArr[i]);
+    }
+    return children;
+}
+
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_Mesh__1nMake
+  (KNativePointer specificationPtr, KInt mode, KNativePointer vertexBufferPtr, KInt vertexCount, KInt vertexOffset,
+   KNativePointer uniformsPtr, KNativePointerArray childrenPtrsArr, KInt* childTypesArr, KInt childCount,
+   KFloat left, KFloat top, KFloat right, KFloat bottom) {
+    SkMeshSpecification* specification = reinterpret_cast<SkMeshSpecification*>(specificationPtr);
+    SkMesh::VertexBuffer* vertexBuffer = reinterpret_cast<SkMesh::VertexBuffer*>(vertexBufferPtr);
+    std::vector<SkMesh::ChildPtr> children = meshChildren(childrenPtrsArr, childTypesArr, childCount);
+
+    SkMesh::Result* result = new SkMesh::Result {
+        SkMesh::Make(
+            sk_ref_sp(specification),
+            static_cast<SkMesh::Mode>(mode),
+            sk_ref_sp(vertexBuffer),
+            vertexCount,
+            vertexOffset,
+            meshUniforms(reinterpret_cast<const SkData*>(uniformsPtr)),
+            SkSpan(children),
+            SkRect::MakeLTRB(left, top, right, bottom))
+    };
+    return reinterpret_cast<KNativePointer>(result);
+}
+
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_Mesh__1nMakeIndexed
+  (KNativePointer specificationPtr, KInt mode, KNativePointer vertexBufferPtr, KInt vertexCount, KInt vertexOffset,
+   KNativePointer indexBufferPtr, KInt indexCount, KInt indexOffset,
+   KNativePointer uniformsPtr, KNativePointerArray childrenPtrsArr, KInt* childTypesArr, KInt childCount,
+   KFloat left, KFloat top, KFloat right, KFloat bottom) {
+    SkMeshSpecification* specification = reinterpret_cast<SkMeshSpecification*>(specificationPtr);
+    SkMesh::VertexBuffer* vertexBuffer = reinterpret_cast<SkMesh::VertexBuffer*>(vertexBufferPtr);
+    SkMesh::IndexBuffer* indexBuffer = reinterpret_cast<SkMesh::IndexBuffer*>(indexBufferPtr);
+    std::vector<SkMesh::ChildPtr> children = meshChildren(childrenPtrsArr, childTypesArr, childCount);
+
+    SkMesh::Result* result = new SkMesh::Result {
+        SkMesh::MakeIndexed(
+            sk_ref_sp(specification),
+            static_cast<SkMesh::Mode>(mode),
+            sk_ref_sp(vertexBuffer),
+            vertexCount,
+            vertexOffset,
+            sk_ref_sp(indexBuffer),
+            indexCount,
+            indexOffset,
+            meshUniforms(reinterpret_cast<const SkData*>(uniformsPtr)),
+            SkSpan(children),
+            SkRect::MakeLTRB(left, top, right, bottom))
+    };
+    return reinterpret_cast<KNativePointer>(result);
+}
+
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_Mesh__1nGetSpecification
+  (KNativePointer ptr) {
+    SkMesh* mesh = reinterpret_cast<SkMesh*>(ptr);
+    return reinterpret_cast<KNativePointer>(mesh->refSpec().release());
+}
+
+SKIKO_EXPORT KInt org_jetbrains_skia_Mesh__1nGetMode
+  (KNativePointer ptr) {
+    SkMesh* mesh = reinterpret_cast<SkMesh*>(ptr);
+    return static_cast<KInt>(mesh->mode());
+}
+
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_Mesh__1nGetVertexBuffer
+  (KNativePointer ptr) {
+    SkMesh* mesh = reinterpret_cast<SkMesh*>(ptr);
+    return reinterpret_cast<KNativePointer>(mesh->refVertexBuffer().release());
+}
+
+SKIKO_EXPORT KInt org_jetbrains_skia_Mesh__1nGetVertexOffset
+  (KNativePointer ptr) {
+    SkMesh* mesh = reinterpret_cast<SkMesh*>(ptr);
+    return mesh->vertexOffset();
+}
+
+SKIKO_EXPORT KInt org_jetbrains_skia_Mesh__1nGetVertexCount
+  (KNativePointer ptr) {
+    SkMesh* mesh = reinterpret_cast<SkMesh*>(ptr);
+    return mesh->vertexCount();
+}
+
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_Mesh__1nGetIndexBuffer
+  (KNativePointer ptr) {
+    SkMesh* mesh = reinterpret_cast<SkMesh*>(ptr);
+    return reinterpret_cast<KNativePointer>(mesh->refIndexBuffer().release());
+}
+
+SKIKO_EXPORT KInt org_jetbrains_skia_Mesh__1nGetIndexOffset
+  (KNativePointer ptr) {
+    SkMesh* mesh = reinterpret_cast<SkMesh*>(ptr);
+    return mesh->indexOffset();
+}
+
+SKIKO_EXPORT KInt org_jetbrains_skia_Mesh__1nGetIndexCount
+  (KNativePointer ptr) {
+    SkMesh* mesh = reinterpret_cast<SkMesh*>(ptr);
+    return mesh->indexCount();
+}
+
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_Mesh__1nGetUniforms
+  (KNativePointer ptr) {
+    SkMesh* mesh = reinterpret_cast<SkMesh*>(ptr);
+    // SkData is immutable, so the Kotlin peer may hold a reference to the very same object.
+    return reinterpret_cast<KNativePointer>(const_cast<SkData*>(mesh->refUniforms().release()));
+}
+
+SKIKO_EXPORT void org_jetbrains_skia_Mesh__1nGetBounds
+  (KNativePointer ptr, KInteropPointer resultArray) {
+    SkMesh* mesh = reinterpret_cast<SkMesh*>(ptr);
+    skija::Rect::copyToInterop(mesh->bounds(), resultArray);
+}
+
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_Mesh__1nResultGetMesh
+  (KNativePointer resultPtr) {
+    auto result = reinterpret_cast<SkMesh::Result*>(resultPtr);
+    return reinterpret_cast<KNativePointer>(new SkMesh(result->mesh));
+}
+
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_Mesh__1nResultGetError
+  (KNativePointer resultPtr) {
+    auto result = reinterpret_cast<SkMesh::Result*>(resultPtr);
+    if (result->error.isEmpty()) {
+        return static_cast<KNativePointer>(nullptr);
+    } else {
+        return reinterpret_cast<KNativePointer>(&(result->error));
+    }
+}
+
+SKIKO_EXPORT void org_jetbrains_skia_Mesh__1nResultDestroy
+  (KNativePointer resultPtr) {
+    delete reinterpret_cast<SkMesh::Result*>(resultPtr);
+}
+
+static void deleteMeshUniformBuilder(MeshUniformBuilder* builder) {
+    delete builder;
+}
+
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_MeshUniformBuilder__1nGetFinalizer() {
+    return reinterpret_cast<KNativePointer>((&deleteMeshUniformBuilder));
+}
+
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_MeshUniformBuilder__1nMake
+  (KNativePointer specificationPtr) {
+    SkMeshSpecification* specification = reinterpret_cast<SkMeshSpecification*>(specificationPtr);
+    MeshUniformBuilder* builder = new MeshUniformBuilder(sk_ref_sp(specification));
+    return reinterpret_cast<KNativePointer>(builder);
+}
+
+SKIKO_EXPORT KInt org_jetbrains_skia_MeshUniformBuilder__1nUniformInts
+  (KNativePointer builderPtr, KInteropPointer uniformName, KInt* valuesArr, KInt count) {
+    MeshUniformBuilder* builder = reinterpret_cast<MeshUniformBuilder*>(builderPtr);
+    SkString name = skString(uniformName);
+    return builder->write(name.c_str(), MeshUniformBuilder::ValueKind::kInt, valuesArr, count * sizeof(int32_t));
+}
+
+SKIKO_EXPORT KInt org_jetbrains_skia_MeshUniformBuilder__1nUniformFloats
+  (KNativePointer builderPtr, KInteropPointer uniformName, KFloat* valuesArr, KInt count) {
+    MeshUniformBuilder* builder = reinterpret_cast<MeshUniformBuilder*>(builderPtr);
+    SkString name = skString(uniformName);
+    return builder->write(name.c_str(), MeshUniformBuilder::ValueKind::kFloat, valuesArr, count * sizeof(float));
+}
+
+SKIKO_EXPORT KNativePointer org_jetbrains_skia_MeshUniformBuilder__1nBuild
+  (KNativePointer builderPtr) {
+    MeshUniformBuilder* builder = reinterpret_cast<MeshUniformBuilder*>(builderPtr);
+    return reinterpret_cast<KNativePointer>(builder->build().release());
+}


### PR DESCRIPTION
[SKIKO-1154](https://youtrack.jetbrains.com/issue/SKIKO-1154) Expose SkMesh

This adds the mesh API as one Kotlin type per Skia type:
- `MeshSpecification` compiles the two SkSL programs and reports Skia's own message as an `IllegalArgumentException` when they are rejected. It also reports what Skia compiled: the attributes, the uniforms with the offset and size of each value, the children, the varyings and the color space.
- `MeshVertexBuffer` and `MeshIndexBuffer` wrap the CPU-backed buffers from `SkMeshes`. They are separate objects, as in Skia, so one buffer can be shared between meshes. The GPU-backed buffers are Ganesh-only with no graphite equivalent, so they are left out rather than exposed on some backends.
- `Mesh` covers the indexed and the non-indexed form and reports what it was made from. It is immutable, as `SkMesh` is.
- `MeshUniformBuilder` packs the single `Data` that `SkMesh` takes, as `RuntimeShaderBuilder` does for runtime effect uniforms. It is a convenience over `MeshSpecification.uniforms`, not the only way to reach it.
- `Canvas.drawMesh` takes either a `Blender` or a `BlendMode`.

`RuntimeEffect.Child` is a new sealed interface implemented by `Shader`, `ColorFilter` and `Blender`. It names the set of values `SkRuntimeEffect::ChildPtr` holds, so a mesh binds any of the three kinds of child its programs declare and the call site is checked at compile time. It sits on `RuntimeEffect` because that is where Skia declares it. It declares no members, so nothing changes for existing callers of those three classes.
