### PR TITLE
[web] Enforce exact list of proposals enabled in skiko.wasm artifact

### DIFF
--- a/skiko/buildSrc/src/main/kotlin/tasks/configuration/WasmTasksConfiguration.kt
+++ b/skiko/buildSrc/src/main/kotlin/tasks/configuration/WasmTasksConfiguration.kt
@@ -237,7 +237,11 @@ fun SkikoProjectContext.declareWasmTasks() {
                 }
                 add("--converge") // Run passes to convergence, continuing while binary size decreases
                 add("--strip-producers") // strip the wasm producers section
-                add("--all-features") // enable all features (most of them are required because of compilation with emcc)
+                add("--enable-bulk-memory")
+                add("--enable-exception-handling")
+                add("--enable-nontrapping-float-to-int")
+                add("--enable-sign-ext")
+                add("--enable-threads")
             }
         )
     }


### PR DESCRIPTION
Before this commit https://github.com/JetBrains/skiko/commit/be47d484fbd560974098a5e30bb9ed3c65de5cb1
following six  extensions were enabled in skiko.wasm:

Bulk memory operations
Exception handling
Import/Export of mutable globals
Legacy exception handling
Non-trapping float-to-int conversions
Sign-extension operators


After the commit accidentally some newer one slipped into the build and list looks likes:

Proposal,Google Chrome,Mozilla Firefox,Apple Safari
- Bulk memory operations,Chrome 75+ (May 2019),Firefox 79+ (Jul 2020),Safari 15.0+ (Sep 2021)
- **Exception handling (Standard/Phase 4),Chrome 124+ (Apr 2024),Firefox 129+ (Aug 2024),Safari 18.4+ (Mar 2025)**
- Import/Export of mutable globals,Chrome 74+ (Apr 2019),Firefox 61+ (Sep 2018),Safari 12.0+ (Mar 2019)
- Legacy exception handling,Chrome 95+ (Oct 2021),Firefox 100+ (May 2022),Safari 15.2+ (Dec 2021)
- Non-trapping float-to-int conversions,Chrome 75+ (May 2019),Firefox 64+ (Dec 2018),Safari 15.0+ (Sep 2021)
- Reference types,Chrome 96+ (Nov 2021),Firefox 79+ (Jul 2020),Safari 15.0+ (Sep 2021)
- Sign-extension operators,Chrome 74+ (Apr 2019),Firefox 62+ (Sep 2018),Safari 14.1+ (Apr 2021)
- **Tail call,Chrome 112+ (Apr 2023),Firefox 121+ (Dec 2023),Safari 18.2+ (Dec 2024)**
- **Typed function references,Chrome 119+ (Nov 2023),Firefox 120+ (Nov 2023),Safari 18.0+ (Sep 2024)**

Bold ones are one that make it impossible to use Skia we are currently supporting
Actually some of new proposals can be left there however the goal of this PR is to restore the pre-problematic state

The actual list of new proposals should agreed upon and introduced separately