### PR TITLE
Use `delay(Duration)` overload

### DIFF
--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/HardwareLayer.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/HardwareLayer.kt
@@ -8,6 +8,7 @@ import java.awt.Component
 import java.awt.Graphics
 import java.awt.event.InputMethodEvent
 import javax.accessibility.AccessibleContext
+import kotlin.time.Duration.Companion.seconds
 
 internal open class HardwareLayer(
     private val accessibleContextProvider: ((Component) -> AccessibleContext)? = null
@@ -82,7 +83,7 @@ internal fun layerFrameLimiter(
             //  on my machine it takes 0.2ms on Linux, 0.01ms on macOs, 0.1ms on Windows
             state.frameLimit = component.getDisplayRefreshRate()
             onNewFrameLimit(state.frameLimit)
-            delay(1000)
+            delay(1.seconds)
         }
     }
 

--- a/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerPerformanceTest.kt
+++ b/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerPerformanceTest.kt
@@ -13,7 +13,9 @@ import org.junit.Test
 import java.awt.Point
 import javax.swing.WindowConstants
 import kotlin.math.*
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.nanoseconds
+import kotlin.time.Duration.Companion.seconds
 
 @Suppress("BlockingMethodInNonBlockingContext", "SameParameterValue")
 class SkiaLayerPerformanceTest {
@@ -133,7 +135,7 @@ class SkiaLayerPerformanceTest {
 
     private suspend fun awaitFrameCollection(windows: List<PerformanceHelper>) {
         while (!windows.all(PerformanceHelper::isCollected)) {
-            delay(100)
+            delay(100.milliseconds)
         }
     }
 
@@ -200,7 +202,7 @@ class SkiaLayerPerformanceTest {
                 window.location = Point((index + 1) * 200, 200)
             }
         }
-        delay(1000)
+        delay(1.seconds)
         try {
             helpers.forEach { it.startCollect() }
             awaitFrameCollection(helpers)
@@ -225,7 +227,7 @@ class SkiaLayerPerformanceTest {
                 window.location = Point(index * 300, 200)
             }
         }
-        delay(1000)
+        delay(1.seconds)
         try {
             helpers.forEach { it.startCollect() }
             awaitFrameCollection(helpers)

--- a/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
+++ b/skiko/src/awtTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
@@ -52,6 +52,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 @Suppress("SameParameterValue")
@@ -144,7 +145,7 @@ class SkiaLayerTest {
             frame.contentPane.add(layer)
             frame.size = Dimension(200, 200)
             frame.isVisible = true
-            delay(30)
+            delay(30.milliseconds)
             layer.dispose()
             frame.dispose()
         }
@@ -154,14 +155,14 @@ class SkiaLayerTest {
             createAndDisposeWindow()
         }
 
-        delay(1000)
+        delay(1.seconds)
         val initialWindowCount = getApplicationWindowCount()
 
         repeat(32) {
             createAndDisposeWindow()
         }
 
-        delay(1000)
+        delay(1.seconds)
         val actualWindowCount = getApplicationWindowCount()
 
         assertTrue(
@@ -182,12 +183,12 @@ class SkiaLayerTest {
             window.isUndecorated = true
             window.isVisible = true
 
-            delay(1000)
+            delay(1.seconds)
             screenshots.assert(window.bounds, "frame1")
 
             app.rectWidth = 100
             window.layer.needRender()
-            delay(1000)
+            delay(1.seconds)
             screenshots.assert(window.bounds, "frame2")
 
             assertRenderApiFor(window.layer)
@@ -213,12 +214,12 @@ class SkiaLayerTest {
             window.isUndecorated = true
             window.isVisible = true
 
-            delay(1000)
+            delay(1.seconds)
             screenshots.assert(window.bounds, "frame1")
 
             app.rectWidth = 100
             layer.repaint()
-            delay(1000)
+            delay(1.seconds)
             screenshots.assert(window.bounds, "frame2")
 
             assertRenderApiFor(layer)
@@ -241,12 +242,12 @@ class SkiaLayerTest {
             window.paint(window.graphics)
             window.isVisible = true
 
-            delay(1000)
+            delay(1.seconds)
             screenshots.assert(window.bounds, "frame1")
 
             app.rectWidth = 100
             window.layer.needRender()
-            delay(1000)
+            delay(1.seconds)
             screenshots.assert(window.bounds, "frame2")
 
             assertRenderApiFor(window.layer)
@@ -275,27 +276,27 @@ class SkiaLayerTest {
             window.isUndecorated = true
             window.isVisible = true
             layer.needRender()
-            delay(1000)
+            delay(1.seconds)
             assertEquals(0, renderedWidth)
 
             renderedWidth = -1
             layer.needRender()
-            delay(1000)
+            delay(1.seconds)
             assertEquals(0, renderedWidth)
 
             renderedWidth = -1
             layer.size = Dimension(30, 40)
-            delay(1000)
+            delay(1.seconds)
             assertEquals((30 * density).toInt(), renderedWidth)
 
             renderedWidth = -1
             layer.size = Dimension(0, 0)
-            delay(1000)
+            delay(1.seconds)
             assertEquals(0, renderedWidth)
 
             renderedWidth = -1
             layer.size = Dimension(40, 40)
-            delay(1000)
+            delay(1.seconds)
             assertEquals((40 * density).toInt(), renderedWidth)
 
             assertRenderApiFor(layer)
@@ -334,11 +335,11 @@ class SkiaLayerTest {
             window.isUndecorated = true
             window.isVisible = true
 
-            delay(1000)
+            delay(1.seconds)
             screenshots.assert(window.bounds, "frame1")
 
             box.setBounds(100, 0, 100, 100)
-            delay(1000)
+            delay(1.seconds)
             screenshots.assert(window.bounds, "frame2")
 
             assertRenderApiFor(layer)
@@ -358,10 +359,10 @@ class SkiaLayerTest {
             window.layer.renderDelegate = RectRenderer(window.layer, 20, 10, Color.RED)
             window.isUndecorated = true
             window.isVisible = true
-            delay(1000)
+            delay(1.seconds)
 
             window.setSize(80, 40)
-            delay(1000)
+            delay(1.seconds)
 
             screenshots.assert(window.bounds)
 
@@ -414,11 +415,11 @@ class SkiaLayerTest {
             window.layer.preferredSize = initialContentSize
             window.pack()
             window.isVisible = true
-            delay(200)
+            delay(200.milliseconds)
             assertEquals("The window didn't pack to the requested content size", initialContentSize, window.layer.size)
 
             dragBottomRightCorner(window, by = growBy)
-            delay(200)
+            delay(200.milliseconds)
 
             assertEquals("The drag didn't resize the content as requested", finalContentSize, window.layer.size)
             assertEquals("The final layer's size is incorrect", finalContentSize, window.layer.size)
@@ -461,18 +462,18 @@ class SkiaLayerTest {
         val window3 = window(Color.BLACK)
 
         try {
-            delay(1000)
+            delay(1.seconds)
 
             window1.toFront()
-            delay(1000)
+            delay(1.seconds)
             screenshots.assert(window1.bounds, "window1")
 
             window2.toFront()
-            delay(1000)
+            delay(1.seconds)
             screenshots.assert(window2.bounds, "window2")
 
             window3.toFront()
-            delay(1000)
+            delay(1.seconds)
             screenshots.assert(window3.bounds, "window3")
 
             assertRenderApiFor(window1.layer)
@@ -500,7 +501,7 @@ class SkiaLayerTest {
             })
             window.isVisible = true
 
-            delay(1000)
+            delay(1.seconds)
             assertEquals(true, stateRemainsFullscreen)
             assertRenderApiFor(window.layer)
         } finally {
@@ -509,7 +510,7 @@ class SkiaLayerTest {
             // Delay before starting the next test to let the window animation complete and allow the next window
             // to become fullscreen
             if (hostOs == OS.MacOS) {
-                delay(1000)
+                delay(1.seconds)
             }
         }
     }
@@ -527,17 +528,17 @@ class SkiaLayerTest {
             window.isUndecorated = true
             window.isVisible = true
 
-            delay(1000)
+            delay(1.seconds)
             assertTrue(renderCount > 0)
             renderCount = 0
 
             window.setSize(50, 20)
-            delay(1000)
+            delay(1.seconds)
             assertTrue(renderCount > 0)
             renderCount = 0
 
             window.layer.needRender()
-            delay(1000)
+            delay(1.seconds)
             assertEquals(1, renderCount)
         } finally {
             window.close()
@@ -577,7 +578,7 @@ class SkiaLayerTest {
 
             val delayCount = random.nextLong(5)
             if (delayCount > 0) {
-                delay(delayCount * 10)
+                delay((delayCount * 10).milliseconds)
             }
 
             openedWindows.forEach {
@@ -587,7 +588,7 @@ class SkiaLayerTest {
 
         openedWindows.forEach(JFrame::close)
 
-        delay(5000)
+        delay(5.seconds)
     }
 
     @Test(timeout = 60000)
@@ -627,7 +628,7 @@ class SkiaLayerTest {
         }
 
         repeat(30) {
-            delay(100)
+            delay(100.milliseconds)
             val window = openWindow()
             window.isVisible = true
             window.layer.needRender()
@@ -683,12 +684,12 @@ class SkiaLayerTest {
             window.isUndecorated = true
             window.isVisible = true
 
-            delay(1000)
+            delay(1.seconds)
             screenshots.assert(window.bounds, "frame1", "testFallbackToSoftware")
 
             app.rectWidth = 100
             window.layer.needRender()
-            delay(1000)
+            delay(1.seconds)
             screenshots.assert(window.bounds, "frame2", "testFallbackToSoftware")
 
             assertEquals(GraphicsApi.SOFTWARE_COMPAT, window.layer.renderApi)
@@ -734,7 +735,7 @@ class SkiaLayerTest {
             window.setSize(400, 200)
             window.isVisible = true
 
-            delay(1000)
+            delay(1.seconds)
 
             assertEquals(GraphicsApi.SOFTWARE_COMPAT, window.layer.renderApi)
             assertTrue(rendererChangedCallbackInvoked)
@@ -821,12 +822,12 @@ class SkiaLayerTest {
             window.layeredPane.background = Color.BLUE
             window.layeredPane.isOpaque = true
 
-            delay(1000)
+            delay(1.seconds)
             screenshots.assert(window.bounds, "visible_parent")
 
             window.contentPane.isVisible = false
 
-            delay(1000)
+            delay(1.seconds)
             screenshots.assert(window.bounds, "hidden_parent")
         } finally {
             window.close()
@@ -852,7 +853,7 @@ class SkiaLayerTest {
         try {
             window.isUndecorated = true
             window.isVisible = true
-            delay(1000)
+            delay(1.seconds)
             screenshots.assert(window.bounds, "frame")
         } finally {
             window.close()
@@ -878,9 +879,9 @@ class SkiaLayerTest {
             window.size = Dimension(800, 800)
             repeat(10) {
                 window.isVisible = true
-                delay(16)
+                delay(16.milliseconds)
                 window.layer.needRender()
-                delay(500)
+                delay(500.milliseconds)
                 window.isVisible = false
 
                 val dt = renderTimes.last() - renderTimes.first()
@@ -1004,7 +1005,7 @@ class SkiaLayerTest {
             window.isUndecorated = true
             window.isVisible = true
 
-            delay(1000)
+            delay(1.seconds)
             assertEquals(Version.skiko, analytics.rendererInfo.skikoVersion)
             assertEquals(hostOs, analytics.rendererInfo.os)
             assertNotNull(analytics.rendererInfo.api)
@@ -1042,7 +1043,7 @@ class SkiaLayerTest {
 
             window.isUndecorated = true
             window.isVisible = true
-            delay(1000)
+            delay(1.seconds)
 
             // check the line metrics
             val lineMetrics = paragraph.lineMetrics
@@ -1082,7 +1083,7 @@ class SkiaLayerTest {
                 window.location = window.location.let {
                     Point(it.x + 10, it.y + 10)
                 }
-                delay(50)
+                delay(50.milliseconds)
             }
 
             // Ideally, layoutCount would be just 1, but Swing appears to call layout one extra time, so it ends up being 2.
@@ -1131,7 +1132,7 @@ class SkiaLayerTest {
         }
 
         window.isVisible = true
-        delay(500)
+        delay(500.milliseconds)
         val pixelLocation = window.bounds.let {
             Point(it.x + it.width/2, it.y + it.height/2)
         }
@@ -1157,27 +1158,27 @@ class SkiaLayerTest {
         try {
             // Check with `window.isVisible = false`
             repeat(20) {
-                delay(200)
+                delay(200.milliseconds)
                 window.isVisible = false
-                delay(300)
+                delay(300.milliseconds)
                 assertNull(nonBlackPixelDetected, "Detected a non-black pixel when hiding window")
                 // Acquire the semaphore while making the window visible, to disable screenshotting
                 semaphore.acquire()
                 window.isVisible = true
-                delay(500)
+                delay(500.milliseconds)
                 semaphore.release()
             }
 
             // Check with `window.dispose()`
             repeat(20) {
-                delay(200)
+                delay(200.milliseconds)
                 window.dispose()
-                delay(300)
+                delay(300.milliseconds)
                 assertNull(nonBlackPixelDetected, "Detected a non-black pixel when disposing window")
                 // Acquire the semaphore while making the window visible, to disable screenshotting
                 semaphore.acquire()
                 window.isVisible = true
-                delay(500)
+                delay(500.milliseconds)
                 semaphore.release()
             }
         } finally {
@@ -1223,7 +1224,7 @@ class SkiaLayerTest {
         }
         backgroundWindow.isVisible = true
         backgroundWindow.waitUntilOpened()
-        delay(200)
+        delay(200.milliseconds)
         backgroundWindow.toFront()
 
         val pixelLocation = backgroundWindow.bounds.let {
@@ -1254,7 +1255,7 @@ class SkiaLayerTest {
 
         suspend fun waitForSampledPixelCloseTo(targetColor: Color) {
             do {
-                delay(200)
+                delay(200.milliseconds)
             } while (!lastPixelColorDetected.load().let { it != null && it.closeTo(targetColor) })
         }
 
@@ -1338,7 +1339,7 @@ class SkiaLayerTest {
         }
 
         window.isVisible = true
-        delay(1500)
+        delay(1.5.seconds)
         val pixelLocation = window.bounds.let {
             Point(it.x + it.width/2, it.y + it.height/2)
         }
@@ -1416,7 +1417,7 @@ class SkiaLayerTest {
 
         // Wait for things to settle down, specifically the workaround for JBR-5259, which moves
         // the backed layer when graphicsContextScaleTransform changes
-        delay(100)
+        delay(100.milliseconds)
 
         try {
             renderChannel.receive()
@@ -1426,7 +1427,7 @@ class SkiaLayerTest {
                 window.layer.needRender(true)
                 window.layer.needRender(false)
             }
-            delay(100)
+            delay(100.milliseconds)
             assertEquals("Render was called more than once on needRender(true), needRender(false)", 1, renderCalls)
             assertEquals("Draw was called more than once on needRender(true), needRender(false)", 1, drawCalls)
 
@@ -1436,7 +1437,7 @@ class SkiaLayerTest {
                 window.layer.needRender(false)
                 window.layer.needRender(true)
             }
-            delay(100)
+            delay(100.milliseconds)
             assertEquals("Render was called more than once on needRender(false), needRender(true)", 1, renderCalls)
             assertEquals("Draw was called more than once on needRender(true), needRender(true)", 1, drawCalls)
         } finally {
@@ -1499,7 +1500,7 @@ class SkiaLayerTest {
             initLayer(window)
             layer.background = Color.RED
             window.isVisible = true
-            delay(1000)
+            delay(1.seconds)
 
             val robot = Robot()
             val windowBounds = window.bounds
@@ -1511,11 +1512,11 @@ class SkiaLayerTest {
             assertLayerIs(Color.RED)
 
             layer.background = Color.BLUE
-            delay(100)
+            delay(100.milliseconds)
             assertLayerIs(Color.BLUE)
 
             layer.background = Color.GREEN
-            delay(100)
+            delay(100.milliseconds)
             assertLayerIs(Color.GREEN)
         } finally {
             window.dispose()
@@ -1585,7 +1586,7 @@ class SkiaLayerTest {
             window.isUndecorated = true
             window.isVisible = true
 
-            delay(100)
+            delay(100.milliseconds)
             withContext(Dispatchers.Default) {
                 Robot().waitForIdle()
             }
@@ -1600,7 +1601,7 @@ class SkiaLayerTest {
             layeredPane.remove(swingComponent)
             layer.clipComponents.remove(clipRect)
 
-            delay(100)
+            delay(100.milliseconds)
             withContext(Dispatchers.Default) {
                 Robot().waitForIdle()
             }

--- a/skiko/src/awtTest/kotlin/org/jetbrains/skiko/swing/AcceleratedSwingPainterTest.kt
+++ b/skiko/src/awtTest/kotlin/org/jetbrains/skiko/swing/AcceleratedSwingPainterTest.kt
@@ -8,11 +8,9 @@ import org.jetbrains.skia.Paint
 import org.jetbrains.skia.Rect
 import org.jetbrains.skia.Surface
 import org.jetbrains.skiko.MainUIDispatcher
-import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.SkikoRenderDelegate
 import org.jetbrains.skiko.toImage
 import org.jetbrains.skiko.util.ScreenshotTestRule
-import org.junit.Assume
 import org.junit.Rule
 import org.junit.Test
 import java.awt.Color
@@ -23,6 +21,7 @@ import java.awt.image.BufferedImage
 import javax.swing.JFrame
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.time.Duration.Companion.seconds
 
 class AcceleratedSwingPainterTest {
     @get:Rule
@@ -87,7 +86,7 @@ class AcceleratedSwingPainterTest {
                 val layer = SkiaSwingLayer(FakeRenderer(window, 100, 100, Color.RED))
                 window.contentPane.add(layer)
                 window.setSize(100, 100)
-                delay(1000)
+                delay(1.seconds)
 
                 val image = BufferedImage(100, 100, BufferedImage.TYPE_INT_ARGB)
                 val g2d = image.createGraphics()
@@ -109,7 +108,7 @@ class AcceleratedSwingPainterTest {
                 window.setSize(100, 100)
                 window.isUndecorated = true
                 window.isVisible = true
-                delay(1000)
+                delay(1.seconds)
 
                 val image = BufferedImage(100, 100, BufferedImage.TYPE_INT_ARGB)
                 val g2d = image.createGraphics()

--- a/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/FrameWatcher.kt
+++ b/skiko/src/jvmMain/kotlin/org/jetbrains/skiko/FrameWatcher.kt
@@ -2,6 +2,9 @@ package org.jetbrains.skiko
 
 import kotlinx.coroutines.*
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * This class is intended to mitigate issues coming from the situation that we have
@@ -12,7 +15,7 @@ import java.util.concurrent.atomic.AtomicInteger
  * making sure that we'll have memory consumption under control.
  */
 internal object FrameWatcher {
-    var gcDelayMillis = 30_000L
+    var gcDelay: Duration = 30.seconds
     var minFramesToRenderer = 1_000
 
     fun start() {
@@ -22,7 +25,7 @@ internal object FrameWatcher {
         GlobalScope.launch(Dispatchers.IO) {
             while (true) {
                 // Wait some time between collection attempts.
-                delay(gcDelayMillis)
+                delay(gcDelay)
                 // Ensure that certain number of frames were rendered, as we allocate Skia
                 // garbage when rendering.
                 if (frameCounter.get() > minFramesToRenderer) {

--- a/skiko/src/jvmTest/kotlin/org/jetbrains/skiko/FrameLimiterTest.kt
+++ b/skiko/src/jvmTest/kotlin/org/jetbrains/skiko/FrameLimiterTest.kt
@@ -105,7 +105,7 @@ class FrameLimiterTest {
             repeat(frameCount) {
                 limiter.awaitNextFrame()
                 ticks.add(currentTime.toInt())
-                advanceTimeBy(frameRenderMillis)
+                advanceTimeBy(frameRenderMillis.milliseconds)
             }
         }
         return ticks
@@ -124,21 +124,21 @@ class FrameLimiterTest {
                 repeat(frameCount) {
                     limiter.awaitNextFrame()
                     ticks1.add(currentTime.toInt())
-                    advanceTimeBy(3)
+                    advanceTimeBy(3.milliseconds)
                 }
             }
             launch {
                 repeat(frameCount) {
                     limiter.awaitNextFrame()
                     ticks2.add(currentTime.toInt())
-                    advanceTimeBy(1)
+                    advanceTimeBy(1.milliseconds)
                 }
             }
             launch {
                 repeat(frameCount) {
                     limiter.awaitNextFrame()
                     ticks3.add(currentTime.toInt())
-                    advanceTimeBy(1)
+                    advanceTimeBy(1.milliseconds)
                 }
             }
         }
@@ -160,7 +160,7 @@ class FrameLimiterTest {
                 currentTime = { testScheduler.currentTime.milliseconds },
                 impreciseDelay = { timeMillis ->
                     val ms = ceil(timeMillis.toDouble() / delayPrecisionMillis).toInt() * delayPrecisionMillis
-                    delay(ms)
+                    delay(ms.milliseconds)
                 }
             )
             block(limiter)

--- a/skiko/src/jvmTest/kotlin/org/jetbrains/skiko/RendezvousBroadcastChannelTest.kt
+++ b/skiko/src/jvmTest/kotlin/org/jetbrains/skiko/RendezvousBroadcastChannelTest.kt
@@ -5,6 +5,8 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import kotlin.random.Random
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class RendezvousBroadcastChannelTest {
     @Test(timeout = 5000)
@@ -96,10 +98,10 @@ class RendezvousBroadcastChannelTest {
         val channel = RendezvousBroadcastChannel<Int>()
         runBlocking {
             try {
-                withTimeout(1000) {
+                withTimeout(1.seconds) {
                     channel.sendAll(1)
                 }
-            } catch (e: TimeoutCancellationException) {
+            } catch (_: TimeoutCancellationException) {
                 isExceptionThrown = true
             }
         }
@@ -115,10 +117,10 @@ class RendezvousBroadcastChannelTest {
             launch {
                 channel.sendAll(1)
                 try {
-                    withTimeout(1000) {
+                    withTimeout(1.seconds) {
                         channel.sendAll(1)
                     }
-                } catch (e: TimeoutCancellationException) {
+                } catch (_: TimeoutCancellationException) {
                     isExceptionThrown = true
                 }
             }
@@ -137,10 +139,10 @@ class RendezvousBroadcastChannelTest {
         val channel = RendezvousBroadcastChannel<Int>()
         runBlocking {
             try {
-                withTimeout(1000) {
+                withTimeout(1.seconds) {
                     channel.receive()
                 }
-            } catch (e: TimeoutCancellationException) {
+            } catch (_: TimeoutCancellationException) {
                 isExceptionThrown = true
             }
         }
@@ -156,10 +158,10 @@ class RendezvousBroadcastChannelTest {
             launch {
                 channel.receive()
                 try {
-                    withTimeout(1000) {
+                    withTimeout(1.seconds) {
                         channel.receive()
                     }
-                } catch (e: TimeoutCancellationException) {
+                } catch (_: TimeoutCancellationException) {
                     isExceptionThrown = true
                 }
             }
@@ -184,7 +186,7 @@ class RendezvousBroadcastChannelTest {
         val produceJob = launch {
             for (i in 0 until 1000) {
                 channel.sendAll(i)
-                delay(10)
+                delay(10.milliseconds)
             }
         }
 
@@ -193,19 +195,19 @@ class RendezvousBroadcastChannelTest {
         launch {
             repeat(1000) {
                 frames1.add(channel.receive())
-                delay(random.nextLong(10L))
+                delay(random.nextLong(10L).milliseconds)
             }
         }
         launch {
             repeat(1000) {
                 frames2.add(channel.receive())
-                delay(random.nextLong(10L))
+                delay(random.nextLong(10L).milliseconds)
             }
         }
         launch {
             repeat(1000) {
                 frames3.add(channel.receive())
-                delay(random.nextLong(10L))
+                delay(random.nextLong(10L).milliseconds)
             }
         }
 


### PR DESCRIPTION
To avoid the linter warnings