### PR TITLE
Increase wasm stack size to 1 MB

### DIFF
--- a/skiko/build.gradle.kts
+++ b/skiko/build.gradle.kts
@@ -172,6 +172,7 @@ val coreDependencies: SkikoDependencyScope.() -> Unit = {
                 "-s", "EXPORT_ES6=1",
                 "-s", "EXPORT_NAME=loadSkikoWASM",
                 "-s", "EXPORTED_RUNTIME_METHODS=\"[GL, wasmExports, loadDynamicLibrary, LDSO, HEAPU8]\"",
+                "-s", "STACK_SIZE=1048576", // 1 MB
                 "--bind",
             )
         }


### PR DESCRIPTION
After the introduction of https://github.com/JetBrains/skiko/pull/1022, a number of unexpected crashes started occurring in Compose for Web. Investigation showed that the default stack size (64 KiB) is too small.

This PR increases the stack size to 1 MiB matching the value used by Skia in its configuration: https://github.com/google/skia/blob/8fce167bdded29771e992d8c097ecdb50ad69706/gn/skia/BUILD.gn#L824

Fixes [SKIKO-1183](https://youtrack.jetbrains.com/issue/SKIKO-1183)