### PR TITLE
Introduce SkiaLayer.makeWithContextAttributes to pass arbitrary EmscriptenWebGLContextAttributes

### DIFF
--- a/skiko/src/jsMain/kotlin/org/jetbrains/skiko/wasm/Wrapper.kt
+++ b/skiko/src/jsMain/kotlin/org/jetbrains/skiko/wasm/Wrapper.kt
@@ -1,8 +1,5 @@
 package org.jetbrains.skiko.wasm
 
-import org.jetbrains.skia.impl.NativePointer
-import org.jetbrains.skiko.GL
-import org.w3c.dom.HTMLCanvasElement
 import kotlin.js.*
 
 /**
@@ -12,40 +9,4 @@ import kotlin.js.*
  */
 actual fun onWasmReady(onReady: () -> Unit) {
     awaitSkiko.then { onReady() }
-}
-
-internal fun ContextAttributes.asJsObject(): dynamic {
-    val jsObject = js("{}")
-    alpha?.let { jsObject.alpha = alpha }
-    depth?.let { jsObject.depth = depth }
-    stencil?.let { jsObject.stencil = stencil }
-    antialias?.let { jsObject.antialias = antialias }
-    premultipliedAlpha?.let { jsObject.premultipliedAlpha = premultipliedAlpha }
-    preserveDrawingBuffer?.let { jsObject.preserveDrawingBuffer = preserveDrawingBuffer }
-    preferLowPowerToHighPerformance?.let { jsObject.preferLowPowerToHighPerformance = preferLowPowerToHighPerformance }
-    failIfMajorPerformanceCaveat?.let { jsObject.failIfMajorPerformanceCaveat = failIfMajorPerformanceCaveat }
-    enableExtensionsByDefault?.let { jsObject.enableExtensionsByDefault = enableExtensionsByDefault }
-    explicitSwapControl?.let { jsObject.explicitSwapControl = explicitSwapControl }
-    renderViaOffscreenBackBuffer?.let { jsObject.renderViaOffscreenBackBuffer = renderViaOffscreenBackBuffer }
-    majorVersion?.let { jsObject.majorVersion = majorVersion }
-    return jsObject
-}
-
-internal actual fun createWebGLContext(canvas: HTMLCanvasElement, attr: ContextAttributes?): NativePointer {
-    val contextAttributes = object : ContextAttributes {
-        override val alpha = attr?.alpha ?: 1
-        override val depth = attr?.depth ?: 1
-        override val stencil = attr?.stencil ?: 8
-        override val antialias = attr?.antialias ?: 0
-        override val premultipliedAlpha = attr?.premultipliedAlpha ?: 1
-        override val preserveDrawingBuffer = attr?.preserveDrawingBuffer ?: 0
-        override val preferLowPowerToHighPerformance = attr?.preferLowPowerToHighPerformance ?: 0
-        override val failIfMajorPerformanceCaveat = attr?.failIfMajorPerformanceCaveat ?: 0
-        override val enableExtensionsByDefault = attr?.enableExtensionsByDefault ?: 1
-        override val explicitSwapControl = attr?.explicitSwapControl ?: 0
-        override val renderViaOffscreenBackBuffer = attr?.renderViaOffscreenBackBuffer ?: 0
-        override val majorVersion = attr?.majorVersion ?: 2
-    }
-    patchWebGlContext(canvas)
-    return GL.createContext(canvas, contextAttributes.asJsObject())
 }

--- a/skiko/src/wasmJsMain/kotlin/org/jetbrains/skiko/wasm/Wrapper.kt
+++ b/skiko/src/wasmJsMain/kotlin/org/jetbrains/skiko/wasm/Wrapper.kt
@@ -1,35 +1,5 @@
 package org.jetbrains.skiko.wasm
 
