### PR TITLE
Direct3D. Fix adapter probing with DirectX 11 instead of 12

### DIFF
--- a/skiko/src/awtMain/cpp/windows/InternalDirectXApi.cc
+++ b/skiko/src/awtMain/cpp/windows/InternalDirectXApi.cc
@@ -14,6 +14,7 @@
 
 const D3D_FEATURE_LEVEL minSupportedFeatureLevel = D3D_FEATURE_LEVEL_12_0;
 const D3D_FEATURE_LEVEL featureLevels[] = {
+    // TODO add D3D_FEATURE_LEVEL_12_2
     D3D_FEATURE_LEVEL_12_1,
     D3D_FEATURE_LEVEL_12_0
 };

--- a/skiko/src/awtMain/cpp/windows/InternalDirectXApi.cc
+++ b/skiko/src/awtMain/cpp/windows/InternalDirectXApi.cc
@@ -12,6 +12,12 @@
 #include "exceptions_handler.h"
 #include "window_util.h"
 
+const D3D_FEATURE_LEVEL minSupportedFeatureLevel = D3D_FEATURE_LEVEL_12_0;
+const D3D_FEATURE_LEVEL featureLevels[] = {
+    D3D_FEATURE_LEVEL_12_1,
+    D3D_FEATURE_LEVEL_12_0
+};
+
 class DirectXOffscreenDevice
 {
 public:
@@ -187,7 +193,7 @@ extern "C"
                 break;
             }
             if (
-                SUCCEEDED(D3D12CreateDevice(adapter, D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)) &&
+                SUCCEEDED(D3D12CreateDevice(adapter, minSupportedFeatureLevel, _uuidof(ID3D12Device), nullptr)) &&
                 isAdapterSupported2(env, renderer, adapter)
             ) {
                 return toJavaPointer(adapter);
@@ -212,11 +218,7 @@ extern "C"
         Microsoft::WRL::ComPtr<IDXGIAdapter1> adapter;
         adapter.Attach((IDXGIAdapter1 *) adapterPtr);
 
-        D3D_FEATURE_LEVEL maxSupportedFeatureLevel = D3D_FEATURE_LEVEL_12_0;
-        D3D_FEATURE_LEVEL featureLevels[] = {
-            D3D_FEATURE_LEVEL_12_1,
-            D3D_FEATURE_LEVEL_12_0
-        };
+        D3D_FEATURE_LEVEL maxSupportedFeatureLevel = minSupportedFeatureLevel;
 
         for (int i = 0; i < _countof(featureLevels); i++) {
             if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), featureLevels[i], _uuidof(ID3D12Device), nullptr))) {

--- a/skiko/src/awtMain/cpp/windows/directXRenderer.cc
+++ b/skiko/src/awtMain/cpp/windows/directXRenderer.cc
@@ -21,6 +21,12 @@
 extern "C" JavaVM *jvm;
 
 const int BuffersCount = 2;
+const D3D_FEATURE_LEVEL minSupportedFeatureLevel = D3D_FEATURE_LEVEL_12_0;
+const D3D_FEATURE_LEVEL featureLevels[] = {
+    // TODO add D3D_FEATURE_LEVEL_12_2
+    D3D_FEATURE_LEVEL_12_1,
+    D3D_FEATURE_LEVEL_12_0
+};
 
 class DirectXDevice
 {
@@ -501,7 +507,7 @@ extern "C"
                 break;
             }
             if (
-                SUCCEEDED(D3D12CreateDevice(adapter, D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)) &&
+                SUCCEEDED(D3D12CreateDevice(adapter, minSupportedFeatureLevel, _uuidof(ID3D12Device), nullptr)) &&
                 isAdapterSupported(env, renderer, adapter)
             ) {
                 return toJavaPointer(adapter);
@@ -525,12 +531,7 @@ extern "C"
         Microsoft::WRL::ComPtr<IDXGIAdapter1> adapter;
         adapter.Attach((IDXGIAdapter1 *) adapterPtr);
 
-        D3D_FEATURE_LEVEL maxSupportedFeatureLevel = D3D_FEATURE_LEVEL_12_0;
-        D3D_FEATURE_LEVEL featureLevels[] = {
-            // TODO add D3D_FEATURE_LEVEL_12_2
-            D3D_FEATURE_LEVEL_12_1,
-            D3D_FEATURE_LEVEL_12_0
-        };
+        D3D_FEATURE_LEVEL maxSupportedFeatureLevel = minSupportedFeatureLevel;
 
         for (int i = 0; i < _countof(featureLevels); i++) {
             if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), featureLevels[i], _uuidof(ID3D12Device), nullptr))) {


### PR DESCRIPTION
Fixes adapter probing incorrectly accepting DirectX feature level 11.0 when device creation requires at least 12.0.

The minimum supported feature level and candidate feature levels are now shared by adapter probing and device creation, keeping both paths consistent.

This is mentioned in https://youtrack.jetbrains.com/issue/SKIKO-1116/org.jetbrains.skiko.graphicapi.InternalDirectXApi.createDirectXOffscreenDevice-freezes-UI-thread-for-55-seconds#focus=Comments-27-14371125.0-0

Most probably it doesn't fixes the hang, but there is still a small chance that:
- probing the adapter with DirectX 12 fails (started to be called before requesting in this PR)
- requesting the adapter with DirectX 12 hangs