-import org.jetbrains.skia.impl.NativePointer
-import org.jetbrains.skiko.GL
-import org.w3c.dom.HTMLCanvasElement
-
-@JsFun(
-"""() => {
-    return {
-        alpha: 1,
-        depth: 1,
-        stencil: 8,
-        antialias: 0,
-        premultipliedAlpha: 1,
-        preserveDrawingBuffer: 0,
-        preferLowPowerToHighPerformance: 0,
-        failIfMajorPerformanceCaveat: 0,
-        enableExtensionsByDefault: 1,
-        explicitSwapControl: 0,
-        renderViaOffscreenBackBuffer: 0,
-        majorVersion: 2,
-    }
-}
-""")
-private external fun createDefaultContextAttributes(): ContextAttributes
-
-internal actual fun createWebGLContext(canvas: HTMLCanvasElement, attr: ContextAttributes?): NativePointer {
-    check(attr === null) { "TODO!" }
-    patchWebGlContext(canvas)
-    return GL.createContext(canvas, createDefaultContextAttributes())
-}
-
 actual fun onWasmReady(onReady: () -> Unit) {
     awaitSkiko.then {
         onReady()

--- a/skiko/src/webMain/kotlin/org/jetbrains/skiko/CanvasRenderer.kt
+++ b/skiko/src/webMain/kotlin/org/jetbrains/skiko/CanvasRenderer.kt
@@ -2,8 +2,11 @@ package org.jetbrains.skiko
 
 import org.jetbrains.skia.*
 import org.jetbrains.skia.impl.NativePointer
-import org.jetbrains.skiko.wasm.ContextAttributes
+import org.jetbrains.skiko.wasm.EmscriptenWebGLContextAttributes
+import org.khronos.webgl.WebGLRenderingContextBase
 import org.w3c.dom.HTMLCanvasElement
+import kotlin.js.ExperimentalWasmJsInterop
+import kotlin.js.js
 
 /**
  * CanvasRenderer takes an [HTMLCanvasElement] instance and initializes
@@ -16,11 +19,17 @@ internal abstract class CanvasRenderer(
     private val contextPointer: NativePointer,
     width: Int,
     height: Int,
+    requestedSampleCount: Int = 1, // it must be the actual sampling from the current webgl context.
 ) {
     var width: Int = width
         private set
     var height: Int = height
         private set
+
+    // To remain compatible with the previous implementation, we coerce to 1.
+    // Although Skia does it in src/gpu/ganesh/gl/GrGLBackendSurface.cpp#L295 too:
+    // std::max(1, sampleCnt)
+    val requestedSampleCount: Int = requestedSampleCount.coerceAtLeast(1)
 
     var isDisposed: Boolean = false
         private set
@@ -62,7 +71,7 @@ internal abstract class CanvasRenderer(
         GL.makeContextCurrent(contextPointer)
         disposeCanvas()
 
-        renderTarget = BackendRenderTarget.makeGL(width, height, 1, 8, 0, 0x8058)
+        renderTarget = BackendRenderTarget.makeGL(width, height, requestedSampleCount, 8, 0, 0x8058)
         surface = Surface.makeFromBackendRenderTarget(
             context,
             renderTarget!!,
@@ -143,8 +152,12 @@ private fun windowRequestAnimationFrame(callback: (Double) -> Unit) : Int =
 
 
 internal external interface GLInterface {
-    fun createContext(context: HTMLCanvasElement, contextAttributes: ContextAttributes): NativePointer
+    fun createContext(context: HTMLCanvasElement, contextAttributes: EmscriptenWebGLContextAttributes): NativePointer
     fun makeContextCurrent(contextPointer: NativePointer): Boolean;
 }
 
 internal expect val GL: GLInterface
+
+@OptIn(ExperimentalWasmJsInterop::class)
+internal fun currentGLContext(gl: GLInterface): WebGLRenderingContextBase? =
+    js("gl.currentContext ? gl.currentContext.GLctx : null")

--- a/skiko/src/webMain/kotlin/org/jetbrains/skiko/SkiaLayer.web.kt
+++ b/skiko/src/webMain/kotlin/org/jetbrains/skiko/SkiaLayer.web.kt
@@ -4,8 +4,14 @@ import kotlinx.browser.window
 import org.jetbrains.skia.Canvas
 import org.jetbrains.skia.Color
 import org.jetbrains.skia.PixelGeometry
+import org.jetbrains.skiko.wasm.EmscriptenWebGLContextAttributes
 import org.jetbrains.skiko.wasm.createWebGLContext
+import org.khronos.webgl.WebGLRenderingContext
 import org.w3c.dom.HTMLCanvasElement
+import kotlin.js.ExperimentalWasmJsInterop
+import kotlin.js.JsNumber
+import kotlin.js.toInt
+import kotlin.js.unsafeCast
 
 /**
  * Provides a way to render the content and to receive the input events.
@@ -15,7 +21,23 @@ import org.w3c.dom.HTMLCanvasElement
  * using [attachTo] method.
  */
 actual open class SkiaLayer {
+
+    companion object {
+        /**
+         * @param emscriptenWebGLContextAttributes - the preferred attributes. It's not guaranteed that the browser will respect them.
+         * https://github.com/emscripten-core/emscripten/blob/main/system/include/emscripten/html5_webgl.h#L31
+         */
+        @InternalSkikoApi
+        fun makeWithContextAttributes(emscriptenWebGLContextAttributes: EmscriptenWebGLContextAttributes): SkiaLayer {
+            return SkiaLayer().apply {
+                requestEmscriptenWebGLContextAttributes = emscriptenWebGLContextAttributes
+            }
+        }
+    }
+
     internal var state: CanvasRenderer? = null
+
+    internal var requestEmscriptenWebGLContextAttributes: EmscriptenWebGLContextAttributes? = null
 
     /**
      * [GraphicsApi.WEBGL] is the only supported renderApi for k/js (browser).
@@ -86,6 +108,7 @@ actual open class SkiaLayer {
      * Initializes the [CanvasRenderer] and events listeners.
      * Delegates rendering and events processing to [renderDelegate].
      */
+    @OptIn(ExperimentalWasmJsInterop::class)
     private fun attachTo(htmlCanvas: HTMLCanvasElement) {
         if (this.htmlCanvas === htmlCanvas && state != null) {
             // Re-attaching to the same canvas: reuse the WebGL context and DirectContext.
@@ -97,7 +120,20 @@ actual open class SkiaLayer {
         detach()
         this.htmlCanvas = htmlCanvas
 
-        state = object : CanvasRenderer(createWebGLContext(htmlCanvas), htmlCanvas.width, htmlCanvas.height) {
+        val contextPointer = createWebGLContext(htmlCanvas, requestEmscriptenWebGLContextAttributes)
+        GL.makeContextCurrent(contextPointer)
+
+        // Get the actual sampling in the current webgl context and pass it to Skia.
+        // This value affects the Skia's antialiasing strategy choice.
+        val sampleCount: Int =
+            currentGLContext(GL)?.getParameter(WebGLRenderingContext.SAMPLES)?.unsafeCast<JsNumber>()?.toInt() ?: 0
+
+        state = object : CanvasRenderer(
+            contextPointer = contextPointer,
+            width = htmlCanvas.width,
+            height = htmlCanvas.height,
+            requestedSampleCount = sampleCount
+        ) {
             override fun drawFrame(currentTimestamp: Double) {
                 // currentTimestamp is in milliseconds.
                 val currentNanos = currentTimestamp * 1_000_000

--- a/skiko/src/webMain/kotlin/org/jetbrains/skiko/wasm/Wrapper.kt
+++ b/skiko/src/webMain/kotlin/org/jetbrains/skiko/wasm/Wrapper.kt
@@ -6,19 +6,24 @@ import org.w3c.dom.HTMLCanvasElement
 import kotlin.js.JsAny
 import kotlin.js.Promise
 
-internal external interface ContextAttributes {
+// EmscriptenWebGLContextAttributes combines:
+// https://github.com/KhronosGroup/WebGL/blob/main/specs/latest/1.0/webgl.idl#L43-L58
+// and its own properties https://github.com/emscripten-core/emscripten/blob/main/src/lib/libwebgl.js
+@InternalSkikoApi
+external interface EmscriptenWebGLContextAttributes : JsAny {
     val alpha: Int?
     val depth: Int?
     val stencil: Int?
     val antialias: Int?
     val premultipliedAlpha: Int?
     val preserveDrawingBuffer: Int?
-    val preferLowPowerToHighPerformance: Int?
+    val powerPreference: Int?
     val failIfMajorPerformanceCaveat: Int?
+    val majorVersion: Int?
     val enableExtensionsByDefault: Int?
     val explicitSwapControl: Int?
     val renderViaOffscreenBackBuffer: Int?
-    val majorVersion: Int?
+    val desynchronized: Int?
 }
 
 /**
@@ -94,7 +99,34 @@ internal fun patchWebGlContext(canvas: HTMLCanvasElement): Unit = js("""{
     }
 }""")
 
-internal expect fun createWebGLContext(canvas: HTMLCanvasElement, attr: ContextAttributes? = null): NativePointer
+@JsFun(
+    """(attr) => ({
+        alpha: attr && attr.alpha != null ? attr.alpha : 1,
+        depth: attr && attr.depth != null ? attr.depth : 1,
+        stencil: attr && attr.stencil != null ? attr.stencil : 8,
+        antialias: attr && attr.antialias != null ? attr.antialias : 0,
+        premultipliedAlpha: attr && attr.premultipliedAlpha != null ? attr.premultipliedAlpha : 1,
+        preserveDrawingBuffer: attr && attr.preserveDrawingBuffer != null ? attr.preserveDrawingBuffer : 0,
+        powerPreference: ['default', 'low-power', 'high-performance'][
+            attr && attr.powerPreference != null ? attr.powerPreference : 0
+        ],
+        failIfMajorPerformanceCaveat: attr && attr.failIfMajorPerformanceCaveat != null ? attr.failIfMajorPerformanceCaveat : 0,
+        majorVersion: attr && attr.majorVersion != null ? attr.majorVersion : 2,
+        enableExtensionsByDefault: attr && attr.enableExtensionsByDefault != null ? attr.enableExtensionsByDefault : 1,
+        explicitSwapControl: attr && attr.explicitSwapControl != null ? attr.explicitSwapControl : 0,
+        renderViaOffscreenBackBuffer: attr && attr.renderViaOffscreenBackBuffer != null ? attr.renderViaOffscreenBackBuffer : 0,
+        desynchronized: attr && attr.desynchronized != null ? attr.desynchronized : 0,
+    })"""
+)
+private external fun contextAttributesWithDefaults(attr: EmscriptenWebGLContextAttributes?): EmscriptenWebGLContextAttributes
+
+internal fun createWebGLContext(
+    canvas: HTMLCanvasElement,
+    attr: EmscriptenWebGLContextAttributes? = null
+): NativePointer {
+    patchWebGlContext(canvas)
+    return org.jetbrains.skiko.GL.createContext(canvas, contextAttributesWithDefaults(attr))
+}
 
 internal expect fun onWasmReady(onReady: () -> Unit)
 

--- a/skiko/src/webTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
+++ b/skiko/src/webTest/kotlin/org/jetbrains/skiko/SkiaLayerTest.kt
@@ -1,21 +1,23 @@
 package org.jetbrains.skiko
 
 import kotlinx.browser.document
-import kotlinx.browser.window
 import org.jetbrains.skia.Bitmap
 import org.jetbrains.skia.Canvas
 import org.jetbrains.skia.Color
 import org.jetbrains.skia.Paint
 import org.jetbrains.skiko.tests.runTest
-import org.w3c.dom.ErrorEvent
+import org.jetbrains.skiko.wasm.EmscriptenWebGLContextAttributes
+import org.khronos.webgl.WebGLRenderingContext
+import org.khronos.webgl.WebGLRenderingContextBase
 import org.w3c.dom.HTMLCanvasElement
-import org.w3c.dom.PromiseRejectionEvent
-import org.w3c.dom.events.Event
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
+import kotlin.js.ExperimentalWasmJsInterop
+import kotlin.js.JsNumber
+import kotlin.js.js
+import kotlin.js.toInt
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNotSame
@@ -201,7 +203,56 @@ class SkiaLayerTest {
             }
         }
     }
+
+    @OptIn(ExperimentalWasmJsInterop::class)
+    @Test
+    fun createSkiaLayerWithRequestedContextAttributes() = runTest {
+        withCanvas(200, 200) { canvas ->
+            val layer = SkiaLayer()
+            try {
+                layer.attachTo(canvas)
+                layer.requestAndAwaitRender()
+                assertNoGlError(canvas, "no errors after creating")
+
+                val webgl2Context = canvas.getContext("webgl2") as? WebGLRenderingContextBase
+                assertNotNull(webgl2Context, "the requested context must be provided by the canvas")
+                assertEquals(webgl2Context, currentGLContext(GL))
+
+                val samples = (webgl2Context.getParameter(WebGLRenderingContext.SAMPLES) as JsNumber).toInt()
+                assertEquals(0, samples)
+                assertEquals(1, layer.state?.requestedSampleCount)
+            } finally {
+                layer.detach()
+            }
+        }
+
+        withCanvas(200, 200) { canvas ->
+            val layer = SkiaLayer.makeWithContextAttributes(testContextAttributes(enableAntialias = true))
+            try {
+                layer.attachTo(canvas)
+                layer.requestAndAwaitRender()
+                assertNoGlError(canvas, "no errors after creating")
+
+                val webgl2Context = canvas.getContext("webgl2") as? WebGLRenderingContextBase
+                assertNotNull(webgl2Context, "the requested context must be provided by the canvas")
+                assertEquals(webgl2Context, currentGLContext(GL))
+
+                val samples = (webgl2Context.getParameter(WebGLRenderingContext.SAMPLES) as JsNumber).toInt()
+                assertTrue(samples > 1, "samples expected to be > 1, but was $samples")
+                assertEquals(samples, layer.state?.requestedSampleCount)
+            } finally {
+                layer.detach()
+            }
+        }
+    }
 }
+
+//language=js
+private fun testContextAttributes(enableAntialias: Boolean): EmscriptenWebGLContextAttributes = js(
+    """(function() {
+        return { antialias: enableAntialias ? 1 : 0 };
+    })()"""
+)
 
 @OptIn(ExperimentalWasmJsInterop::class)
 private fun windowRequestAnimationFrame(callback: (Double) -> Unit): Int =


### PR DESCRIPTION
With a new method, it will be easier to experiment with different attributes values in Compose.

For, example: 
- we should consider `antialias: true` to enabled GPU based strategy when Skia decides how to render a Path. Currently skia choose a CPU based approach.